### PR TITLE
fix wrong return code of fsync from Teng Wang

### DIFF
--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -1561,8 +1561,8 @@ int UNIFYCR_WRAP(fsync)(int fd)
                                 return -1;
                             } else {
                                 /**/
-                                if (ack_msg[0] != COMM_META ||
-                                    ack_msg[1] != ACK_SUCCESS) {
+                                if (*((int *)cmd_buf) != COMM_META ||
+                                    *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                     return -1;
                                 } else {
 


### PR DESCRIPTION
Trying to get UnifyCR up to date with Teng's bug fixes in burstfs here: https://github.com/LLNL/burstfs/commit/2edb8ad73f8c95659a89130cada6da82cc69d3ca

