### PR TITLE
fix the use spillover default

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1756,14 +1756,14 @@ static int unifycr_init(int rank)
         unifycr_min_long = LONG_MIN;
 
         /* will we use spillover to store the files? */
-        unifycr_use_spillover = 0;
+        unifycr_use_spillover = 1;
 
         env = getenv("UNIFYCR_USE_SPILLOVER");
         if (env) {
             int val = atoi(env);
-            if (val != 0) {
-                unifycr_use_spillover = 1;
-            }
+            if (val != 1)
+                unifycr_use_spillover = 0;
+
         }
 
         DEBUG("are we using spillover? %d\n", unifycr_use_spillover);

--- a/docs/start-stop.rst
+++ b/docs/start-stop.rst
@@ -37,7 +37,6 @@ Next, we can start run our application with UnifyCR in the following manner:
 
         #!/bin/bash
 
-        export UNIFYCR_USE_SPILLOVER=1
         APP_PATH=/path/to/my/app
 
         NODES=1


### PR DESCRIPTION
UNIFYCR_USE_SPILLOVER should default to being turned on.

I also removed the UNIFYCR_USE_SPILLOVER from the docs file that was setting it in an example script.
