### PR TITLE
travis: add 'make distcheck' test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ cache:
 
 script:
   - sh autogen.sh && ./configure && make
+  - make distcheck
   - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes


### PR DESCRIPTION
Add a 'make distcheck' step to travis to more thoroughly test
the 'make dist' distribution tarball. From the automake manual:

The distcheck make target first makes a distribution, and then,
operating from it, takes the following steps:

- tries to do a VPATH build (see VPATH Builds), with the srcdir
  and all its content made read-only;
- runs the test suite (with make check) on this fresh build;
- installs the package in a temporary directory (with make install),
  and tries runs the test suite on the resulting installation
  (with make installcheck);
- checks that the package can be correctly uninstalled (by make
  uninstall) and cleaned (by make distclean)
- finally, makes another tarball to ensure the distribution is
  self-contained.