### PR TITLE
Add missing / when constructing paths

### DIFF
--- a/meta/src/indexes.c
+++ b/meta/src/indexes.c
@@ -592,17 +592,20 @@ int open_db_store(struct mdhim_t *md, struct index_t *index) {
 
 	//Database filename is dependent on ranges.  This needs to be configurable and take a prefix
 	if (!md->db_opts->db_paths) {
-		sprintf(filename, "%s%s-%d-%d", md->db_opts->db_path, md->db_opts->db_name, 
-			index->id, md->mdhim_rank);
+		sprintf(filename, "%s/%s-%d-%d", md->db_opts->db_path,
+			md->db_opts->db_name, index->id, md->mdhim_rank);
 	} else {
 		path_num = index->myinfo.rangesrv_num/((double) index->num_rangesrvs/(double) md->db_opts->num_paths);
 		path_num = path_num >= md->db_opts->num_paths ? md->db_opts->num_paths - 1 : path_num;
 		if (path_num < 0) {
-			sprintf(filename, "%s%s-%d-%d", md->db_opts->db_path, md->db_opts->db_name, index->id, 
-				md->mdhim_rank);
+			sprintf(filename, "%s/%s-%d-%d", md->db_opts->db_path,
+				md->db_opts->db_name,
+				index->id, md->mdhim_rank);
 		} else {
-			sprintf(filename, "%s%s-%d-%d", md->db_opts->db_paths[path_num], 
-				md->db_opts->db_name, index->id, md->mdhim_rank);
+			sprintf(filename, "%s/%s-%d-%d",
+				md->db_opts->db_paths[path_num],
+				md->db_opts->db_name, index->id,
+				md->mdhim_rank);
 		}
 	}
 

--- a/meta/tests/single_tests/bput-bget.c
+++ b/meta/tests/single_tests/bput-bget.c
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
 
 	char *manifest_path;
 	manifest_path = malloc(path_len);
-	sprintf(manifest_path, "%s%s", db_opts->db_path, "manifest");
+	sprintf(manifest_path, "%s/%s", db_opts->db_path, "manifest");
 	db_opts->manifest_path = manifest_path;
 	db_opts->db_name = db_name;
 	db_opts->db_type = LEVELDB;

--- a/meta/tests/single_tests/range_bget.c
+++ b/meta/tests/single_tests/range_bget.c
@@ -147,7 +147,7 @@ int main(int argc, char **argv) {
 
 	char *manifest_path;
 	manifest_path = malloc(path_len);
-	sprintf(manifest_path, "%s%s", db_opts->db_path, MANIFEST_FILE_NAME);
+	sprintf(manifest_path, "%s/%s", db_opts->db_path, MANIFEST_FILE_NAME);
 	db_opts->manifest_path = manifest_path;
 	db_opts->db_name = db_name;
 	db_opts->db_type = LEVELDB;

--- a/meta/tests/single_tests/range_test.c
+++ b/meta/tests/single_tests/range_test.c
@@ -139,7 +139,7 @@ int main(int argc, char **argv) {
 
 	char *manifest_path;
 	manifest_path = malloc(path_len);
-	sprintf(manifest_path, "%s%s", db_opts->db_path, MANIFEST_FILE_NAME);
+	sprintf(manifest_path, "%s/%s", db_opts->db_path, MANIFEST_FILE_NAME);
 	db_opts->manifest_path = manifest_path;
 	db_opts->db_name = db_name;
 	db_opts->db_type = LEVELDB;

--- a/server/src/unifycr_metadata.c
+++ b/server/src/unifycr_metadata.c
@@ -115,7 +115,7 @@ int meta_init_store()
         return -1;
     }
 
-    sprintf(manifest_path, "%s%s", db_opts->db_path, MANIFEST_FILE_NAME);
+    sprintf(manifest_path, "%s/%s", db_opts->db_path, MANIFEST_FILE_NAME);
     db_opts->manifest_path = manifest_path;
 
     env = getenv("UNIFYCR_META_DB_NAME");
@@ -610,16 +610,16 @@ int meta_sanitize()
     char dbfilename1[GEN_STR_LEN] = {0};
     char statfilename1[GEN_STR_LEN] = {0};
     char manifestname1[GEN_STR_LEN] = {0};
-    sprintf(dbfilename, "%s%s-%d-%d", md->db_opts->db_path, md->db_opts->db_name,
-            unifycr_indexes[0]->id, md->mdhim_rank);
+    sprintf(dbfilename, "%s/%s-%d-%d", md->db_opts->db_path,
+            md->db_opts->db_name, unifycr_indexes[0]->id, md->mdhim_rank);
 
     sprintf(statfilename, "%s_stats", dbfilename);
     sprintf(manifestname, "%s%d_%d_%d", md->db_opts->manifest_path,
             unifycr_indexes[0]->type,
             unifycr_indexes[0]->id, md->mdhim_rank);
 
-    sprintf(dbfilename1, "%s%s-%d-%d", md->db_opts->db_path, md->db_opts->db_name,
-            unifycr_indexes[1]->id, md->mdhim_rank);
+    sprintf(dbfilename1, "%s/%s-%d-%d", md->db_opts->db_path,
+            md->db_opts->db_name, unifycr_indexes[1]->id, md->mdhim_rank);
 
     sprintf(statfilename1, "%s_stats", dbfilename1);
     sprintf(manifestname1, "%s%d_%d_%d", md->db_opts->manifest_path,


### PR DESCRIPTION
Include a / between path elements when constructing paths to database
files. This fixes a problem where the database file paths would be
incorrect when the metadata path was set using the UNIFYCR_META_DB_PATH
environment variable if the value did not have a trailing slash.