### PR TITLE
fix non-sequential arraylist insertion

### DIFF
--- a/server/src/arraylist.c
+++ b/server/src/arraylist.c
@@ -93,7 +93,10 @@ int arraylist_insert(arraylist_t *arr, int pos, void *elem)
         free(arr->elems[pos]);
     }
     arr->elems[pos] = elem;
-    arr->size = pos + 1;
+
+    if (pos + 1 > arr->size)
+        arr->size = pos + 1;
+
     return 0;
 
 }

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -396,6 +396,8 @@ int rm_process_received_msg(int app_id, int sock_id,
     recv_msg_t *tmp_recv_msg =
         (recv_msg_t *)(recv_msg_buf + sizeof(int));
 
+    recv_cursor += sizeof(int);
+
     shm_meta_t *tmp_sh_msg;
     ptr_size =
         (int *)app_config->shm_recv_bufs[client_id];
@@ -439,7 +441,7 @@ int rm_process_received_msg(int app_id, int sock_id,
 
         memcpy(2 * sizeof(int)
                + app_config->shm_recv_bufs[client_id] + *ptr_size,
-               (void *)tmp_recv_msg,
+               recv_msg_buf + recv_cursor,
                tmp_recv_msg->length + sizeof(recv_msg_t));
 
         *ptr_tot_sz -= tmp_recv_msg->length;


### PR DESCRIPTION
This handles the case when the insertion to the arraylist does not
follow the sequential order.

This patch is from burstfs here:
https://github.com/LLNL/burstfs/commit/46dd467


