### PR TITLE
Fix a slew of compiler warnings in client sources

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -46,3 +46,4 @@ libunifycr_gotcha_la_SOURCES = \
 libunifycr_gotcha_la_CPPFLAGS = -DUNIFYCR_GOTCHA -I$(top_builddir)/client $(GOTCHA_CFLAGS)
 libunifycr_gotcha_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(GOTCHA_LDFLAGS) -lgotcha -lcrypto -lrt -lpthread
 
+AM_CFLAGS = -Wall -Wno-strict-aliasing

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -264,7 +264,8 @@ static int unifycr_chunk_read(
         //MAP_OR_FAIL(pread);
         off_t spill_offset = unifycr_compute_spill_offset(meta, chunk_id, chunk_offset);
         ssize_t rc = pread(unifycr_spilloverblock, buf, count, spill_offset);
-        /* TODO: check return code for errors */
+        if (rc < 0)
+            return unifycr_errno_map_to_err(rc);
     } else {
         /* unknown chunk type */
         debug("unknown chunk type in read\n");

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -72,7 +72,7 @@ extern int unifycr_spillover_max_chunks;
 
 /* given a file id and logical chunk id, return pointer to meta data
  * for specified chunk, return NULL if not found */
-static unifycr_chunkmeta_t *unifycr_get_chunkmeta(int fid, int cid)
+unifycr_chunkmeta_t *unifycr_get_chunkmeta(int fid, int cid)
 {
     /* lookup file meta data for specified file id */
     unifycr_filemeta_t *meta = unifycr_get_meta_from_fid(fid);

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -472,6 +472,9 @@ inline unifycr_filemeta_t *unifycr_get_meta_from_fid(int fid);
 /* given an UNIFYCR error code, return corresponding errno code */
 int unifycr_err_map_to_errno(int rc);
 
+/* given an errno error code, return corresponding UnifyCR error code */
+int unifycr_errno_map_to_err(int rc);
+
 /* checks to see if fid is a directory
  * returns 1 for yes
  * returns 0 for no */

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -467,7 +467,7 @@ unifycr_fd_t *unifycr_get_filedesc_from_fd(int fd);
 
 /* given a file id, return a pointer to the meta data,
  * otherwise return NULL */
-inline unifycr_filemeta_t *unifycr_get_meta_from_fid(int fid);
+unifycr_filemeta_t *unifycr_get_meta_from_fid(int fid);
 
 /* given an UNIFYCR error code, return corresponding errno code */
 int unifycr_err_map_to_errno(int rc);

--- a/client/src/unifycr-stdio.c
+++ b/client/src/unifycr-stdio.c
@@ -165,7 +165,7 @@ int unifycr_unsupported_stream(
     return rc;
 }
 
-static int unifycr_stream_set_pointers(unifycr_stream_t *s)
+int unifycr_stream_set_pointers(unifycr_stream_t *s)
 {
     /* get pointer to file descriptor structure */
     unifycr_fd_t *filedesc = unifycr_get_filedesc_from_fd(s->fd);

--- a/client/src/unifycr-stdio.c
+++ b/client/src/unifycr-stdio.c
@@ -309,7 +309,7 @@ static int unifycr_fopen(
     /* assume default permissions */
     mode_t perms = unifycr_getmode(0);
 
-    int open_rc;
+    int open_rc = -1;
     int fid;
     off_t pos;
     if (read) {

--- a/client/src/unifycr-stdio.c
+++ b/client/src/unifycr-stdio.c
@@ -1328,26 +1328,6 @@ size_t UNIFYCR_WRAP(fwrite)(const void *ptr, size_t size, size_t nitems,
     }
 }
 
-int UNIFYCR_WRAP(fprintf)(FILE *stream, const char *format, ...)
-{
-    /* check whether we should intercept this stream */
-    if (unifycr_intercept_stream(stream)) {
-        /* delegate work to vfprintf */
-        va_list args;
-        va_start(args, format);
-        int ret = UNIFYCR_WRAP(vfprintf)(stream, format, args);
-        va_end(args);
-        return ret;
-    } else {
-        va_list args;
-        va_start(args, format);
-        MAP_OR_FAIL(vfprintf);
-        int ret = UNIFYCR_REAL(vfprintf)(stream, format, args);
-        va_end(args);
-        return ret;
-    }
-}
-
 int UNIFYCR_WRAP(vfprintf)(FILE *stream, const char *format, va_list ap)
 {
     /* check whether we should intercept this stream */
@@ -1407,21 +1387,22 @@ int UNIFYCR_WRAP(vfprintf)(FILE *stream, const char *format, va_list ap)
     }
 }
 
-int UNIFYCR_WRAP(fscanf)(FILE *stream, const char *format, ...)
+int UNIFYCR_WRAP(fprintf)(FILE *stream, const char *format, ...)
 {
+    va_list args;
+    int ret;
+
     /* check whether we should intercept this stream */
     if (unifycr_intercept_stream(stream)) {
-        /* delegate work to vfscanf */
-        va_list args;
+        /* delegate work to vfprintf */
         va_start(args, format);
-        int ret = UNIFYCR_WRAP(vfscanf)(stream, format, args);
+        ret = UNIFYCR_WRAP(vfprintf)(stream, format, args);
         va_end(args);
         return ret;
     } else {
-        va_list args;
         va_start(args, format);
-        MAP_OR_FAIL(vfscanf);
-        int ret = UNIFYCR_REAL(vfscanf)(stream, format, args);
+        MAP_OR_FAIL(vfprintf);
+        ret = UNIFYCR_REAL(vfprintf)(stream, format, args);
         va_end(args);
         return ret;
     }
@@ -1432,18 +1413,40 @@ static int __svfscanf(unifycr_stream_t *fp, const char *fmt0, va_list ap);
 
 int UNIFYCR_WRAP(vfscanf)(FILE *stream, const char *format, va_list ap)
 {
+    va_list args;
+    int ret;
+
     /* check whether we should intercept this stream */
     if (unifycr_intercept_stream(stream)) {
-        va_list args;
         va_copy(args, ap);
-        int ret = __svfscanf((unifycr_stream_t *)stream, format, args);
+        ret = __svfscanf((unifycr_stream_t *)stream, format, args);
         va_end(args);
         return ret;
     } else {
-        va_list args;
         va_copy(args, ap);
         MAP_OR_FAIL(vfscanf);
-        int ret = UNIFYCR_REAL(vfscanf)(stream, format, args);
+        ret = UNIFYCR_REAL(vfscanf)(stream, format, args);
+        va_end(args);
+        return ret;
+    }
+}
+
+int UNIFYCR_WRAP(fscanf)(FILE *stream, const char *format, ...)
+{
+    va_list args;
+    int ret;
+
+    /* check whether we should intercept this stream */
+    if (unifycr_intercept_stream(stream)) {
+        /* delegate work to vfscanf */
+        va_start(args, format);
+        ret = UNIFYCR_WRAP(vfscanf)(stream, format, args);
+        va_end(args);
+        return ret;
+    } else {
+        va_start(args, format);
+        MAP_OR_FAIL(vfscanf);
+        ret = UNIFYCR_REAL(vfscanf)(stream, format, args);
         va_end(args);
         return ret;
     }

--- a/client/src/unifycr-stdio.c
+++ b/client/src/unifycr-stdio.c
@@ -1677,13 +1677,10 @@ int UNIFYCR_WRAP(fflush)(FILE *stream)
 
     /* otherwise, check whether we should intercept this stream */
     if (unifycr_intercept_stream(stream)) {
-        /* lookup stream */
-        unifycr_stream_t *s = (unifycr_stream_t *) stream;
-
         /* TODO: check that stream is active */
-
         /* flush output on stream */
         int rc = unifycr_stream_flush(stream);
+
         if (rc != UNIFYCR_SUCCESS) {
             /* ERROR: flush sets error indicator and errno */
             return EOF;
@@ -2927,7 +2924,7 @@ __sccl(tab, fmt)
 char *tab;
 const u_char *fmt;
 {
-    int c, n, v, i;
+    int c, n, v;
 
     /* first `clear' the whole table */
     c = *fmt++;     /* first char hat => negated scanset */

--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -115,7 +115,10 @@ int UNIFYCR_WRAP(mkdir)(const char *path, mode_t mode)
 
         /* add directory to file list */
         int fid = unifycr_fid_create_directory(path);
-        return 0;
+        if (fid < 0)
+            return -1;
+        else
+            return 0;
     } else {
         MAP_OR_FAIL(mkdir);
         int ret = UNIFYCR_REAL(mkdir)(path, mode);
@@ -154,7 +157,10 @@ int UNIFYCR_WRAP(rmdir)(const char *path)
 
         /* remove the directory from the file list */
         int ret = unifycr_fid_unlink(fid);
-        return 0;
+        if (ret < 0)
+            return -1;
+        else
+            return 0;
     } else {
         MAP_OR_FAIL(rmdir);
         int ret = UNIFYCR_REAL(rmdir)(path);
@@ -1249,11 +1255,12 @@ int unifycr_match_received_ack(read_req_t *read_req, int count,
  * */
 int unifycr_fd_logreadlist(read_req_t *read_req, int count)
 {
-    int i, j, tot_sz = 0, rc = UNIFYCR_SUCCESS,
-              bytes_read = 0, num = 0, bytes_write = 0;
-    int *ptr_size = NULL, *ptr_num = NULL;
-    int tmp_counter = 0;
-    int delegator;
+    int i;
+    int tot_sz = 0;
+    int rc = UNIFYCR_SUCCESS;
+    int num = 0;
+    int *ptr_size = NULL;
+    int *ptr_num = NULL;
 
     /*
      * Todo: When the number of read requests exceed the
@@ -1324,7 +1331,8 @@ int unifycr_fd_logreadlist(read_req_t *read_req, int count)
             if (cmd_fd.revents != 0) {
                 if (cmd_fd.revents == POLLIN) {
                     int sh_cursor = 0;
-                    bytes_read = __real_read(cmd_fd.fd, cmd_buf, sizeof(cmd_buf));
+
+                    (void) __real_read(cmd_fd.fd, cmd_buf, sizeof(cmd_buf));
                     ptr_size = (int *)shm_recvbuf;
                     num = *((int *)shm_recvbuf + 1); /*The first int spared out for size*/
                     ptr_num = (int *)((char *)shm_recvbuf + sizeof(int));

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -279,9 +279,46 @@ int unifycr_err_map_to_errno(int rc)
         return EBADF;
     case UNIFYCR_ERR_ISDIR:
         return EISDIR;
-    default:
-        return EIO;
+    case UNIFYCR_ERR_NOMEM:
+        return ENOMEM;
     }
+    return EIO;
+}
+
+/* given an errno error code, return corresponding UnifyCR error code */
+int unifycr_errno_map_to_err(int rc)
+{
+    switch (rc) {
+    case 0:
+        return UNIFYCR_SUCCESS;
+    case ENOSPC:
+        return UNIFYCR_ERR_NOSPC;
+    case EIO:
+        return UNIFYCR_ERR_IO;
+    case ENAMETOOLONG:
+        return UNIFYCR_ERR_NAMETOOLONG;
+    case ENOENT:
+        return UNIFYCR_ERR_NOENT;
+    case EEXIST:
+        return UNIFYCR_ERR_EXIST;
+    case ENOTDIR:
+        return UNIFYCR_ERR_NOTDIR;
+    case ENFILE:
+        return UNIFYCR_ERR_NFILE;
+    case EINVAL:
+        return UNIFYCR_ERR_INVAL;
+    case EOVERFLOW:
+        return UNIFYCR_ERR_OVERFLOW;
+    case EFBIG:
+        return UNIFYCR_ERR_FBIG;
+    case EBADF:
+        return UNIFYCR_ERR_BADF;
+    case EISDIR:
+        return UNIFYCR_ERR_ISDIR;
+    case ENOMEM:
+        return UNIFYCR_ERR_NOMEM;
+    }
+    return UNIFYCR_FAILURE;
 }
 
 /* returns 1 if two input parameters will overflow their type when

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1992,8 +1992,7 @@ int unifycr_unmount()
         char cmd_buf[GEN_STR_LEN] = {0};
         memcpy(cmd_buf, &cmd, sizeof(int));
 
-        int res = __real_write(cmd_fd.fd,
-                               cmd_buf, sizeof(cmd_buf));
+        int res = __real_write(cmd_fd.fd, cmd_buf, sizeof(cmd_buf));
         if (res != 0) {
             int bytes_read = 0;
             int rc;
@@ -2030,11 +2029,9 @@ int unifycr_unmount()
         } else {
             return UNIFYCR_FAILURE;
         }
-
-    } else {
-        return UNIFYCR_FAILURE;
     }
 
+    return UNIFYCR_FAILURE;
 }
 
 /* mount memfs at some prefix location */

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1261,7 +1261,7 @@ int unifycr_fid_unlink(int fid)
 /* initialize our global pointers into the given superblock */
 static void *unifycr_init_pointers(void *superblock)
 {
-    char *ptr = (char *) superblock;
+    char *ptr = (char *)superblock;
 
     /* jump over header (right now just a uint32_t to record
      * magic value of 0xdeadbeef if initialized */
@@ -1272,21 +1272,21 @@ static void *unifycr_init_pointers(void *superblock)
     ptr += unifycr_stack_bytes(unifycr_max_files);
 
     /* record list of file names */
-    unifycr_filelist = (unifycr_filename_t *) ptr;
+    unifycr_filelist = (unifycr_filename_t *)ptr;
     ptr += unifycr_max_files * sizeof(unifycr_filename_t);
 
     /* array of file meta data structures */
-    unifycr_filemetas = (unifycr_filemeta_t *) ptr;
+    unifycr_filemetas = (unifycr_filemeta_t *)ptr;
     ptr += unifycr_max_files * sizeof(unifycr_filemeta_t);
 
     /* array of chunk meta data strucutres for each file */
-    unifycr_chunkmetas = (unifycr_chunkmeta_t *) ptr;
+    unifycr_chunkmetas = (unifycr_chunkmeta_t *)ptr;
     ptr += unifycr_max_files * unifycr_max_chunks * sizeof(unifycr_chunkmeta_t);
 
-    if (unifycr_use_spillover) {
-        ptr += unifycr_max_files * unifycr_spillover_max_chunks * sizeof(
-                   unifycr_chunkmeta_t);
-    }
+    if (unifycr_use_spillover)
+        ptr += unifycr_max_files * unifycr_spillover_max_chunks *
+               sizeof(unifycr_chunkmeta_t);
+
     /* stack to manage free memory data chunks */
     free_chunk_stack = ptr;
     ptr += unifycr_stack_bytes(unifycr_max_chunks);
@@ -1300,12 +1300,11 @@ static void *unifycr_init_pointers(void *superblock)
     /* Only set this up if we're using memfs */
     if (unifycr_use_memfs) {
         /* round ptr up to start of next page */
-        unsigned long long ull_ptr  = (unsigned long long) ptr;
-        unsigned long long ull_page = (unsigned long long) unifycr_page_size;
+        unsigned long long ull_ptr  = (unsigned long long)ptr;
+        unsigned long long ull_page = (unsigned long long)unifycr_page_size;
         unsigned long long num_pages = ull_ptr / ull_page;
-        if (ull_ptr > num_pages * ull_page) {
+        if (ull_ptr > num_pages * ull_page)
             ptr = (char *)((num_pages + 1) * ull_page);
-        }
 
         /* pointer to start of memory data chunks */
         unifycr_chunks = ptr;
@@ -1316,7 +1315,7 @@ static void *unifycr_init_pointers(void *superblock)
 
     /* pointer to the log-structured metadata structures*/
     if (fs_type == UNIFYCR_LOG) {
-        unifycr_indices.ptr_num_entries = (unsigned long *)ptr;
+        unifycr_indices.ptr_num_entries = (off_t *)ptr;
 
         ptr += unifycr_page_size;
         unifycr_indices.index_entry = (unifycr_index_t *)ptr;
@@ -1324,7 +1323,7 @@ static void *unifycr_init_pointers(void *superblock)
 
         /*data structures  to record the global metadata*/
         ptr += unifycr_max_index_entries * sizeof(unifycr_index_t);
-        unifycr_fattrs.ptr_num_entries = (unsigned long *)ptr;
+        unifycr_fattrs.ptr_num_entries = (off_t *)ptr;
         ptr += unifycr_page_size;
         unifycr_fattrs.meta_entry = (unifycr_fattr_t *)ptr;
     }

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -847,7 +847,7 @@ int unifycr_fid_extend(int fid, off_t length)
     unifycr_filemeta_t *meta = unifycr_get_meta_from_fid(fid);
 
     /* determine file storage type */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK |
+    if (meta->storage == FILE_STORAGE_FIXED_CHUNK ||
         meta->storage == FILE_STORAGE_LOGIO) {
         /* file stored in fixed-size chunks */
         rc = unifycr_fid_store_fixed_extend(fid, meta, length);

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2536,7 +2536,7 @@ static int CountTasksPerNode(int rank, int numTasks)
             set_counter++;
 
             /* broadcast the rank_cnt and rank_set information to each rank */
-            int root_set_no;
+            int root_set_no = -1;
 
             for (i = 0; i < set_counter; i++) {
                 for (j = 0; j < rank_cnt[i]; j++) {
@@ -2563,11 +2563,14 @@ static int CountTasksPerNode(int rank, int numTasks)
 
 
             /* root process set its own local rank set and rank_cnt*/
-            local_rank_lst = malloc(rank_cnt[root_set_no] * sizeof(int));
-            for (i = 0; i < rank_cnt[root_set_no]; i++)
-                local_rank_lst[i] = rank_set[root_set_no][i];
+            if (root_set_no >= 0) {
+                local_rank_lst = malloc(rank_cnt[root_set_no] * sizeof(int));
+                for (i = 0; i < rank_cnt[root_set_no]; i++)
+                    local_rank_lst[i] = rank_set[root_set_no][i];
 
-            local_rank_cnt = rank_cnt[root_set_no];
+                local_rank_cnt = rank_cnt[root_set_no];
+            }
+
             for (i = 0; i < set_counter; i++)
                 free(rank_set[i]);
 

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -68,28 +68,9 @@ typedef struct {
     int rank;
 } name_rank_pair_t;
 
-static int get_del_cnt();
-static int compare_int(const void *a, const void *b);
-static int compare_name_rank_pair(const void *a, const void *b);
-static int find_rank_idx(int rank,
-                         int *local_rank_lst, int local_rank_cnt);
-static int unifycr_init_socket(int proc_id,
-                               int l_num_procs_per_node,
-                               int l_num_del_per_node);
-static int CountTasksPerNode(int rank, int numTasks);
-static int unifycr_init_req_shm(int local_rank_idx, int app_id);
 int unifycr_mount(const char prefix[], int rank, size_t size,
                   int l_app_id, int subtype);
-static int unifycr_init_recv_shm(int local_rank_idx, int app_id);
-static int unifycr_init_req_shm(int local_rank_idx, int app_id);
-static int unifycr_sync_to_del();
-static int unifycr_get_global_fid(const char *path, int *gfid);
-static int get_global_file_meta(int gfid, unifycr_fattr_t **file_meta);
-static int set_global_file_meta(unifycr_fattr_t *f_meta);
-static int ins_file_meta(unifycr_fattr_buf_t *ptr_f_meta_log,
-                         unifycr_fattr_t *ins_fattr);
 int compare_fattr(const void *a, const void *b);
-
 
 /* mount memfs at some prefix location */
 int unifycrfs_mount(const char prefix[], size_t size, int rank);

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -22,6 +22,7 @@ checkpatch_ignore+=",FILE_PATH_CHANGES" # Don't nag about updating MAINTAINERS
 checkpatch_ignore+=",CONST_STRUCT"      # Don't nag about const structs
 checkpatch_ignore+=",SPLIT_STRING"      # Allow long strings to be split
 checkpatch_ignore+=",ARRAY_SIZE"        # Don't require use of ARRAY_SIZE macro
+checkpatch_ignore+=",USE_NEGATIVE_ERRNO" # We don't return negative errnos
 
 checkpatch_cmd+=" --ignore $checkpatch_ignore"
 


### PR DESCRIPTION
Follow on work from #61 to clean up compiler warnings. Enable -Wall in client/src/Makefile and address most of the resulting warnings. A few still remain because they seem to point to actual bugs and the fixes aren't clear.

This one depends on resolving #64:

```
unifycr-stdio.c: In function ‘unifycr_stream_write’:
unifycr-stdio.c:694:9: warning: statement with no effect [-Wunused-value]
         s->ubuflen;
         ^
```

And this one depends on #68:

```
unifycr-stdio.c: In function ‘__svfscanf’:
unifycr-stdio.c:2825:16: warning: ‘nr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             if (nr < 0) {
                ^
```