### PR TITLE
update build docs

### DIFF
--- a/docs/build-intercept.rst
+++ b/docs/build-intercept.rst
@@ -50,11 +50,36 @@ Then to build UnifyCR:
 For users who cannot use Spack, you may fetch the latest release of
 `GOTCHA <https://github.com/LLNL/GOTCHA>`_
 
-Then to build with UnifyCR:
+And leveldb (if not already installed on your system):
+`leveldb https://github.com/google/leveldb/releases/tag/v1.20`_
+
+If you installed leveldb from source then you may have to add the pkgconfig file
+for leveldb manually. This is assuming your install of leveldb does not contain
+a .pc file (it usually doesn't). Then, add the path to that file to
+PKG_CONFIG_PATH.
 
 .. code-block:: Bash
 
-    $ ./configure --prefix=/path/to/install --with-gotcha=/path/to/gotcha --enable-debug
+    $ cat leveldb.pc
+    #leveldb.pc
+    prefix=/path/to/leveldb/install
+    exec_prefix=/path/to/leveldb/install
+    libdir=/path/to/leveldb/install/lib64
+    includedir=/path/to/leveldb/install/include
+    Name: leveldb
+    Description: a fast key-value storage library
+    Version: 1.20
+    Cflags: -I${includedir}
+    Libs: -L${libdir} -lleveldb
+
+    $ export PKG_CONFIG_PATH=/path/to/leveldb/pkgconfig
+
+Leave out the path to leveldb in your configure line if you didn't install it
+from source.
+
+.. code-block:: Bash
+
+    $ ./configure --prefix=/path/to/install --with-gotcha=/path/to/gotcha --enable-debug --with-leveldb=/path/to/leveldb
     $ make
     $ make install
 


### PR DESCRIPTION
An example of a leveldb pkgconfig file was added to the 'building without
spack' section of the documentation. The change in the configure line was
also documented. This problem arises when someone uses a leveldb build
from source and is not using spack to build their dependencies.
