### PR TITLE
Default to silent build mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
 AM_INIT_AUTOMAKE([foreign tar-pax subdir-objects])
+AM_SILENT_RULES([yes])
 
 AM_MAINTAINER_MODE([disable])
 


### PR DESCRIPTION
Change the default build mode to "silent", rather than showing the full
command line for each stage. This makes compiler warnings stand out much
more clearly. For debugging, the verbose mode can be enabled by running
'make V=1'.

make[2]: Entering directory \`/usr/workspace/wsb/bass6/unifycr/meta'
Making all in src
make[3]: Entering directory \`/usr/workspace/wsb/bass6/unifycr/meta/src'
  CC       Mlog2/mlog2.o
  CC       client.o
  CC       local_client.o
  CC       data_store.o
  CC       partitioner.o
  CC       messages.o
  CC       range_server.o
  CC       ds_leveldb.o
  CC       mdhim_options.o
  CC       mdhim_private.o
  CC       indexes.o
  CC       mdhim.o
  AR       libmdhim.a
