### PR TITLE
travis-ci: don't cache spack lock file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ cache:
   directories:
     - $HOME/spack
 
+# Don't update the cache just because the spack lock file changed
+before_cache:
+  - rm -f $HOME/spack/opt/spack/.spack-db/prefix_lock
+
 script:
   - sh autogen.sh && ./configure && make
   - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes


### PR DESCRIPTION
Remove the spack lock file before inspecting the cache for
changes so we don't upload a new cache for no good reason.
This will reduce noise in the build log and may save some
bandwidth on the travis backend.