### PR TITLE
fix hard coding of external meta and data dirs

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -235,9 +235,6 @@ enum flock_enum {
 #define FILE_STORAGE_FIXED_CHUNK 1
 #define FILE_STORAGE_LOGIO       2
 
-#define EXTERNAL_DATA_DIR "/l/ssd"
-#define EXTERNAL_META_DIR "/l/ssd"
-
 /* TODO: make this an enum */
 #define CHUNK_LOCATION_NULL      0
 #define CHUNK_LOCATION_MEMFS     1

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1931,7 +1931,9 @@ static int unifycr_init(int rank)
         if (env) {
             strcpy(external_data_dir, env);
         } else {
-            strcpy(external_data_dir, EXTERNAL_DATA_DIR);
+            DEBUG("UNIFYCR_EXTERNAL_DATA_DIR not set to an existing writable"
+                  " path (i.e UNIFYCR_EXTERNAL_DATA_DIR=/mnt/ssd):\n");
+            return UNIFYCR_FAILURE;
         }
 
         sprintf(spillfile_prefix, "%s/spill_%d_%d.log",
@@ -1953,7 +1955,9 @@ static int unifycr_init(int rank)
         if (env) {
             strcpy(external_meta_dir, env);
         } else {
-            strcpy(external_meta_dir, EXTERNAL_META_DIR);
+            DEBUG("UNIFYCR_EXTERNAL_META_DIR not set to an existing writable"
+                  " path (i.e UNIFYCR_EXTERNAL_META_DIR=/mnt/ssd):\n");
+            return UNIFYCR_FAILURE;
         }
 
         /*ToDo: add the spillover feature for the index metadata*/
@@ -2643,7 +2647,10 @@ int unifycrfs_mount(const char prefix[], size_t size, int rank)
     }
 
     /* initialize our library */
-    unifycr_init(rank);
+    int ret = unifycr_init(rank);
+
+    if (ret != UNIFYCR_SUCCESS)
+        return ret;
 
     if (fs_type == UNIFYCR_LOG || fs_type == UNIFYCR_STRIPE) {
         char host_name[UNIFYCR_MAX_FILENAME] = {0};

--- a/client/tests/test_read.c
+++ b/client/tests/test_read.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <aio.h>
 #include <strings.h>
+#include <errno.h>
 
 #define GEN_STR_LEN 1024
 
@@ -73,8 +74,12 @@ int main(int argc, char *argv[]) {
     struct aiocb **cb_list = (struct aiocb **)malloc (num_reqs * \
       sizeof (struct aiocb *)); /*list of read requests in lio_listio*/
 
-	unifycr_mount("/tmp", rank, rank_num,\
-	  		1, 1);
+    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 1, 1);
+
+    if (mnt_success != 0 && rank == 0) {
+        printf("unifycr mount call failed\n");
+        exit(EIO);
+    }
 
 	if (pat == 1) {
 		sprintf(tmpfname, "%s%d", fname, rank);

--- a/client/tests/test_write.c
+++ b/client/tests/test_write.c
@@ -47,6 +47,7 @@
 #include <string.h>
 #include <mpi.h>
 #include <sys/time.h>
+#include <errno.h>
 
 #define GEN_STR_LEN 1024
 
@@ -97,7 +98,12 @@ int main(int argc, char *argv[]) {
 		  }
 		}
 
-	unifycr_mount("/tmp", rank, rank_num, 0, 1);
+    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 0, 1);
+
+    if (mnt_success != 0 && rank == 0) {
+        printf("unifycr_mount call failed\n");
+        exit(EIO);
+    }
 
 	char *buf = malloc (tran_sz);
 	if (buf == NULL)


### PR DESCRIPTION
The external data and meta directories should be set based on the
path to the external SSD's on that system. The path was using a
default (/l/ssd/), which only exists on a particular cluster.

   - The client now fails when the external meta and data directory
     are not set

   - To run the client successfully the UNIFYCR_EXTERNAL_META_DIR
     and the UNIFYCR_EXTERNAL_DATA_DIR need to be set to valid paths