### PR TITLE
Fix a slew of compiler warnings in the meta sources

### DIFF
--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -31,5 +31,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
               -I$(top_srcdir)/meta/src/uthash
 
 AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS)
+AM_CFLAGS += -Wall
 
-CLEANFILES = 
+CLEANFILES =

--- a/meta/src/ds_leveldb.c
+++ b/meta/src/ds_leveldb.c
@@ -1003,7 +1003,7 @@ int leveldb_process_range(leveldb_iterator_t *iter,\
 
 	const char *ret_key, *ret_val;
 	long tmp_key_len, tmp_val_len;
-	const char *save_next_ret_key, *save_next_ret_val;
+	const char *save_next_ret_key;
 
 	leveldb_iter_seek(iter, (char *)start_key, key_len);
 
@@ -1118,10 +1118,7 @@ int leveldb_process_range(leveldb_iterator_t *iter,\
 							out_val, out_val_len, tmp_records_cnt, \
 								tmp_out_cap);
 		} else {
-		    save_next_ret_key = ret_key;
-		    save_next_ret_val = ret_val;
-
-
+			save_next_ret_key = ret_key;
 			ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
 			if (!ret_key)
 				return MDHIM_DB_ERROR;
@@ -1212,7 +1209,6 @@ int leveldb_process_range(leveldb_iterator_t *iter,\
 		}
 
 	}
-
 
 	return 0;
 }

--- a/meta/src/mdhim.c
+++ b/meta/src/mdhim.c
@@ -38,6 +38,7 @@
 #include <stdlib.h>
 #include <sys/time.h>
 #include <stdio.h>
+#include <unistd.h>
 #include <ftw.h>
 #include "mdhim.h"
 #include "range_server.h"

--- a/meta/src/mdhim_private.c
+++ b/meta/src/mdhim_private.c
@@ -479,9 +479,6 @@ struct mdhim_bgetrm_t *_bget_range_records(struct mdhim_t *md, struct index_t *i
 	calrangetime+=1000000*(confgetstart.tv_sec-localgetstart.tv_sec)+\
 		confgetstart.tv_usec-localgetstart.tv_usec;
 	while (rl) {
-//		printf("rl->ri's addr is %x, rank is %d, first_key fid is %ld, first_key offset is %ld \n", \
-				rl->ri, rl->ri->rank, *(((long *)rl->ri->first_key)),  *(((long *)rl->ri->first_key)+1));
-//		fflush(stdout);
 		if (rl->ri->rank != md->mdhim_rank) {
 			//Set the message in the list for this range server
 			bgm = bgm_list[rl->ri->rangesrv_num - 1];

--- a/meta/src/messages.c
+++ b/meta/src/messages.c
@@ -61,14 +61,13 @@ void test_req_and_wait(struct mdhim_t *md, MPI_Request *req) {
 	int flag;
 	MPI_Status status;
 	int done = 0;
-	int ret;
 
 	while (!done) {
 		pthread_mutex_lock(md->mdhim_comm_lock);
-		ret = MPI_Test(req, &flag, &status);
+		(void) MPI_Test(req, &flag, &status);
 		//Unlock the mdhim_comm_lock
 		pthread_mutex_unlock(md->mdhim_comm_lock);
-	
+
 		if (flag) {
 			done = 1;
 		} else {

--- a/meta/src/partitioner.c
+++ b/meta/src/partitioner.c
@@ -95,17 +95,8 @@ unsigned long * get_meta_pair(void *key, uint32_t key_len) {
 }
 
 uint64_t get_byte_num(void *key, uint32_t key_len) {
-	int i;
-	unsigned char val;
 	uint64_t byte_num;
-	
-	byte_num = 0;
-	//Iterate through each character to perform the algorithm mentioned above
-/*	for (i = 0; i < key_len; i++) {
-	  val = (int)(((char *) key)[i]);       
-		byte_num += val * powl(2, i);
-	}
-*/
+
 	byte_num = *((long *)(((char *)key)+sizeof(long)));
 	return byte_num;
 }
@@ -969,13 +960,10 @@ rangesrv_list *get_range_servers_from_range(struct mdhim_t *md, struct index_t *
 					    void *start_key, void *end_key, int key_len) {
 	//The number that maps a key to range server (dependent on key type)
 
-	int slice_num, cur_slice, start_slice, end_slice;
+	int start_slice, end_slice;
 	//The range server number that we return
 	rangesrv_info *ret_rp;
 	rangesrv_list *rl;
-	int float_type = 0;
-	long double fstat = 0;
-	uint64_t istat = 0;
 
 	//If we don't have any stats info, then return null
 	if (!index->stats) {
@@ -1006,7 +994,7 @@ rangesrv_list *get_range_servers_from_range(struct mdhim_t *md, struct index_t *
 	rl = NULL;
 
 	for (i = start_slice; i <= end_slice; i++) {
-		struct mdhim_stat *cur_stat, *new_stat;
+		struct mdhim_stat *cur_stat;
 		gettimeofday(&rangehashstart, NULL);
 		HASH_FIND_INT(index->stats, &i, cur_stat);
 		gettimeofday(&rangehashend, NULL);
@@ -1028,7 +1016,7 @@ rangesrv_list *get_range_servers_from_range(struct mdhim_t *md, struct index_t *
 	}
 
 	for (i = start_slice; i <= end_slice; i++) {
-		struct mdhim_stat *cur_stat, *new_stat;
+		struct mdhim_stat *cur_stat;
 		gettimeofday(&rangehashstart, NULL);
 		HASH_FIND_INT(index->stats, &i, cur_stat);
 		gettimeofday(&rangehashend, NULL);

--- a/meta/src/partitioner.c
+++ b/meta/src/partitioner.c
@@ -386,10 +386,9 @@ int get_slice_num(struct mdhim_t *md, struct index_t *index, void *key, int key_
 		key_num = floorl(map_num * total_keys);
 
 		break;
-/*	default:
+	default:
 		return 0;
 		break;
-*/
 	}
 
 

--- a/meta/src/partitioner.c
+++ b/meta/src/partitioner.c
@@ -573,18 +573,7 @@ int get_slice_from_fstat(struct mdhim_t *md, struct index_t *index,
 
 	switch(op) {
 	case MDHIM_GET_NEXT:
-//			printf("max is %lf, fstat is %lf, key is %ld\n", \
-				*(long double *)cur_stat->max, fstat, cur_stat->key);
-//			fflush(stdout);
-/*		if (cur_stat && *(long double *)cur_stat->max > fstat) {
-			slice_num = cur_slice;
-			goto done;
-		} else {
-			new_stat = get_next_slice_stat(md, index, cur_slice);
-			goto new_stat;
-		}
-*/
-			slice_num = cur_slice;
+		slice_num = cur_slice;
 		break;
 	case MDHIM_GET_PREV:
 		if (cur_stat && *(long double *)cur_stat->min < fstat) {

--- a/meta/src/range_server.c
+++ b/meta/src/range_server.c
@@ -150,7 +150,6 @@ int send_locally_or_remote(struct mdhim_t *md, int dest, void *message) {
 		msg_req = malloc(sizeof(MPI_Request *));
 		sendbuf = malloc(sizeof(void *));
 		sizebuf = malloc(sizeof(int));
-		struct mdhim_stat *ttmp, *stat;
 		ret = send_client_response(md, dest, message, sizebuf, 
 					   sendbuf, size_req, msg_req);
 

--- a/meta/src/range_server.c
+++ b/meta/src/range_server.c
@@ -1383,7 +1383,7 @@ int range_server_add_oreq(struct mdhim_t *md, MPI_Request *req, void *msg) {
 int range_server_clean_oreqs(struct mdhim_t *md) {
 	out_req *item;
 	out_req *t;
-	int ret;
+	int ret = MDHIM_SUCCESS;
 	int flag = 0;
 	MPI_Status status;
 
@@ -1398,6 +1398,11 @@ int range_server_clean_oreqs(struct mdhim_t *md) {
 		pthread_mutex_lock(md->mdhim_comm_lock);
 		ret = MPI_Test((MPI_Request *)item->req, &flag, &status); 
 		pthread_mutex_unlock(md->mdhim_comm_lock);
+
+		if (ret != MPI_SUCCESS) {
+			ret = MDHIM_ERROR;
+			break;
+		}
 
 		if (!flag) {
 			item = item->next;
@@ -1430,7 +1435,7 @@ int range_server_clean_oreqs(struct mdhim_t *md) {
 
 	pthread_mutex_unlock(md->mdhim_rs->out_req_mutex);
 
-	return MDHIM_SUCCESS;
+	return ret;
 }
 
 /**

--- a/meta/src/range_server.c
+++ b/meta/src/range_server.c
@@ -48,6 +48,7 @@
 #include "range_server.h"
 #include "partitioner.h"
 #include "mdhim_options.h"
+#include "ds_leveldb.h"
 #include "uthash.h"
 
 #define UNIFYCR_FID(key) *(long *)key
@@ -1140,8 +1141,11 @@ int range_server_bget_op(struct mdhim_t *md, struct mdhim_bgetm_t *bgm, int sour
 		*get_key_len = bgm->key_lens[0];
 		key_lens[0] = *get_key_len;
 
-		error = mdhim_levedb_batch_next(index->mdhim_store->db_handle, keys, key_lens, values, value_lens, \
-					bgm->num_keys * bgm->num_recs, &num_records);
+		error = mdhim_levedb_batch_next(index->mdhim_store->db_handle,
+						(char **)keys, key_lens,
+						(char **)values, value_lens,
+						bgm->num_keys * bgm->num_recs,
+						&num_records);
 
 	}
 

--- a/meta/src/range_server.h
+++ b/meta/src/range_server.h
@@ -96,5 +96,6 @@ int levedb_batch_ranges(void *dbh, char **key, int *key_len,\
 		char ***out_key, int **out_key_len,\
 			char ***out_val, int **out_val_len,\
 				int tot_records, int *out_records_cnt);
+int unifycr_compare(const char *a, const char *b);
 
 #endif


### PR DESCRIPTION
Follow on work from #61 to clean up compiler warnings. Enable -Wall in meta/src/Makefile and address most of the resulting warnings. This one still remains because cleaning it up properly will depend on the resolution of issue #63:

```
range_server.c: In function ‘range_server_bget_op’:
range_server.c:1073:7: warning: suggest parentheses around assignment used as truth value [-Wparentheses]
       if (ret = index->mdhim_store->get_next(index->mdhim_store->db_handle,\
       ^
```