### PR TITLE
fix debug output in client

### DIFF
--- a/client/src/unifycr-defs.h
+++ b/client/src/unifycr-defs.h
@@ -1,8 +1,15 @@
+/* holds debug level for unifycr, this defaults to zero
+ * in unifycr_init, but can be changed at runtime by setting
+ * the UNIFYCR_DEBUG env variable to a value greater than 1
+ */
+extern int unifycr_debug_level;
+
 #define UNIFYCR_MAX_FILES        ( 128 )
 
 /* eventually could decouple these so there could be
  * more or less file descriptors than files, but for
- * now they're the same */
+ * now they're the same
+ */
 #define UNIFYCR_MAX_FILEDESCS    ( UNIFYCR_MAX_FILES )
 
 #define UNIFYCR_MAX_FILENAME     ( 128 )

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -111,7 +111,7 @@ static inline void *unifycr_compute_chunk_buf(
         start = unifycr_chunks + ((long)physical_id << unifycr_chunk_bits);
     } else {
         /* chunk is in spill over */
-        debug("wrong chunk ID\n");
+        DEBUG("wrong chunk ID\n");
         return NULL;
     }
 
@@ -135,7 +135,7 @@ static inline off_t unifycr_compute_spill_offset(
     /* compute start of chunk in spill over device */
     off_t start = 0;
     if (physical_id < unifycr_max_chunks) {
-        debug("wrong spill-chunk ID\n");
+        DEBUG("wrong spill-chunk ID\n");
         return -1;
     } else {
         /* compute buffer loc within spillover device chunk */
@@ -167,14 +167,14 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
         } else if (unifycr_use_spillover) {
             /* shm segment out of space, grab a block from spill-over device */
 
-            debug("getting blocks from spill-over device\n");
+            DEBUG("getting blocks from spill-over device\n");
             /* TODO: missing lock calls? */
             /* add unifycr_max_chunks to identify chunk location */
             unifycr_stack_lock();
             id = unifycr_stack_pop(free_spillchunk_stack) + unifycr_max_chunks;
             unifycr_stack_unlock();
             if (id < unifycr_max_chunks) {
-                debug("spill-over device out of space (%d)\n", id);
+                DEBUG("spill-over device out of space (%d)\n", id);
                 return UNIFYCR_ERR_NOSPC;
             }
 
@@ -183,14 +183,14 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
             chunk_meta->id = id;
         } else {
             /* spill over isn't available, so we're out of space */
-            debug("memfs out of space (%d)\n", id);
+            DEBUG("memfs out of space (%d)\n", id);
             return UNIFYCR_ERR_NOSPC;
         }
     } else if (unifycr_use_spillover) {
         /* memory file system is not enabled, but spill over is */
 
         /* shm segment out of space, grab a block from spill-over device */
-        debug("getting blocks from spill-over device \n");
+        DEBUG("getting blocks from spill-over device\n");
 
         /* TODO: missing lock calls? */
         /* add unifycr_max_chunks to identify chunk location */
@@ -198,7 +198,7 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
         int id = unifycr_stack_pop(free_spillchunk_stack) + unifycr_max_chunks;
         unifycr_stack_unlock();
         if (id < unifycr_max_chunks) {
-            debug("spill-over device out of space (%d)\n", id);
+            DEBUG("spill-over device out of space (%d)\n", id);
             return UNIFYCR_ERR_NOSPC;
         }
 
@@ -221,7 +221,7 @@ static int unifycr_chunk_free(int fid, unifycr_filemeta_t *meta, int chunk_id)
 
     /* get physical id of chunk */
     int id = chunk_meta->id;
-    debug("free chunk %d from location %d\n", id, chunk_meta->location);
+    DEBUG("free chunk %d from location %d\n", id, chunk_meta->location);
 
     /* determine location of chunk */
     if (chunk_meta->location == CHUNK_LOCATION_MEMFS) {
@@ -232,7 +232,7 @@ static int unifycr_chunk_free(int fid, unifycr_filemeta_t *meta, int chunk_id)
         /* TODO: free spill over chunk */
     } else {
         /* unkwown chunk location */
-        debug("unknown chunk location %d\n", chunk_meta->location);
+        DEBUG("unknown chunk location %d\n", chunk_meta->location);
         return UNIFYCR_ERR_IO;
     }
 
@@ -267,7 +267,7 @@ static int unifycr_chunk_read(
         /* TODO: check return code for errors */
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -509,7 +509,7 @@ static int unifycr_logio_chunk_write(
         /* TOdo: check return code for errors */
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -548,7 +548,7 @@ static int unifycr_chunk_write(
         /* TODO: check return code for errors */
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -578,7 +578,7 @@ int unifycr_fid_store_fixed_extend(int fid, unifycr_filemeta_t *meta,
             /* allocate a new chunk */
             int rc = unifycr_chunk_alloc(fid, meta, meta->chunks);
             if (rc != UNIFYCR_SUCCESS) {
-                debug("failed to allocate chunk\n");
+                DEBUG("failed to allocate chunk\n");
                 return UNIFYCR_ERR_NOSPC;
             }
 

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -71,12 +71,12 @@
 
 /* TODO: move common includes to another file */
 #include "unifycr-defs.h"
-
-#ifdef UNIFYCR_DEBUG
-#define debug(fmt, args... )  printf("%s: "fmt, __func__, ##args)
-#else
-#define debug(fmt, args... )
-#endif
+#define DEBUG(fmt, ...) \
+do { \
+    if (unifycr_debug_level > 0) \
+        printf("unifycr: %s:%d: %s: " fmt "\n", \
+               __FILE__, __LINE__, __func__, ## __VA_ARGS__); \
+} while (0)
 
 /* define a macro to capture function name, file name, and line number
  * along with user-defined string */

--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -81,19 +81,20 @@ int UNIFYCR_WRAP(access)(const char *path, int mode)
     if (unifycr_intercept_path(path)) {
         /* check if path exists */
         if (unifycr_get_fid_from_path(path) < 0) {
-            debug("access: unifycr_get_id_from path failed, returning -1, %s\n", path);
+            DEBUG("access: unifycr_get_id_from path failed, returning -1, %s\n",
+                  path);
             errno = ENOENT;
             return -1;
         }
 
         /* currently a no-op */
-        debug("access: path intercepted, returning 0, %s\n", path);
+        DEBUG("access: path intercepted, returning 0, %s\n", path);
         return 0;
     } else {
-        debug("access: calling MAP_OR_FAIL, %s\n", path);
+        DEBUG("access: calling MAP_OR_FAIL, %s\n", path);
         MAP_OR_FAIL(access);
         int ret = UNIFYCR_REAL(access)(path, mode);
-        debug("access: returning __real_access %d,%s\n", ret, path);
+        DEBUG("access: returning __real_access %d,%s\n", ret, path);
         return ret;
     }
 }
@@ -178,10 +179,10 @@ int UNIFYCR_WRAP(rename)(const char *oldpath, const char *newpath)
 
         /* verify that we really have a file by the old name */
         int fid = unifycr_get_fid_from_path(oldpath);
-        debug("orig file in position %d\n", fid);
+        DEBUG("orig file in position %d\n", fid);
         if (fid < 0) {
             /* ERROR: oldname does not exist */
-            debug("Couldn't find entry for %s in UNIFYCR\n", oldpath);
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", oldpath);
             errno = ENOENT;
             return -1;
         }
@@ -196,11 +197,12 @@ int UNIFYCR_WRAP(rename)(const char *oldpath, const char *newpath)
             }
 
             /* finally overwrite the old name with the new name */
-            debug("Changing %s to %s\n", (char *)&unifycr_filelist[fid].filename, newpath);
+            DEBUG("Changing %s to %s\n",
+                  (char *)&unifycr_filelist[fid].filename, newpath);
             strcpy((void *)&unifycr_filelist[fid].filename, newpath);
         } else {
             /* ERROR: new name already exists */
-            debug("File %s exists\n", newpath);
+            DEBUG("File %s exists\n", newpath);
             errno = EEXIST;
             return -1;
         }
@@ -228,7 +230,7 @@ int UNIFYCR_WRAP(truncate)(const char *path, off_t length)
         int fid = unifycr_get_fid_from_path(path);
         if (fid < 0) {
             /* ERROR: file does not exist */
-            debug("Couldn't find entry for %s in UNIFYCR\n", path);
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
             errno = ENOENT;
             return -1;
         }
@@ -236,7 +238,7 @@ int UNIFYCR_WRAP(truncate)(const char *path, off_t length)
         /* truncate the file */
         int rc = unifycr_fid_truncate(fid, length);
         if (rc != UNIFYCR_SUCCESS) {
-            debug("unifycr_fid_truncate failed for %s in UNIFYCR\n", path);
+            DEBUG("unifycr_fid_truncate failed for %s in UNIFYCR\n", path);
             errno = EIO;
             return -1;
         }
@@ -257,7 +259,7 @@ int UNIFYCR_WRAP(unlink)(const char *path)
         int fid = unifycr_get_fid_from_path(path);
         if (fid < 0) {
             /* ERROR: file does not exist */
-            debug("Couldn't find entry for %s in UNIFYCR\n", path);
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
             errno = ENOENT;
             return -1;
         }
@@ -265,7 +267,7 @@ int UNIFYCR_WRAP(unlink)(const char *path)
         /* check that it's not a directory */
         if (unifycr_fid_is_dir(fid)) {
             /* ERROR: is a directory */
-            debug("Attempting to unlink a directory %s in UNIFYCR\n", path);
+            DEBUG("Attempting to unlink a directory %s in UNIFYCR\n", path);
             errno = EISDIR;
             return -1;
         }
@@ -289,7 +291,7 @@ int UNIFYCR_WRAP(remove)(const char *path)
         int fid = unifycr_get_fid_from_path(path);
         if (fid < 0) {
             /* ERROR: file does not exist */
-            debug("Couldn't find entry for %s in UNIFYCR\n", path);
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
             errno = ENOENT;
             return -1;
         }
@@ -298,7 +300,7 @@ int UNIFYCR_WRAP(remove)(const char *path)
         if (unifycr_fid_is_dir(fid)) {
             /* TODO: shall be equivalent to rmdir(path) */
             /* ERROR: is a directory */
-            debug("Attempting to remove a directory %s in UNIFYCR\n", path);
+            DEBUG("Attempting to remove a directory %s in UNIFYCR\n", path);
             errno = EISDIR;
             return -1;
         }
@@ -317,7 +319,7 @@ int UNIFYCR_WRAP(remove)(const char *path)
 
 int UNIFYCR_WRAP(stat)(const char *path, struct stat *buf)
 {
-    debug("stat was called for %s....\n", path);
+    DEBUG("stat was called for %s....\n", path);
     if (unifycr_intercept_path(path)) {
         int fid = unifycr_get_fid_from_path(path);
         if (fid < 0) {
@@ -337,7 +339,7 @@ int UNIFYCR_WRAP(stat)(const char *path, struct stat *buf)
 
 int UNIFYCR_WRAP(__xstat)(int vers, const char *path, struct stat *buf)
 {
-    debug("xstat was called for %s....\n", path);
+    DEBUG("xstat was called for %s....\n", path);
     if (unifycr_intercept_path(path)) {
         /* get file id for path */
         int fid = unifycr_get_fid_from_path(path);
@@ -538,7 +540,7 @@ int UNIFYCR_WRAP(creat)(const char *path, mode_t mode)
         filedesc->pos   = pos;
         filedesc->read  = 0;
         filedesc->write = 1;
-        debug("UNIFYCR_open generated fd %d for file %s\n", fid, path);
+        DEBUG("UNIFYCR_open generated fd %d for file %s\n", fid, path);
 
         /* don't conflict with active system fds that range from 0 - (fd_limit) */
         int ret = fid + unifycr_fd_limit;
@@ -596,7 +598,7 @@ int UNIFYCR_WRAP(open)(const char *path, int flags, ...)
                           || ((flags & O_RDWR) == O_RDWR);
         filedesc->write = ((flags & O_WRONLY) == O_WRONLY)
                           || ((flags & O_RDWR) == O_RDWR);
-        debug("UNIFYCR_open generated fd %d for file %s\n", fid, path);
+        DEBUG("UNIFYCR_open generated fd %d for file %s\n", fid, path);
 
         /* don't conflict with active system fds that range from 0 - (fd_limit) */
         ret = fid + unifycr_fd_limit;
@@ -666,7 +668,7 @@ off_t UNIFYCR_WRAP(lseek)(int fd, off_t offset, int whence)
         off_t current_pos = filedesc->pos;
 
         /* compute final file position */
-        debug("seeking from %ld\n", current_pos);
+        DEBUG("seeking from %ld\n", current_pos);
         switch (whence) {
         case SEEK_SET:
             /* seek to offset */
@@ -684,7 +686,7 @@ off_t UNIFYCR_WRAP(lseek)(int fd, off_t offset, int whence)
             errno = EINVAL;
             return (off_t) (-1);
         }
-        debug("seeking to %ld\n", current_pos);
+        DEBUG("seeking to %ld\n", current_pos);
 
         /* set and return final file position */
         filedesc->pos = current_pos;
@@ -1629,7 +1631,7 @@ int UNIFYCR_WRAP(flock)(int fd, int operation)
           switch (operation)
           {
               case LOCK_EX:
-                  debug("locking file %d..\n",fid);
+                  DEBUG("locking file %d..\n", fid);
                   ret = pthread_spin_lock(&meta->fspinlock);
                   if ( ret ) {
                       perror("pthread_spin_lock() failed");
@@ -1644,7 +1646,7 @@ int UNIFYCR_WRAP(flock)(int fd, int operation)
                   break;
               case LOCK_UN:
                   ret = pthread_spin_unlock(&meta->fspinlock);
-                  debug("unlocking file %d..\n",fid);
+                  DEBUG("unlocking file %d..\n", fid);
                   meta->flock_status = UNLOCKED;
                   break;
               default:
@@ -1773,7 +1775,7 @@ int UNIFYCR_WRAP(close)(int fd)
 {
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        debug("closing fd %d\n", fd);
+        DEBUG("closing fd %d\n", fd);
 
         /* TODO: what to do if underlying file has been deleted? */
 

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -176,6 +176,9 @@ extern pthread_mutex_t unifycr_stack_mutex;
 /* keep track of what we've initialized */
 int unifycr_initialized = 0;
 
+/* keep track of debug level */
+int unifycr_debug_level;
+
 /* global persistent memory block (metadata + data) */
 void *unifycr_superblock = NULL;
 static void *free_fid_stack = NULL;
@@ -279,9 +282,46 @@ int unifycr_err_map_to_errno(int rc)
         return EBADF;
     case UNIFYCR_ERR_ISDIR:
         return EISDIR;
-    default:
-        return EIO;
+    case UNIFYCR_ERR_NOMEM:
+        return ENOMEM;
     }
+    return EIO;
+}
+
+/* given an errno error code, return corresponding UnifyCR error code */
+int unifycr_errno_map_to_err(int rc)
+{
+    switch (rc) {
+    case 0:
+        return UNIFYCR_SUCCESS;
+    case ENOSPC:
+        return UNIFYCR_ERR_NOSPC;
+    case EIO:
+        return UNIFYCR_ERR_IO;
+    case ENAMETOOLONG:
+        return UNIFYCR_ERR_NAMETOOLONG;
+    case ENOENT:
+        return UNIFYCR_ERR_NOENT;
+    case EEXIST:
+        return UNIFYCR_ERR_EXIST;
+    case ENOTDIR:
+        return UNIFYCR_ERR_NOTDIR;
+    case ENFILE:
+        return UNIFYCR_ERR_NFILE;
+    case EINVAL:
+        return UNIFYCR_ERR_INVAL;
+    case EOVERFLOW:
+        return UNIFYCR_ERR_OVERFLOW;
+    case EFBIG:
+        return UNIFYCR_ERR_FBIG;
+    case EBADF:
+        return UNIFYCR_ERR_BADF;
+    case EISDIR:
+        return UNIFYCR_ERR_ISDIR;
+    case ENOMEM:
+        return UNIFYCR_ERR_NOMEM;
+    }
+    return UNIFYCR_FAILURE;
 }
 
 /* returns 1 if two input parameters will overflow their type when
@@ -419,7 +459,7 @@ inline int unifycr_intercept_fd(int *fd)
          * so intercept the call and shift the fd */
         int newfd = oldfd - unifycr_fd_limit;
         *fd = newfd;
-        debug("Changing fd from exposed %d to internal %d\n", oldfd, newfd);
+        DEBUG("Changing fd from exposed %d to internal %d\n", oldfd, newfd);
         return 1;
     }
 }
@@ -452,9 +492,8 @@ inline int unifycr_get_fid_from_path(const char *path)
     while (i < unifycr_max_files) {
         if (unifycr_filelist[i].in_use &&
             strcmp((void *)&unifycr_filelist[i].filename, path) == 0) {
-            debug("File found: unifycr_filelist[%d].filename = %s\n",
-                  i, (char *)&unifycr_filelist[i].filename
-                 );
+            DEBUG("File found: unifycr_filelist[%d].filename = %s\n",
+                  i, (char *)&unifycr_filelist[i].filename);
             return i;
         }
         i++;
@@ -524,9 +563,6 @@ static int unifycr_fid_store_alloc(int fid)
 /* free data management resource for file */
 static int unifycr_fid_store_free(int fid)
 {
-    /* get meta data for this file */
-    unifycr_filemeta_t *meta = unifycr_get_meta_from_fid(fid);
-
     return UNIFYCR_SUCCESS;
 }
 
@@ -566,9 +602,8 @@ int unifycr_fid_is_dir_empty(const char *path)
             char *strptr = strstr(path, unifycr_filelist[i].filename);
             if (strptr == unifycr_filelist[i].filename
                 && strcmp(path, unifycr_filelist[i].filename)) {
-                debug("File found: unifycr_filelist[%d].filename = %s\n",
-                      i, (char *)&unifycr_filelist[i].filename
-                     );
+                DEBUG("File found: unifycr_filelist[%d].filename = %s\n",
+                      i, (char *)&unifycr_filelist[i].filename);
                 return 0;
             }
         }
@@ -630,10 +665,10 @@ int unifycr_fid_alloc()
     unifycr_stack_lock();
     int fid = unifycr_stack_pop(free_fid_stack);
     unifycr_stack_unlock();
-    debug("unifycr_stack_pop() gave %d\n", fid);
+    DEBUG("unifycr_stack_pop() gave %d\n", fid);
     if (fid < 0) {
         /* need to create a new file, but we can't */
-        debug("unifycr_stack_pop() failed (%d)\n", fid);
+        DEBUG("unifycr_stack_pop() failed (%d)\n", fid);
         return -1;
     }
     return fid;
@@ -665,7 +700,8 @@ int unifycr_fid_create_file(const char *path)
      * and return appropriate error if it is greater
      */
     strcpy((void *)&unifycr_filelist[fid].filename, path);
-    debug("Filename %s got unifycr fd %d\n", unifycr_filelist[fid].filename, fid);
+    DEBUG("Filename %s got unifycr fd %d\n",
+          unifycr_filelist[fid].filename, fid);
 
     /* initialize meta data */
     unifycr_filemeta_t *meta = unifycr_get_meta_from_fid(fid);
@@ -810,7 +846,7 @@ int unifycr_fid_extend(int fid, off_t length)
     unifycr_filemeta_t *meta = unifycr_get_meta_from_fid(fid);
 
     /* determine file storage type */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK |
+    if (meta->storage == FILE_STORAGE_FIXED_CHUNK ||
         meta->storage == FILE_STORAGE_LOGIO) {
         /* file stored in fixed-size chunks */
         rc = unifycr_fid_store_fixed_extend(fid, meta, length);
@@ -901,7 +937,6 @@ static int unifycr_get_global_fid(const char *path, int *gfid)
     unsigned char md[16];
     memset(md, 0, 16);
 
-    int i;
     MD5_Init(&ctx);
     MD5_Update(&ctx, path, strlen(path));
     MD5_Final(md, &ctx);
@@ -1095,14 +1130,14 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
 
     /* check whether this file already exists */
     int fid = unifycr_get_fid_from_path(path);
-    debug("unifycr_get_fid_from_path() gave %d\n", fid);
+    DEBUG("unifycr_get_fid_from_path() gave %d\n", fid);
 
     int gfid = -1, rc = 0;
     if (fs_type == UNIFYCR_LOG) {
         if (fid < 0) {
             rc = unifycr_get_global_fid(path, &gfid);
             if (rc != UNIFYCR_SUCCESS) {
-                debug("Failed to generate fid for file %s\n", path);
+                DEBUG("Failed to generate fid for file %s\n", path);
                 return UNIFYCR_ERR_IO;
             }
 
@@ -1118,14 +1153,14 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
                  * allocate a file id slot for this existing file */
                 fid = unifycr_fid_create_file(path);
                 if (fid < 0) {
-                    debug("Failed to create new file %s\n", path);
+                    DEBUG("Failed to create new file %s\n", path);
                     return UNIFYCR_ERR_NFILE;
                 }
 
                 /* initialize the storage for the file */
                 int store_rc = unifycr_fid_store_alloc(fid);
                 if (store_rc != UNIFYCR_SUCCESS) {
-                    debug("Failed to create storage for file %s\n", path);
+                    DEBUG("Failed to create storage for file %s\n", path);
                     return UNIFYCR_ERR_IO;
                 }
                 /* initialize the global metadata
@@ -1148,23 +1183,23 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
         /* file does not exist */
         /* create file if O_CREAT is set */
         if (flags & O_CREAT) {
-            debug("Couldn't find entry for %s in UNIFYCR\n", path);
-            debug("unifycr_superblock = %p; free_fid_stack = %p; free_chunk_stack = %p; unifycr_filelist = %p; chunks = %p\n",
-                  unifycr_superblock, free_fid_stack, free_chunk_stack, unifycr_filelist,
-                  unifycr_chunks
-                 );
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
+            DEBUG("unifycr_superblock = %p; free_fid_stack = %p;"
+                  "free_chunk_stack = %p; unifycr_filelist = %p;"
+                  "chunks = %p\n", unifycr_superblock, free_fid_stack,
+                  free_chunk_stack, unifycr_filelist, unifycr_chunks);
 
             /* allocate a file id slot for this new file */
             fid = unifycr_fid_create_file(path);
             if (fid < 0) {
-                debug("Failed to create new file %s\n", path);
+                DEBUG("Failed to create new file %s\n", path);
                 return UNIFYCR_ERR_NFILE;
             }
 
             /* initialize the storage for the file */
             int store_rc = unifycr_fid_store_alloc(fid);
             if (store_rc != UNIFYCR_SUCCESS) {
-                debug("Failed to create storage for file %s\n", path);
+                DEBUG("Failed to create storage for file %s\n", path);
                 return UNIFYCR_ERR_IO;
             }
 
@@ -1184,7 +1219,7 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
             }
         } else {
             /* ERROR: trying to open a file that does not exist without O_CREATE */
-            debug("Couldn't find entry for %s in UNIFYCR\n", path);
+            DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
             return UNIFYCR_ERR_NOENT;
         }
     } else {
@@ -1222,7 +1257,7 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
     /* set in_use flag and file pointer */
     *outfid = fid;
     *outpos = pos;
-    debug("UNIFYCR_open generated fd %d for file %s\n", fid, path);
+    DEBUG("UNIFYCR_open generated fd %d for file %s\n", fid, path);
 
     /* don't conflict with active system fds that range from 0 - (fd_limit) */
     return UNIFYCR_SUCCESS;
@@ -1261,7 +1296,7 @@ int unifycr_fid_unlink(int fid)
 /* initialize our global pointers into the given superblock */
 static void *unifycr_init_pointers(void *superblock)
 {
-    char *ptr = (char *) superblock;
+    char *ptr = (char *)superblock;
 
     /* jump over header (right now just a uint32_t to record
      * magic value of 0xdeadbeef if initialized */
@@ -1272,21 +1307,21 @@ static void *unifycr_init_pointers(void *superblock)
     ptr += unifycr_stack_bytes(unifycr_max_files);
 
     /* record list of file names */
-    unifycr_filelist = (unifycr_filename_t *) ptr;
+    unifycr_filelist = (unifycr_filename_t *)ptr;
     ptr += unifycr_max_files * sizeof(unifycr_filename_t);
 
     /* array of file meta data structures */
-    unifycr_filemetas = (unifycr_filemeta_t *) ptr;
+    unifycr_filemetas = (unifycr_filemeta_t *)ptr;
     ptr += unifycr_max_files * sizeof(unifycr_filemeta_t);
 
     /* array of chunk meta data strucutres for each file */
-    unifycr_chunkmetas = (unifycr_chunkmeta_t *) ptr;
+    unifycr_chunkmetas = (unifycr_chunkmeta_t *)ptr;
     ptr += unifycr_max_files * unifycr_max_chunks * sizeof(unifycr_chunkmeta_t);
 
-    if (unifycr_use_spillover) {
-        ptr += unifycr_max_files * unifycr_spillover_max_chunks * sizeof(
-                   unifycr_chunkmeta_t);
-    }
+    if (unifycr_use_spillover)
+        ptr += unifycr_max_files * unifycr_spillover_max_chunks *
+               sizeof(unifycr_chunkmeta_t);
+
     /* stack to manage free memory data chunks */
     free_chunk_stack = ptr;
     ptr += unifycr_stack_bytes(unifycr_max_chunks);
@@ -1300,12 +1335,11 @@ static void *unifycr_init_pointers(void *superblock)
     /* Only set this up if we're using memfs */
     if (unifycr_use_memfs) {
         /* round ptr up to start of next page */
-        unsigned long long ull_ptr  = (unsigned long long) ptr;
-        unsigned long long ull_page = (unsigned long long) unifycr_page_size;
+        unsigned long long ull_ptr  = (unsigned long long)ptr;
+        unsigned long long ull_page = (unsigned long long)unifycr_page_size;
         unsigned long long num_pages = ull_ptr / ull_page;
-        if (ull_ptr > num_pages * ull_page) {
+        if (ull_ptr > num_pages * ull_page)
             ptr = (char *)((num_pages + 1) * ull_page);
-        }
 
         /* pointer to start of memory data chunks */
         unifycr_chunks = ptr;
@@ -1316,7 +1350,7 @@ static void *unifycr_init_pointers(void *superblock)
 
     /* pointer to the log-structured metadata structures*/
     if (fs_type == UNIFYCR_LOG) {
-        unifycr_indices.ptr_num_entries = (unsigned long *)ptr;
+        unifycr_indices.ptr_num_entries = (off_t *)ptr;
 
         ptr += unifycr_page_size;
         unifycr_indices.index_entry = (unifycr_index_t *)ptr;
@@ -1324,7 +1358,7 @@ static void *unifycr_init_pointers(void *superblock)
 
         /*data structures  to record the global metadata*/
         ptr += unifycr_max_index_entries * sizeof(unifycr_index_t);
-        unifycr_fattrs.ptr_num_entries = (unsigned long *)ptr;
+        unifycr_fattrs.ptr_num_entries = (off_t *)ptr;
         ptr += unifycr_page_size;
         unifycr_fattrs.meta_entry = (unifycr_fattr_t *)ptr;
     }
@@ -1363,16 +1397,14 @@ static int unifycr_init_structures()
         *(unifycr_indices.ptr_num_entries) = 0;
         *(unifycr_fattrs.ptr_num_entries) = 0;
     }
-    debug("Meta-stacks initialized!\n");
+    DEBUG("Meta-stacks initialized!\n");
 
     return UNIFYCR_SUCCESS;
 }
 
 static int unifycr_get_spillblock(size_t size, const char *path)
 {
-    void *scr_spillblock = NULL;
     int spillblock_fd;
-
     mode_t perms = unifycr_getmode(0);
 
     //MAP_OR_FAIL(open);
@@ -1407,7 +1439,7 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
     void *scr_shmblock = NULL;
     int scr_shmblock_shmid;
 
-    debug("Key for superblock = %x\n", key);
+    DEBUG("Key for superblock = %x\n", key);
     if (fs_type != UNIFYCR_LOG) {
 #ifdef ENABLE_NUMA_POLICY
         /* if user requested to use 1 shm/process along with NUMA optimizations */
@@ -1416,7 +1448,7 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
             /* check to see if NUMA control capability is available */
             if (numa_available() >= 0) {
                 int max_numa_nodes = numa_max_node() + 1;
-                debug("Max. number of NUMA nodes = %d\n", max_numa_nodes);
+                DEBUG("Max. number of NUMA nodes = %d\n", max_numa_nodes);
                 int num_cores = sysconf(_SC_NPROCESSORS_CONF);
                 int my_core, i, pref_numa_bank = -1;
 
@@ -1431,22 +1463,23 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
                     }
                 }
                 if (my_core < 0) {
-                    debug("Not able to get current core affinity\n");
+                    DEBUG("Not able to get current core affinity\n");
                     return NULL;
                 }
-                debug("Process running on core %d\n", my_core);
+                DEBUG("Process running on core %d\n", my_core);
 
                 /* find out which NUMA bank this core belongs to */
                 // numa_preferred doesn't work as needed, returns 0 always. placeholder only.
                 pref_numa_bank = numa_preferred();
-                debug("Preferred NUMA bank for core %d is %d\n", my_core, pref_numa_bank);
+                DEBUG("Preferred NUMA bank for core %d is %d\n",
+                      my_core, pref_numa_bank);
 
                 /* create/attach to respective shmblock*/
                 scr_shmblock_shmid = shmget((key + pref_numa_bank), size,
                                             IPC_CREAT | IPC_EXCL | S_IRWXU);
 
             } else {
-                debug("NUMA support unavailable!\n");
+                DEBUG("NUMA support unavailable!\n");
                 return NULL;
             }
         } else {
@@ -1468,7 +1501,7 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
                     perror("shmat() failed");
                     return NULL;
                 }
-                debug("Superblock exists at %p!\n", scr_shmblock);
+                DEBUG("Superblock exists at %p!\n", scr_shmblock);
 
                 /* init our global variables to point to spots in superblock */
                 unifycr_init_pointers(scr_shmblock);
@@ -1483,7 +1516,7 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
             if (scr_shmblock == (void *) - 1) {
                 perror("shmat() failed");
             }
-            debug("Superblock created at %p!\n", scr_shmblock);
+            DEBUG("Superblock created at %p!\n", scr_shmblock);
 
 
 #ifdef ENABLE_NUMA_POLICY
@@ -1494,12 +1527,12 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
             } else if (strcmp(unifycr_numa_policy, "interleaved") == 0) {
                 /* interleave the shared-memory segment
                  * across all memory banks when all process share 1-superblock */
-                debug("Interleaving superblock across all memory banks\n");
+                DEBUG("Interleaving superblock across all memory banks\n");
                 numa_interleave_memory(scr_shmblock, size, numa_all_nodes_ptr);
             } else if (strcmp(unifycr_numa_policy, "local") == 0) {
                 /* each process has its own superblock, let it be allocated from
                  * the closest memory bank */
-                debug("Assigning memory from closest bank\n");
+                DEBUG("Assigning memory from closest bank\n");
                 numa_setlocal_memory(scr_shmblock, size);
             }
 #endif
@@ -1512,8 +1545,8 @@ static void *unifycr_superblock_shmget(size_t size, key_t key)
     } else {
         /* Use mmap to allocated share memory for UnifyCR*/
         int ret = -1;
-        int fd = -1;
         char shm_name[GEN_STR_LEN] = {0};
+
         sprintf(shm_name, "%d-super-%d", app_id, key);
         superblock_fd = shm_open(shm_name, MMAP_OPEN_FLAG, MMAP_OPEN_MODE);
         if (-1 == (ret = superblock_fd)) {
@@ -1599,17 +1632,15 @@ static int unifycr_abtoull(char *str, unsigned long long *val)
 {
     /* check that we have a string */
     if (str == NULL) {
-        debug("scr_abtoull: Can't convert NULL string to bytes @ %s:%d",
-              __FILE__, __LINE__
-             );
+        DEBUG("scr_abtoull: Can't convert NULL string to bytes @ %s:%d",
+              __FILE__, __LINE__);
         return UNIFYCR_FAILURE;
     }
 
     /* check that we have a value to write to */
     if (val == NULL) {
-        debug("scr_abtoull: NULL address to store value @ %s:%d",
-              __FILE__, __LINE__
-             );
+        DEBUG("scr_abtoull: NULL address to store value @ %s:%d",
+              __FILE__, __LINE__);
         return UNIFYCR_FAILURE;
     }
 
@@ -1618,9 +1649,8 @@ static int unifycr_abtoull(char *str, unsigned long long *val)
     char *next = NULL;
     double num = strtod(str, &next);
     if (errno != 0) {
-        debug("scr_abtoull: Invalid double: %s @ %s:%d",
-              str, __FILE__, __LINE__
-             );
+        DEBUG("scr_abtoull: Invalid double: %s @ %s:%d",
+              str, __FILE__, __LINE__);
         return UNIFYCR_FAILURE;
     }
 
@@ -1641,9 +1671,8 @@ static int unifycr_abtoull(char *str, unsigned long long *val)
             units = 1024 * 1024 * 1024;
             break;
         default:
-            debug("scr_abtoull: Unexpected byte string %s @ %s:%d",
-                  str, __FILE__, __LINE__
-                 );
+            DEBUG("scr_abtoull: Unexpected byte string %s @ %s:%d",
+                  str, __FILE__, __LINE__);
             return UNIFYCR_FAILURE;
         }
 
@@ -1656,18 +1685,16 @@ static int unifycr_abtoull(char *str, unsigned long long *val)
 
         /* check that we've hit the end of the string */
         if (*next != 0) {
-            debug("scr_abtoull: Unexpected byte string: %s @ %s:%d",
-                  str, __FILE__, __LINE__
-                 );
+            DEBUG("scr_abtoull: Unexpected byte string: %s @ %s:%d",
+                  str, __FILE__, __LINE__);
             return UNIFYCR_FAILURE;
         }
     }
 
     /* check that we got a positive value */
     if (num < 0) {
-        debug("scr_abtoull: Byte string must be positive: %s @ %s:%d",
-              str, __FILE__, __LINE__
-             );
+        DEBUG("scr_abtoull: Byte string must be positive: %s @ %s:%d",
+              str, __FILE__, __LINE__);
         return UNIFYCR_FAILURE;
     }
 
@@ -1679,20 +1706,26 @@ static int unifycr_abtoull(char *str, unsigned long long *val)
 
 static int unifycr_init(int rank)
 {
-    if (! unifycr_initialized) {
+    if (!unifycr_initialized) {
+
+        /* unifycr debug level default is zero */
+        unifycr_debug_level = 0;
+
+    if (getenv("UNIFYCR_DEBUG"))
+        unifycr_debug_level = atoi(getenv("UNIFYCR_DEBUG"));
 
 #ifdef UNIFYCR_GOTCHA
         enum gotcha_error_t result;
 
         result = gotcha_wrap(wrap_unifycr_list, GOTCHA_NFUNCS, "unifycr");
         if (result != GOTCHA_SUCCESS) {
-            debug("gotcha_wrap returned %d\n", (int) result);
+            DEBUG("gotcha_wrap returned %d\n", (int) result);
         }
 
         int i;
         for (i = 0; i < GOTCHA_NFUNCS; i++) {
             if (*(void **)(wrap_unifycr_list[i].function_address_pointer) == 0) {
-                printf("This function name failed to be wrapped: %s\n",
+                DEBUG("This function name failed to be wrapped: %s\n",
                        wrap_unifycr_list[i].name);
             }
         }
@@ -1732,7 +1765,7 @@ static int unifycr_init(int rank)
             }
         }
 
-        debug("are we using spillover? %d\n", unifycr_use_spillover);
+        DEBUG("are we using spillover? %d\n", unifycr_use_spillover);
 
         /* determine max number of files to store in file system */
         unifycr_max_files = UNIFYCR_MAX_FILES;
@@ -1803,7 +1836,7 @@ static int unifycr_init(int rank)
         env = getenv("UNIFYCR_NUMA_POLICY");
         if (env) {
             sprintf(unifycr_numa_policy, env);
-            debug("NUMA policy used: %s\n", unifycr_numa_policy);
+            DEBUG("NUMA policy used: %s\n", unifycr_numa_policy);
         } else {
             sprintf(unifycr_numa_policy, "default");
         }
@@ -1836,7 +1869,7 @@ static int unifycr_init(int rank)
         }
         unifycr_fd_limit = r_limit->rlim_cur;
         free(r_limit);
-        debug("FD limit for system = %ld\n", unifycr_fd_limit);
+        DEBUG("FD limit for system = %ld\n", unifycr_fd_limit);
 
         /* determine the size of the superblock */
         /* generous allocation for chunk map (one file can take entire space)*/
@@ -1888,7 +1921,7 @@ static int unifycr_init(int rank)
                              unifycr_mount_shmget_key);
 #endif /* MACHINE_BGQ */
         if (unifycr_superblock == NULL) {
-            debug("unifycr_superblock_shmget() failed\n");
+            DEBUG("unifycr_superblock_shmget() failed\n");
             return UNIFYCR_FAILURE;
         }
         char spillfile_prefix[100];
@@ -1910,7 +1943,7 @@ static int unifycr_init(int rank)
                                      spillfile_prefix);
 
             if (unifycr_spilloverblock < 0) {
-                debug("unifycr_get_spillblock() failed!\n");
+                DEBUG("unifycr_get_spillblock() failed!\n");
                 return UNIFYCR_FAILURE;
             }
         }
@@ -1929,7 +1962,7 @@ static int unifycr_init(int rank)
             unifycr_spillmetablock =
                 unifycr_get_spillblock(unifycr_index_buf_size, spillfile_prefix);
             if (unifycr_spillmetablock < 0) {
-                debug("unifycr_get_spillmetablock failed!\n");
+                DEBUG("unifycr_get_spillmetablock failed!\n");
                 return UNIFYCR_FAILURE;
             }
         }
@@ -1978,241 +2011,76 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
 }
 
 /**
-* unmount the mounted file system, triggered
-* by the root process of an application
-* ToDo: add the support for more operations
-* beyond terminating the servers. E.g.
-* data flush for persistence.
-* @return success/error code
-*/
-int unifycr_unmount()
+ * unmount the mounted file system, triggered
+ * by the root process of an application
+ * ToDo: add the support for more operations
+ * beyond terminating the servers. E.g.
+ * data flush for persistence.
+ * @return success/error code
+ */
+int unifycr_unmount(void)
 {
-    if (fs_type == UNIFYCR_LOG) {
-        int cmd = COMM_UNMOUNT;
-        char cmd_buf[GEN_STR_LEN] = {0};
-        memcpy(cmd_buf, &cmd, sizeof(int));
+    int cmd = COMM_UNMOUNT;
+    char cmd_buf[GEN_STR_LEN] = {0};
+    int bytes_read = 0;
+    int rc;
 
-        int res = __real_write(cmd_fd.fd,
-                               cmd_buf, sizeof(cmd_buf));
-        if (res != 0) {
-            int bytes_read = 0;
-            int rc;
-            cmd_fd.events = POLLIN | POLLPRI;
-            cmd_fd.revents = 0;
-
-            rc = poll(&cmd_fd, 1, -1);
-            if (rc == 0) {
-
-            } else {
-                if (rc > 0) {
-                    if (cmd_fd.revents != 0) {
-                        if (cmd_fd.revents == POLLIN) {
-                            bytes_read = __real_read(cmd_fd.fd, cmd_buf,
-                                                     sizeof(cmd_buf));
-                            if (bytes_read == 0) {
-                                return UNIFYCR_FAILURE;
-                            } else {
-                                if (*((int *)cmd_buf) != COMM_UNMOUNT
-                                    || *((int *)cmd_buf + 1)
-                                    != ACK_SUCCESS) {
-                                    return UNIFYCR_FAILURE;
-                                }
-                                return UNIFYCR_SUCCESS;
-                            }
-                        } else {
-                        }
-                    } else {
-                    }
-                } else {
-
-                }
-            }
-        } else {
-            return UNIFYCR_FAILURE;
-        }
-
-    } else {
+    if (fs_type != UNIFYCR_LOG)
         return UNIFYCR_FAILURE;
-    }
 
-}
+    memcpy(cmd_buf, &cmd, sizeof(int));
 
-/* mount memfs at some prefix location */
-int unifycrfs_mount(const char prefix[], size_t size, int rank)
-{
-    unifycr_mount_prefix = strdup(prefix);
-    unifycr_mount_prefixlen = strlen(unifycr_mount_prefix);
+    rc = __real_write(cmd_fd.fd, cmd_buf, sizeof(cmd_buf));
+    if (rc <= 0)
+        return UNIFYCR_FAILURE;
 
-    /* KMM commented out because we're just using a single rank, so use PRIVATE
-     * downside, can't attach to this in another srun (PRIVATE, that is) */
-    //unifycr_mount_shmget_key = UNIFYCR_SUPERBLOCK_KEY + rank;
+    cmd_fd.events = POLLIN | POLLPRI;
+    cmd_fd.revents = 0;
 
-    char *env = getenv("UNIFYCR_USE_SINGLE_SHM");
-    if (env) {
-        int val = atoi(env);
-        if (val != 0) {
-            unifycr_use_single_shm = 1;
-        }
-    }
+    rc = poll(&cmd_fd, 1, -1);
+    if (rc < 0)
+        return UNIFYCR_FAILURE;
 
-    if (unifycr_use_single_shm) {
-        unifycr_mount_shmget_key = UNIFYCR_SUPERBLOCK_KEY + rank;
-    } else {
-        unifycr_mount_shmget_key = IPC_PRIVATE;
-    }
-
-    if (fs_type == UNIFYCR_LOG || fs_type == UNIFYCR_STRIPE) {
-        int rc = CountTasksPerNode(rank, size);
-        if (rc < 0) {
-            debug("rank:%d, cannot get the local rank list.", dbg_rank);
-            return -1;
-        }
-
-        local_rank_idx = find_rank_idx(rank,
-                                       local_rank_lst, local_rank_cnt);
-
-        /* unifycr_mount_shmget_key marks the start of
-         * the superblock shared memory of each rank
-         * each process has three types of shared memory:
-         * request memory, recv memory and superblock
-         * memory. We set unifycr_mount_shmget_key in
-         * this way to avoid different ranks conflicting
-         * on the same name in shm_open.
-         * */
-        unifycr_mount_shmget_key = local_rank_idx;
-
-    }
-
-    /* initialize our library */
-    unifycr_init(rank);
-
-    if (fs_type == UNIFYCR_LOG || fs_type == UNIFYCR_STRIPE) {
-        char host_name[UNIFYCR_MAX_FILENAME] = {0};
-        int rc = gethostname(host_name, UNIFYCR_MAX_FILENAME);
-        if (rc != 0) {
-            debug("rank:%d, fail to get the host name.", dbg_rank);
+    if (cmd_fd.revents != 0 && cmd_fd.revents == POLLIN) {
+        bytes_read = __real_read(cmd_fd.fd, cmd_buf, sizeof(cmd_buf));
+        if (bytes_read <= 0 ||
+            *((int *)cmd_buf) != COMM_UNMOUNT ||
+            *((int *)cmd_buf + 1) != ACK_SUCCESS)
             return UNIFYCR_FAILURE;
-        }
-
-        /* get the number of collocated delegators*/
-        if (local_rank_idx == 0) {
-            rc = unifycr_init_socket(0, 1, 1);
-            if (rc < 0) {
-                return -1;
-            }
-
-            local_del_cnt = get_del_cnt();
-            if (local_del_cnt > 0) {
-                int i;
-                for (i = 0; i < local_rank_cnt; i++) {
-                    if (local_rank_lst[i] != rank) {
-                        int rc = MPI_Send(&local_del_cnt, 1,
-                                          MPI_INT, local_rank_lst[i], 0, MPI_COMM_WORLD);
-                    }
-                }
-            } else {
-                debug("rank:%d, fail to get the delegator count.", dbg_rank);
-                return -1;
-            }
-
-        } else {
-            MPI_Status status;
-            int rc = MPI_Recv(&local_del_cnt, 1, MPI_INT, local_rank_lst[0],
-                              0, MPI_COMM_WORLD, &status);
-            if (local_del_cnt < 0 || rc < 0) {
-                debug("rank:%d, fail to initialize socket.", dbg_rank);
-                return UNIFYCR_FAILURE;
-                return -1;
-            } else  {
-                int rc = unifycr_init_socket(local_rank_idx,
-                                             local_rank_cnt, local_del_cnt);
-                if (rc < 0) {
-                    debug("rank:%d, fail to initialize socket.", dbg_rank);
-                    return UNIFYCR_FAILURE;
-                    return -1;
-                }
-            }
-        }
-
-        /*connect to server-side delegators*/
-
-        rc = unifycr_init_req_shm(local_rank_idx, app_id);
-        if (rc < 0) {
-            debug("rank:%d, fail to init shared request memory.", dbg_rank);
-            return UNIFYCR_FAILURE;
-        }
-
-        rc = unifycr_init_recv_shm(local_rank_idx, app_id);
-        if (rc < 0) {
-            debug("rank:%d, fail to init shared receive memory.", dbg_rank);
-            return UNIFYCR_FAILURE;
-        }
-
-        rc = unifycr_sync_to_del();
-        if (rc < 0) {
-            debug("rank:%d, fail to convey information to the delegator.", dbg_rank);
-            return UNIFYCR_FAILURE;
-        }
-
-    }
-    /* add mount point as a new directory in the file list */
-    if (unifycr_get_fid_from_path(prefix) >= 0) {
-        /* we can't mount this location, because it already exists */
-        errno = EEXIST;
-        return -1;
-    } else {
-        /* claim an entry in our file list */
-        int fid = unifycr_fid_create_directory(prefix);
-        if (fid < 0) {
-            /* if there was an error, return it */
-            return fid;
-        }
     }
 
-    return 0;
+    return UNIFYCR_SUCCESS;
 }
 
 /**
-* transfer the client-side context information
-* to the corresponding delegator on the
-* server side.
-*/
-static int unifycr_sync_to_del()
+ * Transfer the client-side context information to the corresponding
+ * delegator on the server side.
+ */
+static int unifycr_sync_to_del(void)
 {
-    int rc = -1;
-
     int cmd = COMM_MOUNT;
-
-    int superblock_start = UNIFYCR_SUPERBLOCK_KEY;
     int num_procs_per_node = local_rank_cnt;
     int req_buf_sz = shm_req_size;
     int recv_buf_sz = shm_recv_size;
     long superblock_sz = glb_superblock_size;
-
-    long meta_offset =
-        (void *)unifycr_indices.ptr_num_entries
-        - unifycr_superblock;
-    long meta_size = unifycr_max_index_entries
-                     * sizeof(unifycr_index_t);
-
-    long fmeta_offset =
-        (void *)unifycr_fattrs.ptr_num_entries
-        - unifycr_superblock;
-
-    long fmeta_size = unifycr_max_fattr_entries *
-                      sizeof(unifycr_fattr_t);
-
-    long data_offset =
-        (void *)unifycr_chunks - unifycr_superblock;
+    long meta_offset = (void *)unifycr_indices.ptr_num_entries -
+        unifycr_superblock;
+    long meta_size = unifycr_max_index_entries * sizeof(unifycr_index_t);
+    long fmeta_offset = (void *)unifycr_fattrs.ptr_num_entries -
+        unifycr_superblock;
+    long fmeta_size = unifycr_max_fattr_entries * sizeof(unifycr_fattr_t);
+    long data_offset = (void *)unifycr_chunks - unifycr_superblock;
     long data_size = (long)unifycr_max_chunks * unifycr_chunk_size;
-
     char external_spill_dir[UNIFYCR_MAX_FILENAME] = {0};
+
     strcpy(external_spill_dir, external_data_dir);
 
-    /* copy the client-side information to the command
-     * buffer, and then send to the delegator. The delegator
-     * will attach to the client-side shared memory, and open
-     * the spill log file based on these information*/
+    /*
+     * Copy the client-side information to the command
+     * buffer, then send to the delegator. The delegator
+     * will attach to the client-side shared memory and open
+     * the spill log file based on this information.
+     */
     memcpy(cmd_buf, &cmd, sizeof(int));
     memcpy(cmd_buf + sizeof(int), &app_id, sizeof(int));
     memcpy(cmd_buf + 2 * sizeof(int),
@@ -2240,13 +2108,14 @@ static int unifycr_sync_to_del()
            &data_size, sizeof(long));
 
     memcpy(cmd_buf + 7 * sizeof(int) + 7 * sizeof(long),
-           external_spill_dir, UNIFYCR_MAX_FILENAME); /*adjust to add debug info*/
+           external_spill_dir, UNIFYCR_MAX_FILENAME);
 
     int res = __real_write(client_sockfd,
                            cmd_buf, sizeof(cmd_buf));
     if (res != 0) {
         int bytes_read = 0;
         int rc = -1;
+
         cmd_fd.events = POLLIN | POLLPRI;
         cmd_fd.revents = 0;
 
@@ -2264,8 +2133,8 @@ static int unifycr_sync_to_del()
                             /*remote connection is closed*/
                             return -1;
                         } else {
-                            if (*((int *)cmd_buf) != COMM_MOUNT || *((int *)cmd_buf + 1)
-                                != ACK_SUCCESS) {
+                            if (*((int *)cmd_buf) != COMM_MOUNT ||
+                                *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 /*encounter delegator-side error*/
                                 return rc;
                             } else {
@@ -2297,98 +2166,92 @@ static int unifycr_sync_to_del()
 }
 
 /**
-* Initialize the shared recv memory buffer
-* to receive data from the delegators
-*/
+ * Initialize the shared recv memory buffer to receive data from the delegators
+ */
 static int unifycr_init_recv_shm(int local_rank_idx, int app_id)
 {
+    char *env = getenv("SHM_RECV_SIZE");
+    char shm_name[GEN_STR_LEN] = {0};
     int rc = -1;
 
-    char *env = getenv("SHM_RECV_SIZE");
-    if (env) {
+    if (env)
         shm_recv_size = atol(env);
-    }
 
-    char shm_name[GEN_STR_LEN] = {0};
     sprintf(shm_name, "%d-recv-%d", app_id, local_rank_idx);
 
     recvbuf_fd = shm_open(shm_name, MMAP_OPEN_FLAG, MMAP_OPEN_MODE);
-    if (-1 == (rc = recvbuf_fd)) {
+    rc = recvbuf_fd;
+    if (rc == -1)
         return UNIFYCR_FAILURE;
-    }
 
     rc = ftruncate(recvbuf_fd, shm_recv_size);
-    if (-1 == rc) {
+    if (rc == -1)
         return UNIFYCR_FAILURE;
-    }
 
     shm_recvbuf = mmap(NULL, shm_recv_size, PROT_WRITE | PROT_READ,
                        MAP_SHARED, recvbuf_fd, SEEK_SET);
-    if (NULL == shm_recvbuf) {
+    if (shm_recvbuf == NULL)
         return UNIFYCR_FAILURE;
-    }
 
     *((int *)shm_recvbuf) = app_id + 3;
     return 0;
 }
 
 /**
-* Initialize the shared request memory, which
-* is used to buffer the list of read requests
-* to be transferred to the delegator on the
-* server side.
-* @param local_rank_idx: local process id
-* @param app_id: which application this
-*  process is from
-* @return success/error code
-*/
+ * Initialize the shared request memory, which
+ * is used to buffer the list of read requests
+ * to be transferred to the delegator on the
+ * server side.
+ * @param local_rank_idx: local process id
+ * @param app_id: which application this
+ *  process is from
+ * @return success/error code
+ */
 static int unifycr_init_req_shm(int local_rank_idx, int app_id)
 {
+    char *env = getenv("SHM_REQ_SIZE");
+    char shm_name[GEN_STR_LEN] = {0};
     int rc = -1;
 
     /* initialize request buffer size*/
-    char *env = getenv("SHM_REQ_SIZE");
-    if (env) {
+    if (env)
         shm_req_size = atol(env);
-    }
 
-    char shm_name[GEN_STR_LEN] = {0};
     sprintf(shm_name, "%d-req-%d", app_id, local_rank_idx);
     reqbuf_fd = shm_open(shm_name, MMAP_OPEN_FLAG, MMAP_OPEN_MODE);
-    if (-1 == (rc = reqbuf_fd)) {
+    rc = reqbuf_fd;
+    if (rc == -1)
         return UNIFYCR_FAILURE;
-    }
 
     rc = ftruncate(reqbuf_fd, shm_req_size);
-    if (-1 == rc) {
+    if (rc == -1)
         return UNIFYCR_FAILURE;
-    }
-
 
     shm_reqbuf = mmap(NULL, shm_req_size, PROT_WRITE | PROT_READ,
                       MAP_SHARED, reqbuf_fd, SEEK_SET);
-    if (NULL == shm_reqbuf) {
+    if (shm_reqbuf == NULL)
         return UNIFYCR_FAILURE;
-    }
 
     return 0;
 }
 
 /**
-* get the number of delegators on the
-* same node from the first delegator
-* on the server side
-*/
-static int get_del_cnt()
+ * get the number of delegators on the
+ * same node from the first delegator
+ * on the server side
+ */
+static int get_del_cnt(void)
 {
     int cmd = COMM_SYNC_DEL;
-    memcpy(cmd_buf, &cmd, sizeof(int));
+    int res;
 
-    int res = __real_write(client_sockfd,
-                           cmd_buf, sizeof(cmd_buf));
+    memcpy(cmd_buf, &cmd, sizeof(int));
+    res = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
+
     if (res != 0) {
         int bytes_read = 0;
         int rc = -1;
+
         cmd_fd.events = POLLIN | POLLPRI;
         cmd_fd.revents = 0;
 
@@ -2406,8 +2269,8 @@ static int get_del_cnt()
                             /*remote connection is closed*/
                             return -1;
                         } else {
-                            if (*((int *)cmd_buf) != COMM_SYNC_DEL || *((int *)cmd_buf + 1)
-                                != ACK_SUCCESS) {
+                            if (*((int *)cmd_buf) != COMM_SYNC_DEL ||
+                                *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 /*encounter delegator-side error*/
                                 return rc;
                             } else {
@@ -2432,53 +2295,47 @@ static int get_del_cnt()
         return -1;
     }
 
-
     return *(int *)(cmd_buf + 2 * sizeof(int));
 
 }
 
 /**
-* initialize the client-side socket
-* used to communicate with the server-side
-* delegators. Each client is serviced by
-* one delegator.
-* @param proc_id: local process id
-* @param l_num_procs_per_node: number
-* of ranks on each compute node
-* @param l_num_del_per_node: number of server-side
-* delegators on the same node
-* @return success/error code
-*/
+ * initialize the client-side socket
+ * used to communicate with the server-side
+ * delegators. Each client is serviced by
+ * one delegator.
+ * @param proc_id: local process id
+ * @param l_num_procs_per_node: number
+ * of ranks on each compute node
+ * @param l_num_del_per_node: number of server-side
+ * delegators on the same node
+ * @return success/error code
+ */
 
 static int unifycr_init_socket(int proc_id, int l_num_procs_per_node,
                                int l_num_del_per_node)
 {
-    int rc = -1;
-
+    struct sockaddr_un serv_addr;
+    char tmp_path[GEN_STR_LEN] = {0};
+    int nprocs_per_del;
     int len;
     int result;
+    int flag;
+    int rc = -1;
 
     client_sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (client_sockfd < 0) {
+    if (client_sockfd < 0)
         return -1;
-    }
 
-    struct sockaddr_un serv_addr;
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sun_family = AF_UNIX;
-    char tmp_path[GEN_STR_LEN] = {0};
-
-
-    int nprocs_per_del;
-    if (l_num_procs_per_node % l_num_del_per_node == 0) {
+    if (l_num_procs_per_node % l_num_del_per_node == 0)
         nprocs_per_del = l_num_procs_per_node / l_num_del_per_node;
-    } else {
+    else
         nprocs_per_del = l_num_procs_per_node / l_num_del_per_node + 1;
-    }
 
     /*which delegator I belong to*/
-    sprintf(tmp_path, "%s%d", SOCKET_PATH,
-            proc_id / nprocs_per_del);
+    sprintf(tmp_path, "%s%d", SOCKET_PATH, proc_id / nprocs_per_del);
 
     strcpy(serv_addr.sun_path, tmp_path);
     len = sizeof(serv_addr);
@@ -2490,14 +2347,13 @@ static int unifycr_init_socket(int proc_id, int l_num_procs_per_node,
         return rc;
     }
 
-    int flag = fcntl(client_sockfd, F_GETFL);
+    flag = fcntl(client_sockfd, F_GETFL);
     fcntl(client_sockfd, F_SETFL, flag | O_NONBLOCK);
     cmd_fd.fd = client_sockfd;
     cmd_fd.events = POLLIN | POLLHUP;
     cmd_fd.revents = 0;
 
     return 0;
-
 }
 
 int compare_fattr(const void *a, const void *b)
@@ -2543,62 +2399,57 @@ static int compare_name_rank_pair(const void *a, const void *b)
 }
 
 /**
-* find the local index of a given rank among all ranks
-* collocated on the same node
-* @param local_rank_lst: a list of local ranks
-* @param local_rank_cnt: number of local ranks
-* @return index of rank in local_rank_lst
-*/
-static int find_rank_idx(int rank,
-                         int *local_rank_lst, int local_rank_cnt)
+ * find the local index of a given rank among all ranks
+ * collocated on the same node
+ * @param local_rank_lst: a list of local ranks
+ * @param local_rank_cnt: number of local ranks
+ * @return index of rank in local_rank_lst
+ */
+static int find_rank_idx(int rank, int *local_rank_lst, int local_rank_cnt)
 {
     int i;
+
     for (i = 0; i < local_rank_cnt; i++) {
-        if (local_rank_lst[i] == rank) {
+        if (local_rank_lst[i] == rank)
             return i;
-        }
     }
 
     return -1;
-
 }
 
 
 /**
-* calculate the number of ranks per node,
-*
-* @param numTasks: number of tasks in the application
-* @return success/error code
-* @return local_rank_lst: a list of local ranks
-* @return local_rank_cnt: number of local ranks
-*/
+ * calculate the number of ranks per node,
+ *
+ * @param numTasks: number of tasks in the application
+ * @return success/error code
+ * @return local_rank_lst: a list of local ranks
+ * @return local_rank_cnt: number of local ranks
+ */
 static int CountTasksPerNode(int rank, int numTasks)
 {
-    char       hostname[UNIFYCR_MAX_FILENAME],
-               localhost[UNIFYCR_MAX_FILENAME];
-    int        count               = 1,
-               resultsLen          = 30,
-               i;
-
+    char hostname[UNIFYCR_MAX_FILENAME];
+    char localhost[UNIFYCR_MAX_FILENAME];
+    int resultsLen = 30;
     MPI_Status status;
     int rc;
 
     rc = MPI_Get_processor_name(localhost, &resultsLen);
-    if (rc != 0) {
-        debug("failed to get the processor's name");
-    }
-
-
+    if (rc != 0)
+        DEBUG("failed to get the processor's name");
 
     if (numTasks > 0) {
         if (rank == 0) {
+            int i;
             /* a container of (rank, host) mappings*/
             name_rank_pair_t *host_set =
                 (name_rank_pair_t *)malloc(numTasks
                                            * sizeof(name_rank_pair_t));
-            /* MPI_receive all hostnames, and compare to local hostname */
-            /* ToDo: handle the case when the length of hostname is larger
-             * than 30*/
+            /*
+             * MPI_receive all hostnames, and compare to local hostname
+             * TODO: handle the case when the length of hostname is larger
+             * than 30
+             */
             for (i = 1; i < numTasks; i++) {
                 rc = MPI_Recv(hostname, UNIFYCR_MAX_FILENAME,
                               MPI_CHAR, MPI_ANY_SOURCE,
@@ -2606,7 +2457,7 @@ static int CountTasksPerNode(int rank, int numTasks)
                               &status);
 
                 if (rc != 0) {
-                    debug("cannot receive hostnames");
+                    DEBUG("cannot receive hostnames");
                     return -1;
                 }
                 strcpy(host_set[i].hostname, hostname);
@@ -2619,13 +2470,14 @@ static int CountTasksPerNode(int rank, int numTasks)
             qsort(host_set, numTasks, sizeof(name_rank_pair_t),
                   compare_name_rank_pair);
 
-            /* rank_cnt: records the number of processes on each node
+            /*
+             * rank_cnt: records the number of processes on each node
              * rank_set: the list of ranks for each node
-             * */
+             */
             int **rank_set = (int **)malloc(numTasks * sizeof(int *));
             int *rank_cnt = (int *)malloc(numTasks * sizeof(int));
-
             int cursor = 0, set_counter = 0;
+
             for (i = 1; i < numTasks; i++) {
                 if (strcmp(host_set[i].hostname,
                            host_set[i - 1].hostname) == 0) {
@@ -2633,6 +2485,7 @@ static int CountTasksPerNode(int rank, int numTasks)
                 } else {
                     // find a different rank, so switch to a new set
                     int j, k = 0;
+
                     rank_set[set_counter] =
                         (int *)malloc((i - cursor) * sizeof(int));
                     rank_cnt[set_counter] = i - cursor;
@@ -2648,50 +2501,35 @@ static int CountTasksPerNode(int rank, int numTasks)
 
             }
 
-
-            /*fill rank_cnt and rank_set entry for the last node*/
+            /* fill rank_cnt and rank_set entry for the last node */
             int j = 0;
 
-            rank_set[set_counter] =
-                (int *)malloc((i - cursor) * sizeof(int));
+            rank_set[set_counter] = malloc((i - cursor) * sizeof(int));
             rank_cnt[set_counter] = numTasks - cursor;
-            /*
-            printf("cursor is %d\n", cursor); fflush(stdout);
-            */
             for (i = cursor; i <= numTasks - 1; i++) {
                 rank_set[set_counter][j] = host_set[i].rank;
                 j++;
             }
             set_counter++;
 
-            /*broadcast the rank_cnt and rank_set information to each
-             * rank*/
-            int root_set_no;
+            /* broadcast the rank_cnt and rank_set information to each rank */
+            int root_set_no = -1;
+
             for (i = 0; i < set_counter; i++) {
                 for (j = 0; j < rank_cnt[i]; j++) {
                     if (rank_set[i][j] != 0) {
-                        /*
-                        printf("i is %d, j is %d\n", i, j); fflush(stdout);
-                        printf("rank:%d, 1sending to %d, rank_cnt[%d] is %d\n", rank,
-                                rank_set[i][j], i, rank_cnt[i]); fflush(stdout);
-                                */
-                        rc = MPI_Send(&rank_cnt[i], 1,
-                                      MPI_INT, rank_set[i][j], 0, MPI_COMM_WORLD);
+                        rc = MPI_Send(&rank_cnt[i], 1, MPI_INT, rank_set[i][j],
+                                      0, MPI_COMM_WORLD);
                         if (rc != 0) {
-                            debug("cannot send local rank cnt");
+                            DEBUG("cannot send local rank cnt");
                             return -1;
                         }
 
-
-
                         /*send the local rank set to the corresponding rank*/
-                        rc = MPI_Send(rank_set[i], rank_cnt[i],
-                                      MPI_INT, rank_set[i][j], 0, MPI_COMM_WORLD);
-                        /*
-                        printf("rank:%d, 2sending to %d, rank_cnt[%d] is %d\n", rank,
-                                rank_set[i][j], i, rank_cnt[i]); fflush(stdout);*/
+                        rc = MPI_Send(rank_set[i], rank_cnt[i], MPI_INT,
+                                      rank_set[i][j], 0, MPI_COMM_WORLD);
                         if (rc != 0) {
-                            debug("cannot send local rank list");
+                            DEBUG("cannot send local rank list");
                             return -1;
                         }
                     } else {
@@ -2702,33 +2540,35 @@ static int CountTasksPerNode(int rank, int numTasks)
 
 
             /* root process set its own local rank set and rank_cnt*/
-            local_rank_lst = (int *)malloc(rank_cnt[root_set_no] * sizeof(int));
-            for (i = 0; i < rank_cnt[root_set_no]; i++) {
-                local_rank_lst[i] = rank_set[root_set_no][i];
-            }
-            local_rank_cnt = rank_cnt[root_set_no];
+            if (root_set_no >= 0) {
+                local_rank_lst = malloc(rank_cnt[root_set_no] * sizeof(int));
+                for (i = 0; i < rank_cnt[root_set_no]; i++)
+                    local_rank_lst[i] = rank_set[root_set_no][i];
 
-            for (i = 0; i < set_counter; i++) {
-                free(rank_set[i]);
+                local_rank_cnt = rank_cnt[root_set_no];
             }
+
+            for (i = 0; i < set_counter; i++)
+                free(rank_set[i]);
+
             free(rank_cnt);
             free(host_set);
             free(rank_set);
-
         } else {
-            /* non-root process performs MPI_send to send
-             * hostname to root node */
+            /*
+             * non-root process performs MPI_send to send hostname to root node
+             */
             rc = MPI_Send(localhost, UNIFYCR_MAX_FILENAME,
                           MPI_CHAR, 0, 0, MPI_COMM_WORLD);
             if (rc != 0) {
-                debug("cannot send host name");
+                DEBUG("cannot send host name");
                 return -1;
             }
             /*receive the local rank count */
             rc = MPI_Recv(&local_rank_cnt, 1, MPI_INT, 0,
                           0, MPI_COMM_WORLD, &status);
             if (rc != 0) {
-                debug("cannot receive local rank cnt");
+                DEBUG("cannot receive local rank cnt");
                 return -1;
             }
 
@@ -2738,7 +2578,7 @@ static int CountTasksPerNode(int rank, int numTasks)
                           0, MPI_COMM_WORLD, &status);
             if (rc != 0) {
                 free(local_rank_lst);
-                debug("cannot receive local rank list");
+                DEBUG("cannot receive local rank list");
                 return -1;
             }
 
@@ -2749,15 +2589,163 @@ static int CountTasksPerNode(int rank, int numTasks)
 
         // scatter ranks out
     } else {
-        debug("number of tasks is smaller than 0");
+        DEBUG("number of tasks is smaller than 0");
         return -1;
     }
 
     return 0;
 }
 
-/* get information about the chunk data region
- * for external async libraries to register during their init */
+
+/* mount memfs at some prefix location */
+int unifycrfs_mount(const char prefix[], size_t size, int rank)
+{
+    char *env = getenv("UNIFYCR_USE_SINGLE_SHM");
+
+    unifycr_mount_prefix = strdup(prefix);
+    unifycr_mount_prefixlen = strlen(unifycr_mount_prefix);
+
+    if (env) {
+        int val = atoi(env);
+
+        if (val != 0)
+            unifycr_use_single_shm = 1;
+    }
+
+    if (unifycr_use_single_shm)
+        unifycr_mount_shmget_key = UNIFYCR_SUPERBLOCK_KEY + rank;
+    else
+        unifycr_mount_shmget_key = IPC_PRIVATE;
+
+    if (fs_type == UNIFYCR_LOG || fs_type == UNIFYCR_STRIPE) {
+        int rc = CountTasksPerNode(rank, size);
+
+        if (rc < 0) {
+            DEBUG("rank:%d, cannot get the local rank list.", dbg_rank);
+            return -1;
+        }
+
+        local_rank_idx = find_rank_idx(rank,
+                                       local_rank_lst, local_rank_cnt);
+
+        /*
+         * unifycr_mount_shmget_key marks the start of
+         * the superblock shared memory of each rank
+         * each process has three types of shared memory:
+         * request memory, recv memory and superblock
+         * memory. We set unifycr_mount_shmget_key in
+         * this way to avoid different ranks conflicting
+         * on the same name in shm_open.
+         */
+        unifycr_mount_shmget_key = local_rank_idx;
+
+    }
+
+    /* initialize our library */
+    unifycr_init(rank);
+
+    if (fs_type == UNIFYCR_LOG || fs_type == UNIFYCR_STRIPE) {
+        char host_name[UNIFYCR_MAX_FILENAME] = {0};
+        int rc = gethostname(host_name, UNIFYCR_MAX_FILENAME);
+
+        if (rc != 0) {
+            DEBUG("rank:%d, fail to get the host name.", dbg_rank);
+            return UNIFYCR_FAILURE;
+        }
+
+        /* get the number of collocated delegators*/
+        if (local_rank_idx == 0) {
+            rc = unifycr_init_socket(0, 1, 1);
+            if (rc < 0)
+                return -1;
+
+            local_del_cnt = get_del_cnt();
+            if (local_del_cnt > 0) {
+                int i;
+
+                for (i = 0; i < local_rank_cnt; i++) {
+                    if (local_rank_lst[i] != rank) {
+                        int rc = MPI_Send(&local_del_cnt, 1, MPI_INT,
+                                          local_rank_lst[i], 0,
+                                          MPI_COMM_WORLD);
+                        if (rc != MPI_SUCCESS) {
+                            DEBUG("rank:%d, MPI_Send failed", dbg_rank);
+                            return UNIFYCR_FAILURE;
+                        }
+
+                    }
+                }
+            } else {
+                DEBUG("rank:%d, fail to get the delegator count.", dbg_rank);
+                return UNIFYCR_FAILURE;
+            }
+
+        } else {
+            MPI_Status status;
+            int rc = MPI_Recv(&local_del_cnt, 1, MPI_INT, local_rank_lst[0],
+                              0, MPI_COMM_WORLD, &status);
+
+            if (rc != MPI_SUCCESS) {
+                DEBUG("rank:%d, MPI_Recv failed.", dbg_rank);
+                return UNIFYCR_FAILURE;
+            }
+            if (local_del_cnt < 0 || rc < 0) {
+                DEBUG("rank:%d, fail to initialize socket.", dbg_rank);
+                return UNIFYCR_FAILURE;
+            } else  {
+                int rc = unifycr_init_socket(local_rank_idx,
+                                             local_rank_cnt, local_del_cnt);
+                if (rc < 0) {
+                    DEBUG("rank:%d, fail to initialize socket.", dbg_rank);
+                    return UNIFYCR_FAILURE;
+                }
+            }
+        }
+
+        /*connect to server-side delegators*/
+
+        rc = unifycr_init_req_shm(local_rank_idx, app_id);
+        if (rc < 0) {
+            DEBUG("rank:%d, fail to init shared request memory.", dbg_rank);
+            return UNIFYCR_FAILURE;
+        }
+
+        rc = unifycr_init_recv_shm(local_rank_idx, app_id);
+        if (rc < 0) {
+            DEBUG("rank:%d, fail to init shared receive memory.", dbg_rank);
+            return UNIFYCR_FAILURE;
+        }
+
+        rc = unifycr_sync_to_del();
+        if (rc < 0) {
+            DEBUG("rank:%d, fail to convey information to the delegator.",
+                  dbg_rank);
+            return UNIFYCR_FAILURE;
+        }
+
+    }
+    /* add mount point as a new directory in the file list */
+    if (unifycr_get_fid_from_path(prefix) >= 0) {
+        /* we can't mount this location, because it already exists */
+        errno = EEXIST;
+        return -1;
+    } else {
+        /* claim an entry in our file list */
+        int fid = unifycr_fid_create_directory(prefix);
+
+        if (fid < 0) {
+            /* if there was an error, return it */
+            return fid;
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * get information about the chunk data region for external async libraries
+ * to register during their init
+ */
 size_t unifycr_get_data_region(void **ptr)
 {
     *ptr = unifycr_chunks;
@@ -2770,8 +2758,10 @@ chunk_list_t *unifycr_get_chunk_list(char *path)
     return NULL;
 }
 
-/* debug function to print list of chunks constituting a file
- * and to test above function*/
+/*
+ * debug function to print list of chunks constituting a file and to test
+ * above function
+ */
 void unifycr_print_chunk_list(char *path)
 {
 }


### PR DESCRIPTION
The client was printing debug information about gotcha wrappers by
default.

        - update unifycr-defs so it defaults to not printing debug info
        - update unifycr-internal so that debug function prints file and
          line info
        - change unifycr.c to use debug function instead of printf

