### PR TITLE
Add missing const qualifier to comparison functions

### DIFF
--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -902,47 +902,42 @@ int UNIFYCR_WRAP(lio_listio)(int mode,
 
 int compare_index_entry(const void *a, const void *b)
 {
+    const unifycr_index_t *ptr_a = a;
+    const unifycr_index_t *ptr_b = b;
 
-    if (((unifycr_index_t *)a)->fid - ((unifycr_index_t *)b)->fid > 0) {
+    if (ptr_a->fid - ptr_b->fid > 0)
         return 1;
-    }
 
-    if (((unifycr_index_t *)a)->fid - ((unifycr_index_t *)b)->fid < 0) {
+    if (ptr_a->fid - ptr_b->fid < 0)
         return -1;
-    }
 
-    if (((unifycr_index_t *)a)->file_pos - ((unifycr_index_t *)b)->file_pos > 0) {
+    if (ptr_a->file_pos - ptr_b->file_pos > 0)
         return 1;
-    }
 
-    if (((unifycr_index_t *)a)->file_pos - ((unifycr_index_t *)b)->file_pos < 0) {
+    if (ptr_a->file_pos - ptr_b->file_pos < 0)
         return -1;
-    } else {
-        return 0;
-    }
 
+    return 0;
 }
 
 int compare_read_req(const void *a, const void *b)
 {
-    if (((read_req_t *)a)->fid - ((read_req_t *)b)->fid > 0) {
+    const read_req_t *ptr_a = a;
+    const read_req_t *ptr_b = b;
+
+    if (ptr_a->fid - ptr_b->fid > 0)
         return 1;
-    }
 
-    if (((read_req_t *)a)->fid - ((read_req_t *)b)->fid < 0) {
+    if (ptr_a->fid - ptr_b->fid < 0)
         return -1;
-    }
 
-    if (((read_req_t *)a)->offset - ((read_req_t *)b)->offset > 0) {
+    if (ptr_a->offset - ptr_b->offset > 0)
         return 1;
-    }
 
-    if (((read_req_t *)a)->offset - ((read_req_t *)b)->offset < 0) {
+    if (ptr_a->offset - ptr_b->offset < 0)
         return -1;
-    } else {
-        return 0;
-    }
 
+    return 0;
 }
 
 int unifycr_locate_req(read_req_t *read_req, int count,

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2516,49 +2516,46 @@ static int unifycr_init_socket(int proc_id, int l_num_procs_per_node,
 
 }
 
-int compare_fattr(void *a, void *b)
+int compare_fattr(const void *a, const void *b)
 {
-    unifycr_fattr_t *ptr_a = a;
-    unifycr_fattr_t *ptr_b = b;
+    const unifycr_fattr_t *ptr_a = a;
+    const unifycr_fattr_t *ptr_b = b;
 
-    if (ptr_a->fid > ptr_b->fid) {
+    if (ptr_a->fid > ptr_b->fid)
         return 1;
-    }
-    if (ptr_a->fid < ptr_b->fid) {
+
+    if (ptr_a->fid < ptr_b->fid)
         return -1;
-    }
+
     return 0;
 }
 
-static int compare_int(void *a, void *b)
+static int compare_int(const void *a, const void *b)
 {
-    int *ptr_a = (int *)a;
-    int *ptr_b = (int *)b;
+    const int *ptr_a = a;
+    const int *ptr_b = b;
 
-    if (*ptr_a - *ptr_b > 0) {
+    if (*ptr_a - *ptr_b > 0)
         return 1;
-    }
 
-    if (*ptr_a - *ptr_b < 0) {
+    if (*ptr_a - *ptr_b < 0)
         return -1;
-    }
 
     return 0;
 }
 
 static int compare_name_rank_pair(const void *a, const void *b)
 {
-    name_rank_pair_t *pair_a = (name_rank_pair_t *)a;
-    name_rank_pair_t *pair_b = (name_rank_pair_t *)b;
-    if (strcmp(pair_a->hostname, pair_b->hostname) > 0) {
-        return 1;
-    }
-    if (strcmp(pair_a->hostname, pair_b->hostname) < 0) {
-        return -1;
-    } else {
-        return 0;
-    }
+    const name_rank_pair_t *pair_a = a;
+    const name_rank_pair_t *pair_b = b;
 
+    if (strcmp(pair_a->hostname, pair_b->hostname) > 0)
+        return 1;
+
+    if (strcmp(pair_a->hostname, pair_b->hostname) < 0)
+        return -1;
+
+    return 0;
 }
 
 /**

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -69,7 +69,7 @@ typedef struct {
 } name_rank_pair_t;
 
 static int get_del_cnt();
-static int compare_int(void *a, void *b);
+static int compare_int(const void *a, const void *b);
 static int compare_name_rank_pair(const void *a, const void *b);
 static int find_rank_idx(int rank,
                          int *local_rank_lst, int local_rank_cnt);
@@ -88,7 +88,7 @@ static int get_global_file_meta(int gfid, unifycr_fattr_t **file_meta);
 static int set_global_file_meta(unifycr_fattr_t *f_meta);
 static int ins_file_meta(unifycr_fattr_buf_t *ptr_f_meta_log,
                          unifycr_fattr_t *ins_fattr);
-int compare_fattr(void *a, void *b);
+int compare_fattr(const void *a, const void *b);
 
 
 /* mount memfs at some prefix location */

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -57,8 +57,6 @@ arraylist_t *thrd_list;
 int invert_sock_ids[MAX_NUM_CLIENTS]; /*records app_id for each sock_id*/
 int log_print_level = 5;
 
-static int compare_int(void *a, void *b);
-static int compare_name_rank_pair(const void *a, const void *b);
 int main(int argc, char *argv[])
 {
 
@@ -368,35 +366,32 @@ static int find_rank_idx(int my_rank,
 
 }
 
-static int compare_int(void *a, void *b)
+static int compare_int(const void *a, const void *b)
 {
-    int *ptr_a = (int *)a;
-    int *ptr_b = (int *)b;
+    const int *ptr_a = a;
+    const int *ptr_b = b;
 
-    if (*ptr_a - *ptr_b > 0) {
+    if (*ptr_a - *ptr_b > 0)
         return 1;
-    }
 
-    if (*ptr_a - *ptr_b < 0) {
+    if (*ptr_a - *ptr_b < 0)
         return -1;
-    }
 
     return 0;
 }
 
 static int compare_name_rank_pair(const void *a, const void *b)
 {
-    name_rank_pair_t *pair_a = (name_rank_pair_t *)a;
-    name_rank_pair_t *pair_b = (name_rank_pair_t *)b;
-    if (strcmp(pair_a->hostname, pair_b->hostname) > 0) {
-        return 1;
-    }
-    if (strcmp(pair_a->hostname, pair_b->hostname) < 0) {
-        return -1;
-    } else {
-        return 0;
-    }
+    const name_rank_pair_t *pair_a = a;
+    const name_rank_pair_t *pair_b = b;
 
+    if (strcmp(pair_a->hostname, pair_b->hostname) > 0)
+        return 1;
+
+    if (strcmp(pair_a->hostname, pair_b->hostname) < 0)
+        return -1;
+
+    return 0;
 }
 
 static int unifycr_exit()

--- a/server/src/unifycr_init.h
+++ b/server/src/unifycr_init.h
@@ -48,7 +48,7 @@ typedef struct {
 
 static int CountTasksPerNode(int rank, int numTasks);
 static int compare_name_rank_pair(const void *a, const void *b);
-static int compare_int(void *a, void *b);
+static int compare_int(const void *a, const void *b);
 static int find_rank_idx(int my_rank,
                          int *local_rank_lst, int local_rank_cnt);
 static int unifycr_exit();

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -472,16 +472,16 @@ int rm_init(int size)
     return ULFS_SUCCESS;
 }
 
-int compare_delegators(void *a, void *b)
+int compare_delegators(const void *a, const void *b)
 {
-    if (((send_msg_t *)a)->dest_delegator_rank
-        - ((send_msg_t *)b)->dest_delegator_rank > 0) {
+    const send_msg_t *ptr_a = a;
+    const send_msg_t *ptr_b = b;
+
+    if (ptr_a->dest_delegator_rank - ptr_b->dest_delegator_rank > 0)
         return 1;
-    }
-    if (((send_msg_t *)a)->dest_delegator_rank
-        - ((send_msg_t *)b)->dest_delegator_rank < 0) {
+
+    if (ptr_a->dest_delegator_rank - ptr_b->dest_delegator_rank < 0)
         return -1;
-    }
 
     return 0;
 }

--- a/server/src/unifycr_request_manager.h
+++ b/server/src/unifycr_request_manager.h
@@ -47,7 +47,7 @@ int rm_pack_send_requests(char *req_msg_buf,
                           send_msg_t *send_metas, int req_num,
                           long *tot_sz);
 
-int compare_delegators(void *a, void *b);
+int compare_delegators(const void *a, const void *b);
 int rm_pack_send_msg(int rank, char *send_msg_buf,
                      send_msg_t *send_metas, int meta_num,
                      long *tot_sz);

--- a/server/src/unifycr_service_manager.c
+++ b/server/src/unifycr_service_manager.c
@@ -702,25 +702,22 @@ int sm_ack_remote_delegator(rank_ack_meta_t *ptr_ack_meta)
     return ULFS_SUCCESS;
 }
 
-int compare_ack_stat(void *a, void *b)
+int compare_ack_stat(const void *a, const void *b)
 {
-    ack_stat_t *ptr_a = a;
-    ack_stat_t *ptr_b = b;
-    if (ptr_a->src_rank > ptr_b->src_rank) {
+    const ack_stat_t *ptr_a = a;
+    const ack_stat_t *ptr_b = b;
+
+    if (ptr_a->src_rank > ptr_b->src_rank)
         return 1;
-    }
 
-    if (ptr_a->src_rank < ptr_b->src_rank) {
+    if (ptr_a->src_rank < ptr_b->src_rank)
         return -1;
-    }
 
-    if (ptr_a->src_thrd > ptr_b->src_thrd) {
+    if (ptr_a->src_thrd > ptr_b->src_thrd)
         return 1;
-    }
 
-    if (ptr_a->src_thrd < ptr_b->src_thrd) {
+    if (ptr_a->src_thrd < ptr_b->src_thrd)
         return -1;
-    }
 
     return 0;
 }
@@ -1068,61 +1065,50 @@ void print_service_msgs(service_msgs_t *service_msgs)
 }
 
 
-int compare_send_msg(void *a, void *b)
+int compare_send_msg(const void *a, const void *b)
 {
-    if (((send_msg_t *)a)->dest_app_id
-        - ((send_msg_t *)b)->dest_app_id > 0) {
+    const send_msg_t *ptr_a = a;
+    const send_msg_t *ptr_b = b;
+
+    if (ptr_a->dest_app_id - ptr_b->dest_app_id > 0)
         return 1;
-    }
 
-    if (((send_msg_t *)a)->dest_app_id
-        - ((send_msg_t *)b)->dest_app_id < 0) {
+    if (ptr_a->dest_app_id - ptr_b->dest_app_id < 0)
         return -1;
-    }
 
-    if (((send_msg_t *)a)->dest_client_id
-        - ((send_msg_t *)b)->dest_client_id > 0) {
+    if (ptr_a->dest_client_id - ptr_b->dest_client_id > 0)
         return 1;
-    }
 
-    if (((send_msg_t *)a)->dest_client_id
-        - ((send_msg_t *)b)->dest_client_id < 0) {
+    if (ptr_a->dest_client_id - ptr_b->dest_client_id < 0)
         return -1;
-    }
 
-    if (((send_msg_t *)a)->dest_offset -
-        ((send_msg_t *)b)->dest_offset > 0) {
+    if (ptr_a->dest_offset - ptr_b->dest_offset > 0)
         return 1;
-    }
 
-    if (((send_msg_t *)a)->dest_offset -
-        ((send_msg_t *)b)->dest_offset < 0) {
+    if (ptr_a->dest_offset - ptr_b->dest_offset < 0)
         return -1;
-    } else {
-        return 0;
-    }
 
+    return 0;
 }
 
-int compare_read_task(void *a, void *b)
+int compare_read_task(const void *a, const void *b)
 {
-    read_task_t *ptr_a = (read_task_t *)a;
-    read_task_t *ptr_b = (read_task_t *)b;
+    const read_task_t *ptr_a = a;
+    const read_task_t *ptr_b = b;
 
-    if (ptr_a->size > ptr_b->size) {
+    if (ptr_a->size > ptr_b->size)
         return 1;
-    }
-    if (ptr_a->size < ptr_b->size) {
+
+    if (ptr_a->size < ptr_b->size)
         return -1;
-    }
-    if (ptr_a->arrival_time > ptr_b->arrival_time) {
+
+    if (ptr_a->arrival_time > ptr_b->arrival_time)
         return 1;
-    }
-    if (ptr_a->arrival_time < ptr_b->arrival_time) {
+
+    if (ptr_a->arrival_time < ptr_b->arrival_time)
         return -1;
-    }
+
     return 0;
-
 }
 
 void print_task_set(task_set_t *read_task_set,

--- a/server/src/unifycr_service_manager.h
+++ b/server/src/unifycr_service_manager.h
@@ -100,7 +100,7 @@ void *sm_service_reads(void *ctx);
 int sm_decode_msg(char *recv_msg_buf);
 int sm_classfy_reads(service_msgs_t *service_msgs);
 int sm_ack_reads(service_msgs_t *service_msgs);
-int compare_send_msg(void *a, void *b);
+int compare_send_msg(const void *a, const void *b);
 int sm_wait_until_digested(task_set_t *read_task_set,
                            service_msgs_t *service_msgs,
                            rank_ack_task_t *read_ack_task);
@@ -122,7 +122,7 @@ int sm_cluster_reads(task_set_t *read_task_set,
                      service_msgs_t *service_msgs);
 void reset_read_tasks(task_set_t *read_task_set,
                       service_msgs_t *service_msgs, int index);
-int compare_read_task(void *a, void *b);
+int compare_read_task(const void *a, const void *b);
 int sm_exit();
 void print_task_set(task_set_t *read_task_set,
                     service_msgs_t *service_msgs);
@@ -134,5 +134,5 @@ void print_task_set(task_set_t *read_task_set,
 void print_pended_reads(arraylist_t *pended_reads);
 void print_pended_sends(arraylist_t *pended_sends);
 void print_ack_meta(rank_ack_task_t *rank_ack_tasks);
-int compare_ack_stat(void *a, void *b);
+int compare_ack_stat(const void *a, const void *b);
 #endif


### PR DESCRIPTION
Update comparison functions used with searching and sorting operations
to conform to __compar_fn_t defined in search.h:

  int (*__compar_fn_t) (const void *, const void *);

Some UnifyCR comparison functions omitted the const qualifier, leading
to compiler warnings, e.g.

  unifycr_request_manager.c(81): warning #167: argument of type
  "int (*)(void *, void *)" is incompatible with parameter of
  type "__compar_fn_t" sizeof(send_msg_t), compare_delegators);

Remove unnecessary typedefs and add const qualifier within comparison
function bodies as needed. Remove unnecessary forward declaration of
compare_int() and compare_name_rank_pair() in unifycr_init.c. Make code
formatting style consistent across comparison functions.