### PR TITLE
fix debug output in client

### DIFF
--- a/client/src/unifycr-defs.h
+++ b/client/src/unifycr-defs.h
@@ -1,8 +1,15 @@
+/* holds debug level for unifycr, this defaults to zero
+ * in unifycr_init, but can be changed at runtime by setting
+ * the UNIFYCR_DEBUG env variable to a value greater than 1
+ */
+extern int unifycr_debug_level;
+
 #define UNIFYCR_MAX_FILES        ( 128 )
 
 /* eventually could decouple these so there could be
  * more or less file descriptors than files, but for
- * now they're the same */
+ * now they're the same
+ */
 #define UNIFYCR_MAX_FILEDESCS    ( UNIFYCR_MAX_FILES )
 
 #define UNIFYCR_MAX_FILENAME     ( 128 )

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -111,7 +111,7 @@ static inline void *unifycr_compute_chunk_buf(
         start = unifycr_chunks + ((long)physical_id << unifycr_chunk_bits);
     } else {
         /* chunk is in spill over */
-        debug("wrong chunk ID\n");
+        DEBUG("wrong chunk ID\n");
         return NULL;
     }
 
@@ -135,7 +135,7 @@ static inline off_t unifycr_compute_spill_offset(
     /* compute start of chunk in spill over device */
     off_t start = 0;
     if (physical_id < unifycr_max_chunks) {
-        debug("wrong spill-chunk ID\n");
+        DEBUG("wrong spill-chunk ID\n");
         return -1;
     } else {
         /* compute buffer loc within spillover device chunk */
@@ -167,14 +167,14 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
         } else if (unifycr_use_spillover) {
             /* shm segment out of space, grab a block from spill-over device */
 
-            debug("getting blocks from spill-over device\n");
+            DEBUG("getting blocks from spill-over device\n");
             /* TODO: missing lock calls? */
             /* add unifycr_max_chunks to identify chunk location */
             unifycr_stack_lock();
             id = unifycr_stack_pop(free_spillchunk_stack) + unifycr_max_chunks;
             unifycr_stack_unlock();
             if (id < unifycr_max_chunks) {
-                debug("spill-over device out of space (%d)\n", id);
+                DEBUG("spill-over device out of space (%d)\n", id);
                 return UNIFYCR_ERR_NOSPC;
             }
 
@@ -183,14 +183,14 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
             chunk_meta->id = id;
         } else {
             /* spill over isn't available, so we're out of space */
-            debug("memfs out of space (%d)\n", id);
+            DEBUG("memfs out of space (%d)\n", id);
             return UNIFYCR_ERR_NOSPC;
         }
     } else if (unifycr_use_spillover) {
         /* memory file system is not enabled, but spill over is */
 
         /* shm segment out of space, grab a block from spill-over device */
-        debug("getting blocks from spill-over device \n");
+        DEBUG("getting blocks from spill-over device\n");
 
         /* TODO: missing lock calls? */
         /* add unifycr_max_chunks to identify chunk location */
@@ -198,7 +198,7 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t *meta, int chunk_id)
         int id = unifycr_stack_pop(free_spillchunk_stack) + unifycr_max_chunks;
         unifycr_stack_unlock();
         if (id < unifycr_max_chunks) {
-            debug("spill-over device out of space (%d)\n", id);
+            DEBUG("spill-over device out of space (%d)\n", id);
             return UNIFYCR_ERR_NOSPC;
         }
 
@@ -221,7 +221,7 @@ static int unifycr_chunk_free(int fid, unifycr_filemeta_t *meta, int chunk_id)
 
     /* get physical id of chunk */
     int id = chunk_meta->id;
-    debug("free chunk %d from location %d\n", id, chunk_meta->location);
+    DEBUG("free chunk %d from location %d\n", id, chunk_meta->location);
 
     /* determine location of chunk */
     if (chunk_meta->location == CHUNK_LOCATION_MEMFS) {
@@ -232,7 +232,7 @@ static int unifycr_chunk_free(int fid, unifycr_filemeta_t *meta, int chunk_id)
         /* TODO: free spill over chunk */
     } else {
         /* unkwown chunk location */
-        debug("unknown chunk location %d\n", chunk_meta->location);
+        DEBUG("unknown chunk location %d\n", chunk_meta->location);
         return UNIFYCR_ERR_IO;
     }
 
@@ -268,7 +268,7 @@ static int unifycr_chunk_read(
             return unifycr_errno_map_to_err(rc);
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -510,7 +510,7 @@ static int unifycr_logio_chunk_write(
         /* TOdo: check return code for errors */
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -549,7 +549,7 @@ static int unifycr_chunk_write(
         /* TODO: check return code for errors */
     } else {
         /* unknown chunk type */
-        debug("unknown chunk type in read\n");
+        DEBUG("unknown chunk type in read\n");
         return UNIFYCR_ERR_IO;
     }
 
@@ -579,7 +579,7 @@ int unifycr_fid_store_fixed_extend(int fid, unifycr_filemeta_t *meta,
             /* allocate a new chunk */
             int rc = unifycr_chunk_alloc(fid, meta, meta->chunks);
             if (rc != UNIFYCR_SUCCESS) {
-                debug("failed to allocate chunk\n");
+                DEBUG("failed to allocate chunk\n");
                 return UNIFYCR_ERR_NOSPC;
             }
 

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -71,12 +71,12 @@
 
 /* TODO: move common includes to another file */
 #include "unifycr-defs.h"
-
-#ifdef UNIFYCR_DEBUG
-#define debug(fmt, args... )  printf("%s: "fmt, __func__, ##args)
-#else
-#define debug(fmt, args... )
-#endif
+#define DEBUG(fmt, ...) \
+do { \
+    if (unifycr_debug_level > 0) \
+        printf("unifycr: %s:%d: %s: " fmt "\n", \
+               __FILE__, __LINE__, __func__, ## __VA_ARGS__); \
+} while (0)
 
 /* define a macro to capture function name, file name, and line number
  * along with user-defined string */


### PR DESCRIPTION
This PR was updated to branch off of the current HEAD of the dev branch. 

Update how debug levels are set, and use DEBUG macro to print gotcha debug
info instead of printf

        - define unifycr_debug_level for all files to use in client
        - update unifycr-internal so that DEBUG function prints file and
          line info
        - get UNIFYCR_DEBUG env variable in unifycr_init and set debug
          level
        - change unifycr.c to use DEBUG function instead of printf
        - change all debug calls to DEBUG since it is a macro

Turn UNIFYCR_DEBUG on/off or change level by setting DEBUG environment
variable.
  