### PR TITLE
Permit checkpatch failure with commit message statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,14 +12,15 @@ before_install:
   - $HOME/spack/bin/spack install leveldb
   - $HOME/spack/bin/spack install gotcha
   - $HOME/spack/bin/spack install environment-modules
+  - . $HOME/spack/share/spack/setup-env.sh
+  - spack load environment-modules
+  - source <(spack module loads gotcha leveldb)
+  - eval $(./scripts/git_log_test_env.sh)
 
 cache:
   directories:
     - $HOME/spack
 
 script:
-  - . $HOME/spack/share/spack/setup-env.sh
-  - spack load environment-modules
-  - source <(spack module loads gotcha leveldb)
   - sh autogen.sh && ./configure && make
-  - ./scripts/checkpatch.sh
+  - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes

--- a/scripts/git_log_test_env.sh
+++ b/scripts/git_log_test_env.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This script helps configure a test environment using git commit
+# messages. Extract variable assignment statements beginning with TEST_
+# from the git commit message and print them so the variables can be
+# imported into the caller's environment. For example,
+#
+# eval $(git_log_test_env.sh)
+#
+
+git log HEAD^..HEAD | sed "s/^ *//g" | grep '^TEST_.*='


### PR DESCRIPTION
- Add facility to control whether checkpatch results may
cause the travis build to fail. An author can add the line

TEST_CHECKPATCH_ALLOW_FAILURE=yes

to their commit message so the overall build can still
report success even if the checkpatch.sh step returns
an error. The author should defend the use of this option
in the commit message and pull request. For example, this
commit fails the style checker because the subject line
contains the word "checkpatch", but the failure should be
permitted because the subject does actually does describe
the change, not the tool that found a problem.

The new facility generically sets any environment variables
that appear on their own line in the commit message and begin
with TEST_. We can use this facility in the future to support
other variables to control other aspects of the test suite.

- Move spack environment-setting commands out of the script
section of .travis.yml since they're not tests and we don't
need to see their exit statuses.