### PR TITLE
unifycr command line tool and sysconf file implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ log
 
 # project files
 server/src/unifycrd
+util/unifycr/src/unifycr
 
 # generated package files
 client/unifycr-config

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = meta server client t
+SUBDIRS = meta server client extras t util
 
 CONFIG = ordered
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AM_SILENT_RULES([yes])
 AM_MAINTAINER_MODE([disable])
 
 AC_PROG_CC([mpicc])
+AC_PROG_CC_STDC
 AC_PROG_AWK
 AC_PROG_CPP
 AC_PROG_INSTALL
@@ -268,6 +269,11 @@ eval unifycr_bin_path=$bindir
 prefix=$savePrefix
 exec_prefix=$saveExecprefix
 
+# autoconf<=2.69, runstatedir is not configurable.
+if test "x$runstatedir" = x; then
+        AC_SUBST([runstatedir], ['${localstatedir}/run'])
+fi
+
 CFLAGS="$old_cflags"
 LIBS="$old_libs"
 
@@ -288,9 +294,13 @@ AC_CONFIG_FILES([Makefile
                  client/Makefile
                  client/src/Makefile
                  client/tests/Makefile
+                 client/unifycr.pc
+                 extras/Makefile
                  t/Makefile
                  t/lib/Makefile
-                 client/unifycr.pc])
+                 util/Makefile
+                 util/unifycr/Makefile
+                 util/unifycr/src/Makefile])
 
 UNIFYCR_VERSION=${PACKAGE_VERSION}
 AC_SUBST(UNIFYCR_VERSION)

--- a/extras/Makefile.am
+++ b/extras/Makefile.am
@@ -1,0 +1,6 @@
+confdir = $(sysconfdir)/unifycr
+
+conf_DATA = unifycr.conf unifycr.conf.example
+
+EXTRA_DIST = unifycr.conf unifycr.conf.example
+

--- a/extras/unifycr.conf
+++ b/extras/unifycr.conf
@@ -1,0 +1,13 @@
+# unifycr.conf
+#
+#
+
+[global]
+# by default this value is PREFIX/var/run/unifycr
+runstatedir = "/tmp/unifycr"
+
+# file system behavior
+[filesystem]
+mountpoint = "/mnt/unifycr"
+consistency = "laminated"
+

--- a/extras/unifycr.conf.example
+++ b/extras/unifycr.conf.example
@@ -1,0 +1,8 @@
+# unifycr.conf
+#
+
+# file system behavior
+[filesystem]
+mountpoint = "/mnt/unifycr"
+consistency = "laminated"
+

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -23,6 +23,8 @@ checkpatch_ignore+=",CONST_STRUCT"      # Don't nag about const structs
 checkpatch_ignore+=",SPLIT_STRING"      # Allow long strings to be split
 checkpatch_ignore+=",ARRAY_SIZE"        # Don't require use of ARRAY_SIZE macro
 checkpatch_ignore+=",USE_NEGATIVE_ERRNO" # We don't return negative errnos
+checkpatch_ignore+=",NEW_TYPEDEFS"
+checkpatch_ignore+=",ENOSYS"
 
 checkpatch_cmd+=" --ignore $checkpatch_ignore"
 

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = unifycr

--- a/util/unifycr/Makefile.am
+++ b/util/unifycr/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src

--- a/util/unifycr/src/Makefile.am
+++ b/util/unifycr/src/Makefile.am
@@ -1,0 +1,23 @@
+bin_PROGRAMS = unifycr
+
+unifycr_SOURCES = unifycr.c \
+                  unifycr-cons.c \
+                  unifycr-env.c \
+                  unifycr-rm.c \
+                  unifycr-sysconf.c \
+                  unifycr-runstate.c \
+                  toml.c
+
+noinst_HEADERS = unifycr.h toml.h
+
+#unifycr_LDADD =
+
+AM_CPPFLAGS = -DCONFDIR=\"$(sysconfdir)/unifycr\" \
+              -DBINDIR=\"$(bindir)\" \
+              -DSBINDIR=\"$(sbindir)\" \
+              -DRUNDIR=\"$(runstatedir)/unifycr\"
+
+AM_CFLAGS = -Wall
+
+CLEANFILES = $(bin_PROGRAMS)
+

--- a/util/unifycr/src/toml.c
+++ b/util/unifycr/src/toml.c
@@ -1,0 +1,1903 @@
+/*
+MIT License
+
+Copyright (c) 2017 CK Tan 
+https://github.com/cktan/tomlc99
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#define _POSIX_C_SOURCE 200809L
+#include <stdio.h>
+#include <setjmp.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <ctype.h>
+#include <string.h>
+#include "toml.h"
+
+#ifdef _WIN32
+char* strndup(const char* s, size_t n)
+{
+    size_t len = strnlen(s, n);
+    char* p = malloc(len+1);
+    if (p) {
+	memcpy(p, s, len);
+	p[len] = 0;
+    }
+    return p;
+}
+#endif
+
+
+/**
+ * Convert a char in utf8 into UCS, and store it in *ret.
+ * Return #bytes consumed or -1 on failure.
+ */
+int toml_utf8_to_ucs(const char* orig, int len, int64_t* ret)
+{
+    const unsigned char* buf = (const unsigned char*) orig;
+    unsigned i = *buf++;
+    int64_t v;
+    
+    /* 0x00000000 - 0x0000007F:
+       0xxxxxxx
+    */
+    if (0 == (i >> 7)) {
+	if (len < 1) return -1;
+	v = i;
+	return *ret = v, 1;
+    }
+    /* 0x00000080 - 0x000007FF:
+       110xxxxx 10xxxxxx
+    */
+    if (0x6 == (i >> 5)) {
+	if (len < 2) return -1;
+	v = i & 0x1f;
+	i = *(++buf);
+	if (0x2 != (i >> 6)) return -1;
+	v = (v << 6) | (i & 0x3f);
+	return *ret = v, (const char*) buf - orig;
+    }
+
+    /* 0x00000800 - 0x0000FFFF:
+       1110xxxx 10xxxxxx 10xxxxxx
+    */
+    if (0xE == (i >> 4)) {
+	if (len < 3) return -1;
+	v = i & 0x0F;
+	for (int j = 0; j < 2; j++) {
+	    i = *(++buf);
+	    if (0x2 != (i >> 6)) return -1;
+	    v = (v << 6) | (i & 0x3f);
+	}
+	return *ret = v, (const char*) buf - orig;
+    }
+
+    /* 0x00010000 - 0x001FFFFF:
+       11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (0x1E == (i >> 3)) {
+	if (len < 4) return -1;
+	v = i & 0x07;
+	for (int j = 0; j < 3; j++) {
+	    i = *(++buf);
+	    if (0x2 != (i >> 6)) return -1;
+	    v = (v << 6) | (i & 0x3f);
+	}
+	return *ret = v, (const char*) buf - orig;
+    }
+    
+    /* 0x00200000 - 0x03FFFFFF:
+       111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (0x3E == (i >> 2)) {
+	if (len < 5) return -1;
+	v = i & 0x03;
+	for (int j = 0; j < 4; j++) {
+	    i = *(++buf);
+	    if (0x2 != (i >> 6)) return -1;
+	    v = (v << 6) | (i & 0x3f);
+	}
+	return *ret = v, (const char*) buf - orig;
+    }
+
+    /* 0x04000000 - 0x7FFFFFFF:
+       1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (0x7e == (i >> 1)) {
+	if (len < 6) return -1;
+	v = i & 0x01;
+	for (int j = 0; j < 5; j++) {
+	    i = *(++buf);
+	    if (0x2 != (i >> 6)) return -1;
+	    v = (v << 6) | (i & 0x3f);
+	}
+	return *ret = v, (const char*) buf - orig;
+    }
+    return -1;
+}
+
+
+/**
+ *  Convert a UCS char to utf8 code, and return it in buf.
+ *  Return #bytes used in buf to encode the char, or 
+ *  -1 on error.
+ */
+int toml_ucs_to_utf8(int64_t code, char buf[6])
+{
+    /* http://stackoverflow.com/questions/6240055/manually-converting-unicode-codepoints-into-utf-8-and-utf-16 */
+    /* The UCS code values 0xd800–0xdfff (UTF-16 surrogates) as well
+     * as 0xfffe and 0xffff (UCS noncharacters) should not appear in
+     * conforming UTF-8 streams.
+     */
+    if (0xd800 <= code && code <= 0xdfff) return -1;
+    if (0xfffe <= code && code <= 0xffff) return -1;
+
+    /* 0x00000000 - 0x0000007F:
+       0xxxxxxx
+    */
+    if (code < 0) return -1;
+    if (code <= 0x7F) {
+	buf[0] = (unsigned char) code;
+	return 1;
+    }
+
+    /* 0x00000080 - 0x000007FF:
+       110xxxxx 10xxxxxx
+    */
+    if (code <= 0x000007FF) {
+	buf[0] = 0xc0 | (code >> 6);
+	buf[1] = 0x80 | (code & 0x3f);
+	return 2;
+    }
+
+    /* 0x00000800 - 0x0000FFFF:
+       1110xxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x0000FFFF) {
+	buf[0] = 0xe0 | (code >> 12);
+	buf[1] = 0x80 | ((code >> 6) & 0x3f);
+	buf[2] = 0x80 | (code & 0x3f);
+	return 3;
+    }
+
+    /* 0x00010000 - 0x001FFFFF:
+       11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x001FFFFF) {
+	buf[0] = 0xf0 | (code >> 18);
+	buf[1] = 0x80 | ((code >> 12) & 0x3f);
+	buf[2] = 0x80 | ((code >> 6) & 0x3f);
+	buf[3] = 0x80 | (code & 0x3f);
+	return 4;
+    }
+
+    /* 0x00200000 - 0x03FFFFFF:
+       111110xx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x03FFFFFF) {
+	buf[0] = 0xf8 | (code >> 24);
+	buf[1] = 0x80 | ((code >> 18) & 0x3f);
+	buf[2] = 0x80 | ((code >> 12) & 0x3f);
+	buf[3] = 0x80 | ((code >> 6) & 0x3f);
+	buf[4] = 0x80 | (code & 0x3f);
+	return 5;
+    }
+    
+    /* 0x04000000 - 0x7FFFFFFF:
+       1111110x 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx 10xxxxxx
+    */
+    if (code <= 0x7FFFFFFF) {
+	buf[0] = 0xfc | (code >> 30);
+	buf[1] = 0x80 | ((code >> 24) & 0x3f);
+	buf[2] = 0x80 | ((code >> 18) & 0x3f);
+	buf[3] = 0x80 | ((code >> 12) & 0x3f);
+	buf[4] = 0x80 | ((code >> 6) & 0x3f);
+	buf[5] = 0x80 | (code & 0x3f);
+	return 6;
+    }
+
+    return -1;
+}
+
+/*
+ *  TOML has 3 data structures: value, array, table. 
+ *  Each of them can have identification key.
+ */
+typedef struct toml_keyval_t toml_keyval_t;
+struct toml_keyval_t {
+    const char* key;		/* key to this value */
+    const char* val;		/* the raw value */
+};
+
+
+struct toml_array_t {
+    const char* key;		/* key to this array */
+    int kind; /* element kind: 'v'alue, 'a'rray, or 't'able */
+    int type; /* for value kind: 'i'nt, 'd'ouble, 'b'ool, 's'tring, 't'ime, 'D'ate, 'T'imestamp */
+    
+    int nelem;			/* number of elements */
+    union {
+	char** val;
+	toml_array_t** arr;
+	toml_table_t** tab;
+    } u;
+};
+    
+
+struct toml_table_t {
+    const char* key;		/* key to this table */
+    int implicit;		/* table was created implicitly */
+
+    /* key-values in the table */
+    int             nkval;
+    toml_keyval_t** kval;
+
+    /* arrays in the table */
+    int            narr;
+    toml_array_t** arr;
+
+    /* tables in the table */
+    int            ntab;
+    toml_table_t** tab;
+};
+
+
+static inline void xfree(const void* x) { if (x) free((void*)x); }
+
+
+enum tokentype_t {
+    INVALID,
+    DOT,
+    COMMA,
+    EQUAL,
+    LBRACE,
+    RBRACE,
+    NEWLINE,
+    LBRACKET,
+    RBRACKET,
+    STRING,
+};
+typedef enum tokentype_t tokentype_t;
+
+typedef struct token_t token_t;
+struct token_t {
+    tokentype_t tok;
+    int         lineno;
+    char*       ptr;
+    int         len;
+    int         eof;
+};
+
+
+typedef struct context_t context_t;
+struct context_t {
+    char* start;
+    char* stop;
+    char* errbuf;
+    int   errbufsz;
+    jmp_buf jmp;
+
+    token_t tok;
+    toml_table_t* root;
+    toml_table_t* curtab;
+
+    struct {
+	int     top;
+	char*   key[10];
+	token_t tok[10];
+    } tpath;
+
+};
+
+#define STRINGIFY(x) #x
+#define TOSTRING(x)  STRINGIFY(x)
+#define FLINE __FILE__ ":" TOSTRING(__LINE__)
+
+static tokentype_t next_token(context_t* ctx, int dotisspecial);
+
+/* error routines. All these functions longjmp to ctx->jmp */
+static int e_outofmemory(context_t* ctx, const char* fline)
+{
+    snprintf(ctx->errbuf, ctx->errbufsz, "ERROR: out of memory (%s)", fline);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+
+
+static int e_internal_error(context_t* ctx, const char* fline)
+{
+    snprintf(ctx->errbuf, ctx->errbufsz, "internal error (%s)", fline);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+
+static int e_syntax_error(context_t* ctx, int lineno, const char* msg)
+{
+    snprintf(ctx->errbuf, ctx->errbufsz, "line %d: %s", lineno, msg);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+
+static int e_bad_key_error(context_t* ctx, int lineno)
+{
+    snprintf(ctx->errbuf, ctx->errbufsz, "line %d: bad key", lineno);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+
+/*
+static int e_noimpl(context_t* ctx, const char* feature)
+{
+    snprintf(ctx->errbuf, ctx->errbufsz, "not implemented: %s", feature);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+*/
+
+static int e_key_exists_error(context_t* ctx, token_t keytok)
+{
+    char buf[100];
+    int i;
+    for (i = 0; i < keytok.len && i < (int)sizeof(buf) - 1; i++) {
+	buf[i] = keytok.ptr[i];
+    }
+    buf[i] = 0;
+
+    snprintf(ctx->errbuf, ctx->errbufsz,
+	     "line %d: key %s exists", keytok.lineno, buf);
+    longjmp(ctx->jmp, 1);
+    return -1;
+}
+
+
+
+/* 
+ * Convert src to raw unescaped utf-8 string.
+ * Returns NULL if error with errmsg in errbuf.
+ */
+static char* normalize_string(const char* src, int srclen,
+			      int kill_line_ending_backslash,
+			      char* errbuf, int errbufsz)
+{
+    char* dst = 0;		/* will write to dst[] and return it */
+    int   max = 0;		/* max size of dst[] */
+    int   off = 0;		/* cur offset in dst[] */
+    const char* sp = src;
+    const char* sq = src + srclen;
+    int ch;
+
+    /* scan forward on src */
+    for (;;) {
+	if (off >=  max - 10) { /* have some slack for misc stuff */
+	    char* x = realloc(dst, max += 100);
+	    if (!x) {
+		xfree(dst);
+		snprintf(errbuf, errbufsz, "out of memory");
+		return 0;
+	    }
+	    dst = x;
+	}
+	
+	/* finished? */
+	if (sp >= sq) break; 
+	
+	ch = *sp++;
+	if (ch != '\\') {
+	    // a plain copy suffice
+	    dst[off++] = ch;
+	    continue;
+	}
+
+	/* ch was backslash. we expect the escape char. */
+	if (sp >= sq) {
+	    snprintf(errbuf, errbufsz, "last backslash is invalid");
+	    free(dst);
+	    return 0;
+	}
+
+	/* if we want to kill line-ending-backslash ... */
+	if (kill_line_ending_backslash) {
+	    /* if this is a newline immediately following the backslash ... */
+	    if (*sp == '\n' || (*sp == '\r' && sp[1] == '\n')) {
+		/* skip all the following whitespaces */
+		sp += strspn(sp, " \t\r\n");
+		continue;
+	    }
+	}
+
+	/* get the escaped char */
+	ch = *sp++;
+	switch (ch) {
+	case 'u': case 'U':
+	    {
+		int64_t ucs = 0;
+		int nhex = (ch == 'u' ? 4 : 8);
+		for (int i = 0; i < nhex; i++) {
+		    if (sp >= sq) {
+			snprintf(errbuf, errbufsz, "\\%c expects %d hex chars", ch, nhex);
+			free(dst);
+			return 0;
+		    }
+		    ch = *sp++;
+		    int v = ('0' <= ch && ch <= '9')
+			? ch - '0'
+			: (('A' <= ch && ch <= 'F') ? ch - 'A' + 10 : -1);
+		    if (-1 == v) {
+			snprintf(errbuf, errbufsz, "invalid hex chars for \\u or \\U");
+			free(dst);
+			return 0;
+		    }
+		    ucs = ucs * 16 + v;
+		}
+		int n = toml_ucs_to_utf8(ucs, &dst[off]);
+		if (-1 == n) {
+		    snprintf(errbuf, errbufsz, "illegal ucs code in \\u or \\U");
+		    free(dst);
+		    return 0;
+		}
+		off += n;
+	    }
+	    continue;
+
+	case 'b': ch = '\b'; break;
+	case 't': ch = '\t'; break;
+	case 'n': ch = '\n'; break;
+	case 'f': ch = '\f'; break;
+	case 'r': ch = '\r'; break;
+	case '"':  ch = '"'; break;
+	case '\\': ch = '\\'; break;
+	default: 
+	    snprintf(errbuf, errbufsz, "illegal escape char \\%c", ch);
+	    free(dst);
+	    return 0;
+	}
+
+	dst[off++] = ch;
+    }
+
+    // Cap with NUL and return it.
+    dst[off++] = 0; 
+    return dst;
+}
+
+
+/* Normalize a key. Convert all special chars to raw unescaped utf-8 chars. */
+static char* normalize_key(context_t* ctx, token_t strtok)
+{
+    const char* sp = strtok.ptr;
+    const char* sq = strtok.ptr + strtok.len;
+    int lineno = strtok.lineno;
+    char* ret;
+    int ch = *sp;
+    char ebuf[80];
+
+    /* handle quoted string */
+    if (ch == '\'' || ch == '\"') {
+	/* if ''' or """, take 3 chars off front and back. Else, take 1 char off. */
+	if (sp[1] == ch && sp[2] == ch) 
+	    sp += 3, sq -= 3;
+	else
+	    sp++, sq--;
+
+	if (ch == '\'') {
+	    /* for single quote, take it verbatim. */
+	    if (! (ret = strndup(sp, sq - sp))) {
+                e_outofmemory(ctx, FLINE);
+                return 0;       /* not reached */
+            }
+	} else {
+	    /* for double quote, we need to normalize */
+	    ret = normalize_string(sp, sq - sp, 0, ebuf, sizeof(ebuf));
+	    if (!ret) {
+		snprintf(ctx->errbuf, ctx->errbufsz, "line %d: %s", lineno, ebuf);
+		longjmp(ctx->jmp, 1);
+	    }
+	}
+
+	/* newlines are not allowed in keys */
+	if (strchr(ret, '\n')) {
+	    free(ret);
+	    e_bad_key_error(ctx, lineno);
+            return 0;           /* not reached */
+	}
+	return ret;
+    }
+	
+    /* for bare-key allow only this regex: [A-Za-z0-9_-]+ */
+    const char* xp;
+    for (xp = sp; xp != sq; xp++) {
+	int k = *xp;
+	if (isalnum(k)) continue;
+	if (k == '_' || k == '-') continue;
+	e_bad_key_error(ctx, lineno);
+        return 0;               /* not reached */
+    }
+
+    /* dup and return it */
+    if (! (ret = strndup(sp, sq - sp))) {
+        e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    return ret;
+}
+
+
+/* 
+ * Look up key in tab. Return 0 if not found, or
+ * 'v'alue, 'a'rray or 't'able depending on the element.
+ */
+static int check_key(toml_table_t* tab, const char* key,
+		     toml_keyval_t** ret_val,
+		     toml_array_t** ret_arr,
+		     toml_table_t** ret_tab)
+{
+    int i;
+    void* dummy;
+
+    if (!ret_tab) ret_tab = (toml_table_t**) &dummy;
+    if (!ret_arr) ret_arr = (toml_array_t**) &dummy;
+    if (!ret_val) ret_val = (toml_keyval_t**) &dummy;
+
+    *ret_tab = 0; *ret_arr = 0; *ret_val = 0;
+    
+    for (i = 0; i < tab->nkval; i++) {
+	if (0 == strcmp(key, tab->kval[i]->key)) {
+	    *ret_val = tab->kval[i];
+	    return 'v';
+	}
+    }
+    for (i = 0; i < tab->narr; i++) {
+	if (0 == strcmp(key, tab->arr[i]->key)) {
+	    *ret_arr = tab->arr[i];
+	    return 'a';
+	}
+    }
+    for (i = 0; i < tab->ntab; i++) {
+	if (0 == strcmp(key, tab->tab[i]->key)) {
+	    *ret_tab = tab->tab[i];
+	    return 't';
+	}
+    }
+    return 0;
+}
+
+/* Create a keyval in the table. 
+ */
+static toml_keyval_t* create_keyval_in_table(context_t* ctx, toml_table_t* tab, token_t keytok)
+{
+    /* first, normalize the key to be used for lookup. 
+     * remember to free it if we error out. 
+     */
+    char* newkey = normalize_key(ctx, keytok);
+
+    /* if key exists: error out. */
+    toml_keyval_t* dest = 0;
+    if (check_key(tab, newkey, 0, 0, 0)) {
+	free(newkey);
+	e_key_exists_error(ctx, keytok);
+        return 0;               /* not reached */
+    }
+
+    /* make a new entry */
+    int n = tab->nkval;
+    toml_keyval_t** base;
+    if (0 == (base = (toml_keyval_t**) realloc(tab->kval, (n+1) * sizeof(*base)))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    tab->kval = base;
+    
+    if (0 == (base[n] = (toml_keyval_t*) calloc(1, sizeof(*base[n])))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    dest = tab->kval[tab->nkval++];
+
+    /* save the key in the new value struct */
+    dest->key = newkey;
+    return dest;
+}
+
+
+/* Create a table in the table.
+ */
+static toml_table_t* create_keytable_in_table(context_t* ctx, toml_table_t* tab, token_t keytok)
+{
+    /* first, normalize the key to be used for lookup. 
+     * remember to free it if we error out. 
+     */
+    char* newkey = normalize_key(ctx, keytok);
+
+    /* if key exists: error out */
+    toml_table_t* dest = 0;
+    if (check_key(tab, newkey, 0, 0, &dest)) {
+	free(newkey);		/* don't need this anymore */
+	
+	/* special case: if table exists, but was created implicitly ... */
+	if (dest && dest->implicit) {
+	    /* we make it explicit now, and simply return it. */
+	    dest->implicit = 0;
+	    return dest;
+	}
+	e_key_exists_error(ctx, keytok);
+        return 0;               /* not reached */
+    }
+
+    /* create a new table entry */
+    int n = tab->ntab;
+    toml_table_t** base;
+    if (0 == (base = (toml_table_t**) realloc(tab->tab, (n+1) * sizeof(*base)))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    tab->tab = base;
+	
+    if (0 == (base[n] = (toml_table_t*) calloc(1, sizeof(*base[n])))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    dest = tab->tab[tab->ntab++];
+    
+    /* save the key in the new table struct */
+    dest->key = newkey;
+    return dest;
+}
+
+
+/* Create an array in the table.
+ */
+static toml_array_t* create_keyarray_in_table(context_t* ctx,
+					      toml_table_t* tab,
+					      token_t keytok,
+					      int skip_if_exist)
+{
+    /* first, normalize the key to be used for lookup. 
+     * remember to free it if we error out. 
+     */
+    char* newkey = normalize_key(ctx, keytok);
+    
+    /* if key exists: error out */
+    toml_array_t* dest = 0;
+    if (check_key(tab, newkey, 0, &dest, 0)) {
+	free(newkey); 		/* don't need this anymore */
+
+	/* special case skip if exists? */
+	if (skip_if_exist) return dest;
+	
+	e_key_exists_error(ctx, keytok);
+        return 0;               /* not reached */
+    }
+
+    /* make a new array entry */
+    int n = tab->narr;
+    toml_array_t** base;
+    if (0 == (base = (toml_array_t**) realloc(tab->arr, (n+1) * sizeof(*base)))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    tab->arr = base;
+	
+    if (0 == (base[n] = (toml_array_t*) calloc(1, sizeof(*base[n])))) {
+	free(newkey);
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    dest = tab->arr[tab->narr++];
+
+    /* save the key in the new array struct */
+    dest->key = newkey;
+    return dest;
+}
+
+/* Create an array in an array 
+ */
+static toml_array_t* create_array_in_array(context_t* ctx,
+					   toml_array_t* parent)
+{
+    int n = parent->nelem;
+    toml_array_t** base;
+    if (0 == (base = (toml_array_t**) realloc(parent->u.arr, (n+1) * sizeof(*base)))) {
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    parent->u.arr = base;
+    
+    if (0 == (base[n] = (toml_array_t*) calloc(1, sizeof(*base[n])))) {
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+
+    return parent->u.arr[parent->nelem++];
+}
+
+/* Create a table in an array 
+ */
+static toml_table_t* create_table_in_array(context_t* ctx,
+					   toml_array_t* parent)
+{
+    int n = parent->nelem;
+    toml_table_t** base;
+    if (0 == (base = (toml_table_t**) realloc(parent->u.tab, (n+1) * sizeof(*base)))) {
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+    parent->u.tab = base;
+    
+    if (0 == (base[n] = (toml_table_t*) calloc(1, sizeof(*base[n])))) {
+	e_outofmemory(ctx, FLINE);
+        return 0;               /* not reached */
+    }
+
+    return parent->u.tab[parent->nelem++];
+}
+
+
+#define SKIP_NEWLINES(ctx)  while (ctx->tok.tok == NEWLINE) next_token(ctx, 0)
+#define EAT_TOKEN(ctx, typ) \
+    if ((ctx)->tok.tok != typ) e_internal_error(ctx, FLINE); else next_token(ctx, 0)
+
+
+static void parse_keyval(context_t* ctx, toml_table_t* tab);
+
+
+/* We are at '{ ... }'.
+ * Parse the table.
+ */
+static void parse_table(context_t* ctx, toml_table_t* tab)
+{
+    EAT_TOKEN(ctx, LBRACE);
+
+    for (;;) {
+	SKIP_NEWLINES(ctx);
+
+	/* until } */
+	if (ctx->tok.tok == RBRACE) break;
+
+	if (ctx->tok.tok != STRING) {
+            e_syntax_error(ctx, ctx->tok.lineno, "syntax error");
+            return;             /* not reached */
+	}
+        parse_keyval(ctx, tab);
+	SKIP_NEWLINES(ctx);
+
+	/* on comma, continue to scan for next keyval */
+	if (ctx->tok.tok == COMMA) {
+	    EAT_TOKEN(ctx, COMMA);
+	    continue;
+	}
+	break;
+    }
+
+    if (ctx->tok.tok != RBRACE) {
+	e_syntax_error(ctx, ctx->tok.lineno, "syntax error");
+        return;                 /* not reached */
+    }
+
+    EAT_TOKEN(ctx, RBRACE);
+}
+
+static int valtype(const char* val)
+{
+    toml_timestamp_t ts;
+    if (*val == '\'' || *val == '"') return 's';
+    if (0 == toml_rtob(val, 0)) return 'b';
+    if (0 == toml_rtoi(val, 0)) return 'i';
+    if (0 == toml_rtod(val, 0)) return 'd';
+    if (0 == toml_rtots(val, &ts)) {
+	if (ts.year && ts.hour) return 'T'; /* timestamp */
+	if (ts.year) return 'D'; /* date */
+	return 't'; /* time */
+    }
+    return 'u'; /* unknown */
+}
+
+
+/* We are at '[...]' */
+static void parse_array(context_t* ctx, toml_array_t* arr)
+{
+    EAT_TOKEN(ctx, LBRACKET);
+
+    for (;;) {
+	SKIP_NEWLINES(ctx);
+	
+	/* until ] */
+	if (ctx->tok.tok == RBRACKET) break;
+
+	switch (ctx->tok.tok) {
+	case STRING:
+	    {
+		char* val = ctx->tok.ptr;
+		int   vlen = ctx->tok.len;
+
+		/* set array kind if this will be the first entry */
+		if (arr->kind == 0) arr->kind = 'v';
+		/* check array kind */
+		if (arr->kind != 'v') {
+		    e_syntax_error(ctx, ctx->tok.lineno,
+                                   "a string array can only contain strings");
+                    return;     /* not reached */
+		}
+
+		/* make a new value in array */
+		char** tmp = (char**) realloc(arr->u.val, (arr->nelem+1) * sizeof(*tmp));
+		if (!tmp) {
+                    e_outofmemory(ctx, FLINE);
+                    return;     /* not reached */
+                }
+		arr->u.val = tmp;
+		if (! (val = strndup(val, vlen))) {
+                    e_outofmemory(ctx, FLINE);
+                    return;     /* not reached */
+                }
+		arr->u.val[arr->nelem++] = val;
+
+		/* set array type if this is the first entry, or check that the types matched. */
+		if (arr->nelem == 1) 
+		    arr->type = valtype(arr->u.val[0]);
+		else if (arr->type != valtype(val)) {
+		    e_syntax_error(ctx, ctx->tok.lineno, "array type mismatch");
+                    return;     /* not reached */
+                }
+
+		EAT_TOKEN(ctx, STRING);
+		break;
+	    }
+
+	case LBRACKET:
+	    { /* [ [array], [array] ... ] */
+		/* set the array kind if this will be the first entry */
+		if (arr->kind == 0) arr->kind = 'a';
+		/* check array kind */
+		if (arr->kind != 'a') {
+		    e_syntax_error(ctx, ctx->tok.lineno, "array type mismatch");
+                    return;     /* not reached */
+		}
+		parse_array(ctx, create_array_in_array(ctx, arr));
+		break;
+	    }
+
+	case LBRACE:
+	    { /* [ {table}, {table} ... ] */
+		/* set the array kind if this will be the first entry */
+		if (arr->kind == 0) arr->kind = 't';
+		/* check array kind */
+		if (arr->kind != 't') {
+		    e_syntax_error(ctx, ctx->tok.lineno, "array type mismatch");
+                    return;     /* not reached */
+		}
+		parse_table(ctx, create_table_in_array(ctx, arr));
+		break;
+	    }
+	    
+	default:
+	    e_syntax_error(ctx, ctx->tok.lineno, "syntax error");
+            return;             /* not reached */
+	}
+
+	SKIP_NEWLINES(ctx);
+
+	/* on comma, continue to scan for next element */
+	if (ctx->tok.tok == COMMA) {
+	    EAT_TOKEN(ctx, COMMA);
+	    continue;
+	}
+	break;
+    }
+
+    if (ctx->tok.tok != RBRACKET) {
+	e_syntax_error(ctx, ctx->tok.lineno, "syntax error");
+        return;                 /* not reached */
+    }
+
+    EAT_TOKEN(ctx, RBRACKET);
+}
+
+
+
+/* handle lines like these:
+    key = "value"
+    key = [ array ]
+    key = { table }
+*/
+static void parse_keyval(context_t* ctx, toml_table_t* tab)
+{
+    if (ctx->tok.tok != STRING) {
+	e_internal_error(ctx, FLINE);
+        return;                 /* not reached */
+    }
+
+    token_t key = ctx->tok;
+
+    EAT_TOKEN(ctx, STRING);
+    if (ctx->tok.tok != EQUAL) {
+	e_syntax_error(ctx, ctx->tok.lineno, "missing =");
+        return;                 /* not reached */
+    }
+
+    EAT_TOKEN(ctx, EQUAL);
+
+    switch (ctx->tok.tok) {
+    case STRING:
+	{ /* key = "value" */
+	    toml_keyval_t* keyval = create_keyval_in_table(ctx, tab, key);
+	    token_t val = ctx->tok;
+	    assert(keyval->val == 0);
+	    keyval->val = strndup(val.ptr, val.len);
+	    if (! keyval->val) {
+                e_outofmemory(ctx, FLINE);
+                return;         /* not reached */
+            }
+
+	    EAT_TOKEN(ctx, STRING);
+	    
+	    return;
+	}
+
+    case LBRACKET:
+	{ /* key = [ array ] */
+	    toml_array_t* arr = create_keyarray_in_table(ctx, tab, key, 0);
+	    parse_array(ctx, arr);
+	    return;
+	}
+
+    case LBRACE:
+	{ /* key = { table } */
+	    toml_table_t* nxttab = create_keytable_in_table(ctx, tab, key);
+	    parse_table(ctx, nxttab);
+	    return;
+	}
+
+    default:
+	e_syntax_error(ctx, ctx->tok.lineno, "syntax error");
+        return;                 /* not reached */
+    }
+}
+
+
+typedef struct tabpath_t tabpath_t;
+struct tabpath_t {
+    int     cnt;
+    token_t key[10];
+};
+
+/* at [x.y.z] or [[x.y.z]]
+ * Scan forward and fill tabpath until it enters ] or ]]
+ * There will be at least one entry on return.
+ */
+static void fill_tabpath(context_t* ctx)
+{
+    int lineno = ctx->tok.lineno;
+    int i;
+    
+    /* clear tpath */
+    for (i = 0; i < ctx->tpath.top; i++) {
+	char** p = &ctx->tpath.key[i];
+	xfree(*p);
+	*p = 0;
+    }
+    ctx->tpath.top = 0;
+    
+    for (;;) {
+	if (ctx->tpath.top >= 10) {
+	    e_syntax_error(ctx, lineno, "table path is too deep; max allowed is 10.");
+            return;             /* not reached */
+        }
+
+	if (ctx->tok.tok != STRING) {
+	    e_syntax_error(ctx, lineno, "invalid or missing key");
+            return;             /* not reached */
+        }
+
+	ctx->tpath.tok[ctx->tpath.top] = ctx->tok;
+	ctx->tpath.key[ctx->tpath.top] = normalize_key(ctx, ctx->tok);
+	ctx->tpath.top++;
+	
+	next_token(ctx, 1);
+
+	if (ctx->tok.tok == RBRACKET) break;
+
+	if (ctx->tok.tok != DOT) {
+	    e_syntax_error(ctx, lineno, "invalid key");
+            return;             /* not reached */
+        }
+
+	next_token(ctx, 1);
+    }
+
+    if (ctx->tpath.top <= 0) {
+	e_syntax_error(ctx, lineno, "empty table selector");
+        return;                 /* not reached */
+    }
+}
+
+
+/* Walk tabpath from the root, and create new tables on the way.
+ * Sets ctx->curtab to the final table.
+ */
+static void walk_tabpath(context_t* ctx)
+{
+    /* start from root */
+    toml_table_t* curtab = ctx->root;
+    
+    for (int i = 0; i < ctx->tpath.top; i++) {
+	const char* key = ctx->tpath.key[i];
+
+	toml_keyval_t* nextval = 0;
+	toml_array_t* nextarr = 0;
+	toml_table_t* nexttab = 0;
+	switch (check_key(curtab, key, &nextval, &nextarr, &nexttab)) {
+	case 't':
+	    /* found a table. nexttab is where we will go next. */
+	    break;
+
+	case 'a':
+	    /* found an array. nexttab is the last table in the array. */
+	    if (nextarr->kind != 't') {
+                e_internal_error(ctx, FLINE);
+                return;         /* not reached */
+            }
+	    if (nextarr->nelem == 0) {
+                e_internal_error(ctx, FLINE);
+                return;         /* not reached */
+            }
+	    nexttab = nextarr->u.tab[nextarr->nelem-1];
+	    break;
+
+	case 'v':
+	    e_key_exists_error(ctx, ctx->tpath.tok[i]);
+            return;             /* not reached */
+
+	default:
+	    { /* Not found. Let's create an implicit table. */
+		int n = curtab->ntab;
+		toml_table_t** base = (toml_table_t**) realloc(curtab->tab, (n+1) * sizeof(*base));
+		if (0 == base) {
+                    e_outofmemory(ctx, FLINE);
+                    return;     /* not reached */
+                }
+		curtab->tab = base;
+		
+		if (0 == (base[n] = (toml_table_t*) calloc(1, sizeof(*base[n])))) {
+		    e_outofmemory(ctx, FLINE);
+                    return;     /* not reached */
+                }
+		
+		if (0 == (base[n]->key = strdup(key))) {
+		    e_outofmemory(ctx, FLINE);
+                    return;     /* not reached */
+                }
+		
+		nexttab = curtab->tab[curtab->ntab++];
+		
+		/* tabs created by walk_tabpath are considered implicit */
+		nexttab->implicit = 1;
+	    }
+	    break;
+	}
+
+	/* switch to next tab */
+	curtab = nexttab;
+    }
+
+    /* save it */
+    ctx->curtab = curtab;
+}
+
+    
+/* handle lines like [x.y.z] or [[x.y.z]] */
+static void parse_select(context_t* ctx)
+{
+    int count_lbracket = 0;
+    if (ctx->tok.tok != LBRACKET) {
+        e_internal_error(ctx, FLINE);
+        return;                 /* not reached */
+    }
+    count_lbracket++;
+    next_token(ctx, 1 /* DOT IS SPECIAL */);
+    if (ctx->tok.tok == LBRACKET) {
+	count_lbracket++;
+	next_token(ctx, 1 /* DOT IS SPECIAL */);
+    }
+
+    fill_tabpath(ctx);
+
+    /* For [x.y.z] or [[x.y.z]], remove z from tpath. 
+     */
+    token_t z = ctx->tpath.tok[ctx->tpath.top-1];
+    free(ctx->tpath.key[ctx->tpath.top-1]);
+    ctx->tpath.top--;
+    
+    walk_tabpath(ctx);
+
+    if (count_lbracket == 1) {
+	/* [x.y.z] -> create z = {} in x.y */
+	ctx->curtab = create_keytable_in_table(ctx, ctx->curtab, z);
+    } else {
+	/* [[x.y.z]] -> create z = [] in x.y */
+	toml_array_t* arr = create_keyarray_in_table(ctx, ctx->curtab, z,
+						     1 /*skip_if_exist*/);
+        if (!arr) {
+            e_syntax_error(ctx, z.lineno, "key exists");
+            return;
+        }
+	if (arr->kind == 0) arr->kind = 't';
+	if (arr->kind != 't') {
+            e_syntax_error(ctx, z.lineno, "array mismatch");
+            return;             /* not reached */
+        }
+
+	/* add to z[] */
+	toml_table_t* dest;
+	{
+	    int n = arr->nelem;
+	    toml_table_t** base = realloc(arr->u.tab, (n+1) * sizeof(*base));
+	    if (0 == base) {
+                e_outofmemory(ctx, FLINE);
+                return;         /* not reached */
+            }
+	    arr->u.tab = base;
+	    
+	    if (0 == (base[n] = calloc(1, sizeof(*base[n])))) {
+		e_outofmemory(ctx, FLINE);
+                return;         /* not reached */
+            }
+	    
+            if (0 == (base[n]->key = strdup("__anon__"))) {
+		e_outofmemory(ctx, FLINE);
+                return;         /* not reached */
+            }
+	    
+	    dest = arr->u.tab[arr->nelem++];
+	}
+
+	ctx->curtab = dest;
+    }
+
+    if (ctx->tok.tok != RBRACKET) {
+        e_syntax_error(ctx, ctx->tok.lineno, "expects ]");
+        return;                 /* not reached */
+    }
+    EAT_TOKEN(ctx, RBRACKET);
+
+    if (count_lbracket == 2) {
+	if (ctx->tok.tok != RBRACKET) {
+            e_syntax_error(ctx, ctx->tok.lineno, "expects ]]");
+            return;             /* not reached */
+        }
+	EAT_TOKEN(ctx, RBRACKET);
+    }
+    if (ctx->tok.tok != NEWLINE) {
+        e_syntax_error(ctx, ctx->tok.lineno, "extra chars after ] or ]]");
+        return;                 /* not reached */
+    }
+}
+
+
+
+
+toml_table_t* toml_parse(char* conf,
+			 char* errbuf,
+			 int errbufsz)
+{
+    context_t ctx;
+
+    // clear errbuf 
+    if (errbufsz <= 0) errbufsz = 0;
+    if (errbufsz > 0)  errbuf[0] = 0;
+
+    // init context 
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.start = conf;
+    ctx.stop = ctx.start + strlen(conf);
+    ctx.errbuf = errbuf;
+    ctx.errbufsz = errbufsz;
+
+    // start with an artificial newline of length 0
+    ctx.tok.tok = NEWLINE; 
+    ctx.tok.lineno = 1;
+    ctx.tok.ptr = conf;
+    ctx.tok.len = 0;
+
+    // make a root table
+    if (0 == (ctx.root = calloc(1, sizeof(*ctx.root)))) {
+        /* do not call outofmemory() here... setjmp not done yet */
+        snprintf(ctx.errbuf, ctx.errbufsz, "ERROR: out of memory (%s)", FLINE);
+        return 0;
+    }
+
+    // set root as default table
+    ctx.curtab = ctx.root;
+
+    if (0 != setjmp(ctx.jmp)) {
+	// Got here from a long_jmp. Something bad has happened.
+	// Free resources and return error.
+	for (int i = 0; i < ctx.tpath.top; i++) xfree(ctx.tpath.key[i]);
+	toml_free(ctx.root);
+	return 0;
+    }
+
+    /* Scan forward until EOF */
+    for (token_t tok = ctx.tok; ! tok.eof ; tok = ctx.tok) {
+	switch (tok.tok) {
+	    
+	case NEWLINE:
+	    next_token(&ctx, 1);
+	    break;
+	    
+	case STRING:
+	    parse_keyval(&ctx, ctx.curtab);
+	    if (ctx.tok.tok != NEWLINE) {
+                e_syntax_error(&ctx, ctx.tok.lineno, "extra chars after value");
+                return 0;         /* not reached */
+            }
+
+	    EAT_TOKEN(&ctx, NEWLINE);
+	    break;
+	    
+	case LBRACKET:  /* [ x.y.z ] or [[ x.y.z ]] */
+	    parse_select(&ctx);
+	    break;
+	    
+	default:
+	    snprintf(ctx.errbuf, ctx.errbufsz, "line %d: syntax error", tok.lineno);
+	    longjmp(ctx.jmp, 1);
+	}
+    }
+
+    /* success */
+    for (int i = 0; i < ctx.tpath.top; i++) xfree(ctx.tpath.key[i]);
+    return ctx.root;
+}
+
+
+toml_table_t* toml_parse_file(FILE* fp,
+			      char* errbuf,
+			      int errbufsz)
+{
+    int bufsz = 0;
+    char* buf = 0;
+    int off = 0;
+
+    /* prime the buf[] */
+    bufsz = 1000;
+    if (! (buf = malloc(bufsz + 1))) {
+        snprintf(errbuf, errbufsz, "out of memory");
+        return 0;
+    }
+
+    /* read from fp into buf */
+    while (! feof(fp)) {
+	bufsz += 1000;
+	
+	/* Allocate 1 extra byte because we will tag on a NUL */
+	char* x = realloc(buf, bufsz + 1);
+	if (!x) {
+	    snprintf(errbuf, errbufsz, "out of memory");
+	    xfree(buf);
+	    return 0;
+	}
+	buf = x;
+
+	errno = 0;
+	int n = fread(buf + off, 1, bufsz - off, fp);
+	if (ferror(fp)) {
+	    snprintf(errbuf, errbufsz, "%s",
+		     errno ? strerror(errno) : "Error reading file");
+	    free(buf);
+	    return 0;
+	}
+	off += n;
+    }
+
+    /* tag on a NUL to cap the string */
+    buf[off] = 0; /* we accounted for this byte in the realloc() above. */
+
+    /* parse it, cleanup and finish */
+    toml_table_t* ret = toml_parse(buf, errbuf, errbufsz);
+    free(buf);
+    return ret;
+}
+
+
+static void xfree_kval(toml_keyval_t* p)
+{
+    if (!p) return;
+    xfree(p->key);
+    xfree(p->val);
+    xfree(p);
+}
+
+static void xfree_tab(toml_table_t* p);
+
+static void xfree_arr(toml_array_t* p)
+{
+    if (!p) return;
+
+    xfree(p->key);
+    switch (p->kind) {
+    case 'v':
+	for (int i = 0; i < p->nelem; i++) xfree(p->u.val[i]);
+	xfree(p->u.val);
+	break;
+
+    case 'a':
+	for (int i = 0; i < p->nelem; i++) xfree_arr(p->u.arr[i]);
+	xfree(p->u.arr);
+	break;
+
+    case 't':
+	for (int i = 0; i < p->nelem; i++) xfree_tab(p->u.tab[i]);
+	xfree(p->u.tab);
+	break;
+    }
+
+    xfree(p);
+}
+
+
+static void xfree_tab(toml_table_t* p)
+{
+    int i;
+    
+    if (!p) return;
+    
+    xfree(p->key);
+    
+    for (i = 0; i < p->nkval; i++) xfree_kval(p->kval[i]);
+    xfree(p->kval);
+
+    for (i = 0; i < p->narr; i++) xfree_arr(p->arr[i]);
+    xfree(p->arr);
+
+    for (i = 0; i < p->ntab; i++) xfree_tab(p->tab[i]);
+    xfree(p->tab);
+
+    xfree(p);
+}
+
+
+void toml_free(toml_table_t* tab)
+{
+    xfree_tab(tab);
+}
+
+
+static tokentype_t ret_token(context_t* ctx, tokentype_t tok, int lineno, char* ptr, int len)
+{
+    token_t t;
+    t.tok = tok;
+    t.lineno = lineno;
+    t.ptr = ptr;
+    t.len = len;
+    t.eof = 0;
+    ctx->tok = t;
+    return tok;
+}
+
+static tokentype_t ret_eof(context_t* ctx, int lineno)
+{
+    ret_token(ctx, NEWLINE, lineno, ctx->stop, 0);
+    ctx->tok.eof = 1;
+    return ctx->tok.tok;
+}
+    
+
+static tokentype_t scan_string(context_t* ctx, char* p, int lineno, int dotisspecial)
+{
+    char* orig = p;
+    if (0 == strncmp(p, "'''", 3)) {
+	p = strstr(p + 3, "'''");
+	if (0 == p) {
+	    e_syntax_error(ctx, lineno, "unterminated triple-s-quote");
+            return 0;           /* not reached */
+        }
+
+	return ret_token(ctx, STRING, lineno, orig, p + 3 - orig);
+    }
+
+    if (0 == strncmp(p, "\"\"\"", 3)) {
+	int hexreq = 0;		/* #hex required */
+	int escape = 0;
+	int qcnt = 0;		/* count quote */
+	for (p += 3; *p && qcnt < 3; p++) {
+	    if (escape) {
+		escape = 0;
+		if (strchr("btnfr\"\\", *p)) continue;
+		if (*p == 'u') { hexreq = 4; continue; }
+		if (*p == 'U') { hexreq = 8; continue; }
+		if (*p == '\n') continue; /* allow for line ending backslash */
+		e_syntax_error(ctx, lineno, "bad escape char");
+                return 0;       /* not reached */
+	    }
+	    if (hexreq) {
+		hexreq--;
+		if (strchr("0123456789ABCDEF", *p)) continue;
+		e_syntax_error(ctx, lineno, "expect hex char");
+                return 0;       /* not reached */
+	    }
+	    if (*p == '\\') { escape = 1; continue; }
+	    qcnt = (*p == '"') ? qcnt + 1 : 0; 
+	}
+	if (qcnt != 3) {
+	    e_syntax_error(ctx, lineno, "unterminated triple-quote");
+            return 0;           /* not reached */
+        }
+
+	return ret_token(ctx, STRING, lineno, orig, p - orig);
+    }
+
+    if ('\'' == *p) {
+	for (p++; *p && *p != '\n' && *p != '\''; p++);
+	if (*p != '\'') {
+	    e_syntax_error(ctx, lineno, "unterminated s-quote");
+            return 0;           /* not reached */
+        }
+
+	return ret_token(ctx, STRING, lineno, orig, p + 1 - orig);
+    }
+
+    if ('\"' == *p) {
+	int hexreq = 0;		/* #hex required */
+	int escape = 0;
+	for (p++; *p; p++) {
+	    if (escape) {
+		escape = 0;
+		if (strchr("btnfr\"\\", *p)) continue;
+		if (*p == 'u') { hexreq = 4; continue; }
+		if (*p == 'U') { hexreq = 8; continue; }
+		e_syntax_error(ctx, lineno, "bad escape char");
+                return 0;       /* not reached */
+	    }
+	    if (hexreq) {
+		hexreq--;
+		if (strchr("0123456789ABCDEF", *p)) continue;
+		e_syntax_error(ctx, lineno, "expect hex char");
+                return 0;       /* not reached */
+	    }
+	    if (*p == '\\') { escape = 1; continue; }
+	    if (*p == '\n') break;
+	    if (*p == '"') break;
+	}
+	if (*p != '"') {
+	    e_syntax_error(ctx, lineno, "unterminated quote");
+            return 0;           /* not reached */
+        }
+
+	return ret_token(ctx, STRING, lineno, orig, p + 1 - orig);
+    }
+
+    for ( ; *p && *p != '\n'; p++) {
+	int ch = *p;
+	if (ch == '.' && dotisspecial) break;
+	if ('A' <= ch && ch <= 'Z') continue;
+	if ('a' <= ch && ch <= 'z') continue;
+	if ('0' <= ch && ch <= '9') continue;
+	if (strchr("+-_.:", ch)) continue;
+	break;
+    }
+
+    return ret_token(ctx, STRING, lineno, orig, p - orig);
+}
+
+
+static tokentype_t next_token(context_t* ctx, int dotisspecial)
+{
+    int   lineno = ctx->tok.lineno;
+    char* p = ctx->tok.ptr;
+    int i;
+
+    /* eat this tok */
+    for (i = 0; i < ctx->tok.len; i++) {
+	if (*p++ == '\n')
+	    lineno++;
+    }
+
+    /* make next tok */
+    while (p < ctx->stop) {
+	/* skip comment. stop just before the \n. */
+	if (*p == '#') {
+	    for (p++; p < ctx->stop && *p != '\n'; p++);
+	    continue;
+	}
+
+	if (dotisspecial && *p == '.')
+	    return ret_token(ctx, DOT, lineno, p, 1);
+	
+	switch (*p) {
+	case ',': return ret_token(ctx, COMMA, lineno, p, 1);
+	case '=': return ret_token(ctx, EQUAL, lineno, p, 1);
+	case '{': return ret_token(ctx, LBRACE, lineno, p, 1);
+	case '}': return ret_token(ctx, RBRACE, lineno, p, 1);
+	case '[': return ret_token(ctx, LBRACKET, lineno, p, 1);
+	case ']': return ret_token(ctx, RBRACKET, lineno, p, 1);
+	case '\n': return ret_token(ctx, NEWLINE, lineno, p, 1);
+	case '\r': case ' ': case '\t':
+	    /* ignore white spaces */
+	    p++;
+	    continue;
+	}
+
+	return scan_string(ctx, p, lineno, dotisspecial);
+    }
+
+    return ret_eof(ctx, lineno);
+}
+
+
+const char* toml_key_in(toml_table_t* tab, int keyidx)
+{
+    if (keyidx < tab->nkval) return tab->kval[keyidx]->key;
+    
+    keyidx -= tab->nkval;
+    if (keyidx < tab->narr)  return tab->arr[keyidx]->key;
+    
+    keyidx -= tab->narr;
+    if (keyidx < tab->ntab)  return tab->tab[keyidx]->key;
+
+    return 0;
+}
+
+
+const char* toml_raw_in(toml_table_t* tab, const char* key)
+{
+    int i;
+    for (i = 0; i < tab->nkval; i++) {
+	if (0 == strcmp(key, tab->kval[i]->key))
+	    return tab->kval[i]->val;
+    }
+    return 0;
+}
+
+toml_array_t* toml_array_in(toml_table_t* tab, const char* key)
+{
+    int i;
+    for (i = 0; i < tab->narr; i++) {
+	if (0 == strcmp(key, tab->arr[i]->key))
+	    return tab->arr[i];
+    }
+    return 0;
+}
+
+
+toml_table_t* toml_table_in(toml_table_t* tab, const char* key)
+{
+    int i;
+    for (i = 0; i < tab->ntab; i++) {
+	if (0 == strcmp(key, tab->tab[i]->key))
+	    return tab->tab[i];
+    }
+    return 0;
+}
+
+const char* toml_raw_at(toml_array_t* arr, int idx)
+{
+    if (arr->kind != 'v')
+	return 0;
+    if (! (0 <= idx && idx < arr->nelem))
+	return 0;
+    return arr->u.val[idx];
+}
+
+char toml_array_kind(toml_array_t* arr)
+{
+    return arr->kind;
+}
+
+
+
+toml_array_t* toml_array_at(toml_array_t* arr, int idx)
+{
+    if (arr->kind != 'a')
+	return 0;
+    if (! (0 <= idx && idx < arr->nelem))
+	return 0;
+    return arr->u.arr[idx];
+}
+
+toml_table_t* toml_table_at(toml_array_t* arr, int idx)
+{
+    if (arr->kind != 't')
+	return 0;
+    if (! (0 <= idx && idx < arr->nelem))
+	return 0;
+    return arr->u.tab[idx];
+}
+
+
+int toml_rtots(const char* src_, toml_timestamp_t* ret)
+{
+    if (! src_) return -1;
+    
+    const char* p = src_;
+    const char* q = src_ + strlen(src_);
+    int64_t val;
+    int i;
+    
+    memset(ret, 0, sizeof(*ret));
+
+    /* parse date */
+    val = 0;
+    if (q - p > 4 && p[4] == '-') {
+	for (i = 0; i < 10; i++, p++) {
+	    int xx = *p;
+	    if (xx == '-') {
+		if (i == 4 || i == 7) continue; else return -1;
+	    }
+	    if (! ('0' <= xx && xx <= '9')) return -1;
+	    val = val * 10 + (xx - '0');
+	}
+	ret->day   = &ret->__buffer.day;
+	ret->month = &ret->__buffer.month;
+	ret->year  = &ret->__buffer.year;
+	
+	*ret->day   = val % 100; val /= 100;
+	*ret->month = val % 100; val /= 100;
+	*ret->year  = val;
+	
+	if (*p) {
+	    if (*p != 'T') return -1;
+	    p++;
+	}
+    }
+    if (q == p) return 0;
+
+    /* parse time */
+    val = 0;
+    if (q - p < 8) return -1;
+    for (i = 0; i < 8; i++, p++) {
+	int xx = *p;
+	if (xx == ':') {
+	    if (i == 2 || i == 5) continue; else return -1;
+	}
+	if (! ('0' <= xx && xx <= '9')) return -1;
+	val = val * 10 + (xx - '0');
+    }
+    ret->second = &ret->__buffer.second;
+    ret->minute = &ret->__buffer.minute;
+    ret->hour   = &ret->__buffer.hour;
+    
+    *ret->second = val % 100; val /= 100;
+    *ret->minute = val % 100; val /= 100;
+    *ret->hour   = val;
+    
+    /* skip fractional second */
+    if (*p == '.') for (p++; '0' <= *p && *p <= '9'; p++);
+    if (q == p) return 0;
+    
+    /* parse and copy Z */
+    ret->z = ret->__buffer.z;
+    char* z = ret->z;
+    if (*p == 'Z') {
+	*z++ = *p++;
+	*z = 0;
+	return (p == q) ? 0 : -1;
+    }
+    if (*p == '+' || *p == '-') {
+	*z++ = *p++;
+	
+	if (! (isdigit(p[0]) && isdigit(p[1]))) return -1;
+	*z++ = *p++;
+	*z++ = *p++;
+	
+	if (*p == ':') {
+	    *z++ = *p++;
+	    
+	    if (! (isdigit(p[0]) && isdigit(p[1]))) return -1;
+	    *z++ = *p++;
+	    *z++ = *p++;
+	}
+	
+	*z = 0;
+    }
+    return (p == q) ? 0 : -1;
+}
+
+
+/* Raw to boolean */
+int toml_rtob(const char* src, int* ret_)
+{
+    if (!src) return -1;
+    int dummy;
+    int* ret = ret_ ? ret_ : &dummy;
+    
+    if (0 == strcmp(src, "true")) {
+	*ret = 1;
+	return 0;
+    }
+    if (0 == strcmp(src, "false")) {
+	*ret = 0;
+	return 0;
+    }
+    return -1;
+}
+
+
+/* Raw to integer */
+int toml_rtoi(const char* src, int64_t* ret_)
+{
+    if (!src) return -1;
+    
+    char buf[100];
+    char* p = buf;
+    char* q = p + sizeof(buf);
+    const char* s = src;
+    int64_t dummy;
+    int64_t* ret = ret_ ? ret_ : &dummy;
+    
+    if (*s == '+')
+	*p++ = *s++;
+    else if (*s == '-')
+	*p++ = *s++;
+
+    /* if 0 ... */
+    if ('0' == s[0]) {
+	/* ensure no other digits after it */
+	if (s[1]) return -1;
+	return *ret = 0, 0;
+    }
+
+    /* just strip underscores and pass to strtoll */
+    while (*s && p < q) {
+	int ch = *s++;
+	if (ch == '_') ; else *p++ = ch;
+    }
+    if (*s || p == q) return -1;
+    
+    /* cap with NUL */
+    *p = 0;
+
+    /* Run strtoll on buf to get the integer */
+    char* endp;
+    errno = 0;
+    *ret = strtoll(buf, &endp, 0);
+    return (errno || *endp) ? -1 : 0;
+}
+
+
+int toml_rtod(const char* src, double* ret_)
+{
+    if (!src) return -1;
+    
+    char buf[100];
+    char* p = buf;
+    char* q = p + sizeof(buf);
+    const char* s = src;
+    double dummy;
+    double* ret = ret_ ? ret_ : &dummy;
+
+    /* check for special cases */
+    if (s[0] == '+' || s[0] == '-') *p++ = *s++;
+    if (s[0] == '.') return -1;	/* no leading zero */
+    if (s[0] == '0') {
+	/* zero must be followed by . or NUL */
+	if (s[1] && s[1] != '.') return -1;
+    }
+
+    /* just strip underscores and pass to strtod */
+    while (*s && p < q) {
+	int ch = *s++;
+	if (ch == '_') ; else *p++ = ch;
+    }
+    if (*s || p == q) return -1;
+
+    if (p != buf && p[-1] == '.') 
+	return -1; /* no trailing zero */
+
+    /* cap with NUL */
+    *p = 0;
+
+    /* Run strtod on buf to get the value */
+    char* endp;
+    errno = 0;
+    *ret = strtod(buf, &endp);
+    return (errno || *endp) ? -1 : 0;
+}
+
+
+static char* kill_line_ending_backslash(char* str)
+{
+    if (!str) return 0;
+    
+    /* first round: find (backslash, \n) */
+    char* p = str;
+    while (0 != (p = strstr(p, "\\\n"))) {
+	char* q = (p + 1);
+	q += strspn(q, " \t\r\n");
+	memmove(p, q, strlen(q) + 1);
+    }
+    /* second round: find (backslash, \r, \n) */
+    p = str;
+    while (0 != (p = strstr(p, "\\\r\n"))) {
+	char* q = (p + 1);
+	q += strspn(q, " \t\r\n");
+	memmove(p, q, strlen(q) + 1);
+    }
+
+    return str;
+}
+
+
+int toml_rtos(const char* src, char** ret)
+{
+    if (!src) return -1;
+    if (*src != '\'' && *src != '"') return -1;
+
+    *ret = 0;
+    int srclen = strlen(src);
+    if (*src == '\'') {
+	if (0 == strncmp(src, "'''", 3)) {
+	    const char* sp = src + 3;
+	    const char* sq = src + srclen - 3;
+	    /* last 3 chars in src must be ''' */
+	    if (! (sp <= sq && 0 == strcmp(sq, "'''")))
+		return -1;
+	    
+	    /* skip first new line right after ''' */
+	    if (*sp == '\n')
+		sp++;
+	    else if (sp[0] == '\r' && sp[1] == '\n')
+		sp += 2;
+
+	    *ret = kill_line_ending_backslash(strndup(sp, sq - sp));
+	} else {
+	    const char* sp = src + 1;
+	    const char* sq = src + srclen - 1;
+	    /* last char in src must be ' */
+	    if (! (sp <= sq && *sq == '\''))
+		return -1;
+	    /* copy from sp to p */
+	    *ret = strndup(sp, sq - sp);
+	}
+	return *ret ? 0 : -1;
+    }
+
+    const char* sp;
+    const char* sq;
+    if (0 == strncmp(src, "\"\"\"", 3)) {
+	sp = src + 3;
+	sq = src + srclen - 3;
+	if (! (sp <= sq && 0 == strcmp(sq, "\"\"\"")))
+	    return -1;
+	
+	/* skip first new line right after """ */
+	if (*sp == '\n')
+	    sp++;
+	else if (sp[0] == '\r' && sp[1] == '\n')
+	    sp += 2;
+    } else {
+	sp = src + 1;
+	sq = src + srclen - 1;
+	if (! (sp <= sq && *sq == '"'))
+	    return -1;
+    }
+
+    char dummy_errbuf[1];
+    *ret = normalize_string(sp, sq - sp,
+			    1, // flag kill_line_ending_backslash 
+			    dummy_errbuf, sizeof(dummy_errbuf));
+    return *ret ? 0 : -1;
+}

--- a/util/unifycr/src/toml.h
+++ b/util/unifycr/src/toml.h
@@ -1,0 +1,110 @@
+/*
+MIT License
+
+Copyright (c) 2017 CK Tan
+https://github.com/cktan/tomlc99
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#ifndef TOML_H
+#define TOML_H
+
+#ifdef __cplusplus
+#define TOML_EXTERN extern "C"
+#else
+#define TOML_EXTERN extern
+#endif
+
+typedef struct toml_table_t toml_table_t;
+typedef struct toml_array_t toml_array_t;
+
+/* Parse a file. Return a table on success, or 0 otherwise. 
+ * Caller must toml_free(the-return-value) after use.
+ */
+TOML_EXTERN toml_table_t* toml_parse_file(FILE* fp, 
+					  char* errbuf,
+					  int errbufsz);
+
+/* Parse a string containing the full config. 
+ * Return a table on success, or 0 otherwise.
+ * Caller must toml_free(the-return-value) after use.
+ */
+TOML_EXTERN toml_table_t* toml_parse(char* conf, /* NUL terminated, please. */
+				     char* errbuf,
+				     int errbufsz);
+
+/* Free the table returned by toml_parse() or toml_parse_file(). */
+TOML_EXTERN void toml_free(toml_table_t* tab);
+
+/* Retrieve the key in table at keyidx. Return 0 if out of range. */
+TOML_EXTERN const char* toml_key_in(toml_table_t* tab, int keyidx);
+
+/* Lookup table by key. Return the element or 0 if not found. */
+TOML_EXTERN const char* toml_raw_in(toml_table_t* tab, const char* key);
+TOML_EXTERN toml_array_t* toml_array_in(toml_table_t* tab, const char* key);
+TOML_EXTERN toml_table_t* toml_table_in(toml_table_t* tab, const char* key);
+
+/* Return the array kind: 't'able, 'a'rray, 'v'alue */
+TOML_EXTERN char toml_array_kind(toml_array_t* arr);
+
+/* Deref array by index. Return the element at idx or 0 if out of range. */
+TOML_EXTERN const char* toml_raw_at(toml_array_t* arr, int idx);
+TOML_EXTERN toml_array_t* toml_array_at(toml_array_t* arr, int idx);
+TOML_EXTERN toml_table_t* toml_table_at(toml_array_t* arr, int idx);
+
+
+/* Raw to String. Caller must call free(ret) after use. 
+ * Return 0 on success, -1 otherwise.
+ */
+TOML_EXTERN int toml_rtos(const char* s, char** ret);
+
+/* Raw to Boolean. Return 0 on success, -1 otherwise. */
+TOML_EXTERN int toml_rtob(const char* s, int* ret);
+
+/* Raw to Integer. Return 0 on success, -1 otherwise. */
+TOML_EXTERN int toml_rtoi(const char* s, int64_t* ret);
+
+/* Raw to Double. Return 0 on success, -1 otherwise. */
+TOML_EXTERN int toml_rtod(const char* s, double* ret);
+
+/* Timestamp types. The year, month, day, hour, minute, second, z 
+ * fields may be NULL if they are not relevant. e.g. In a DATE
+ * type, the hour, minute, second and z fields will be NULLs.
+ */
+typedef struct toml_timestamp_t toml_timestamp_t;
+struct toml_timestamp_t {
+    struct { /* internal. do not use. */
+	int year, month, day;
+	int hour, minute, second;
+	char z[10];
+    } __buffer;
+    int *year, *month, *day;
+    int *hour, *minute, *second;
+    char* z;
+};
+
+/* Raw to Timestamp. Return 0 on success, -1 otherwise. */
+TOML_EXTERN int toml_rtots(const char* s, toml_timestamp_t* ret);
+
+/* misc */
+TOML_EXTERN int toml_utf8_to_ucs(const char* orig, int len, int64_t* ret);
+TOML_EXTERN int toml_ucs_to_utf8(int64_t code, char buf[6]);
+
+
+#endif /* TOML_H */

--- a/util/unifycr/src/unifycr-cons.c
+++ b/util/unifycr/src/unifycr-cons.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "unifycr.h"
+
+/**
+ * @brief this should match with the enum definition of unifycr_cm_t in
+ * unifycr.h
+ */
+static char *consistency_strs[N_UNIFYCR_CM] = { "none", "laminated", "posix" };
+
+/**
+ * @brief return consistency enum entry matching with the given string.
+ *
+ * @param str input string of the consistency model
+ *
+ * @return matching enum entry on success, UNIFYCR_CM_INVALID (-1) otherwise
+ */
+unifycr_cm_t unifycr_read_consistency(const char *str)
+{
+    int i = 0;
+
+    for (i = 0; i < N_UNIFYCR_CM; i++)
+        if (!strcmp(str, consistency_strs[i]))
+            return i;
+
+    return UNIFYCR_CM_INVALID;
+}
+
+/**
+ * @brief return the consistency string based on the given code.
+ *
+ * @param con the consistency code (integer)
+ *
+ * @return string that describes the consistency model
+ */
+const char *unifycr_write_consistency(unifycr_cm_t con)
+{
+    if (con < 0 || con >= N_UNIFYCR_CM)
+        return "invalid";
+    else
+        return consistency_strs[con];
+}
+
+

--- a/util/unifycr/src/unifycr-env.c
+++ b/util/unifycr/src/unifycr-env.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "unifycr.h"
+
+int unifycr_read_env(unifycr_env_t *env)
+{
+    char *val = NULL;
+
+    val = getenv("UNIFYCR_MT");
+    if (val)
+        env->unifycr_mt = strdup(val);
+
+    return 0;
+}
+

--- a/util/unifycr/src/unifycr-rm.c
+++ b/util/unifycr/src/unifycr-rm.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include "unifycr.h"
+
+/**
+ * @brief get the node list from the $PBS_NODEFILE
+ *
+ * @param resource
+ *
+ * @return
+ */
+static int read_resource_pbs(unifycr_resource_t *resource)
+{
+    int ret = 0;
+    int i = 0;
+    int n_nodes = 0;
+    FILE *fp = NULL;
+    char **nodes = NULL;
+    char buf[1024] = { 0, };
+    char *nodefile = getenv("PBS_NODEFILE");
+
+    if (!nodefile)
+        return -EINVAL;
+
+    fp = fopen(nodefile, "r");
+    if (!fp)
+        return -errno;
+
+    while (fgets(buf, 1023, fp))
+        n_nodes++;
+
+    if (ferror(fp)) {
+        ret = -errno;
+        goto out;
+    }
+
+    nodes = calloc(sizeof(char *), n_nodes);
+    if (!nodes) {
+        ret = -errno;
+        goto out;
+    }
+
+    rewind(fp);
+
+    while (fgets(buf, 1024, fp) != NULL) {
+        buf[strlen(buf) - 1] = '\0';    /* discard the newline */
+        nodes[i] = strdup(buf);
+        i++;
+    }
+
+    resource->n_nodes = n_nodes;
+    resource->nodes = nodes;
+
+out:
+    fclose(fp);
+
+    return ret;
+}
+
+/**
+ * TODO: not implemented yet
+ *
+ * @brief get the node list from the $SLURM_JOB_NODELIST, which requires
+ * parsing.
+ *
+ * @param resource
+ *
+ * @return
+ */
+static int read_resource_slurm(unifycr_resource_t *resource)
+{
+    return -ENOSYS;
+}
+
+/**
+ * From the documentation: The list of hosts selected by LSF Batch to run the
+ * batch job. If the job is run on a single processor, the value of LSB_HOSTS
+ * is the name of the execution host. For parallel jobs, the names of all
+ * execution hosts are listed separated by spaces. The batch job file is run on
+ * the first host in the list.
+ *
+ * @brief get the node list from the $LSB_HOSTS.
+ *
+ * @param resource
+ *
+ * @return
+ */
+static int read_resource_lsf(unifycr_resource_t *resource)
+{
+    int i = 0;
+    char *node = NULL;
+    char *pos = NULL;
+    int n_nodes = 0;
+    char **nodes = NULL;
+    char *lsb_hosts = NULL;
+
+    node = getenv("LSB_HOSTS");
+    if (!node)
+        return -EINVAL;
+
+    lsb_hosts = strdup(node);
+    pos = lsb_hosts;
+
+    for (pos = lsb_hosts; *pos; pos++)
+        if (isspace(*pos))
+            i++;
+
+    n_nodes = i + 1;
+    nodes = calloc(sizeof(char *), n_nodes);
+
+    for (i = 0, node = pos = lsb_hosts; *pos; pos++) {
+        if (isspace(*pos)) {
+            *pos = '\0';
+            nodes[i++] = node;
+            node = &pos[1];
+        }
+    }
+
+    nodes[i] = node;    /* the last one, not caught by isspace() */
+
+    resource->n_nodes = n_nodes;
+    resource->nodes = nodes;
+
+    return 0;
+}
+
+int unifycr_read_resource(unifycr_resource_t *resource)
+{
+    int ret = -1;
+    char *str = NULL;
+
+    str = getenv("PBS_JOBID");
+    if (str) {
+        ret = read_resource_pbs(resource);
+        goto out;
+    }
+
+    str = getenv("SLURM_JOBID");
+    if (str) {
+        ret = read_resource_slurm(resource);
+        goto out;
+    }
+
+    str = getenv("LSB_JOBID");
+    if (str) {
+        ret = read_resource_lsf(resource);
+        goto out;
+    }
+
+out:
+    return ret;
+}
+

--- a/util/unifycr/src/unifycr-runstate.c
+++ b/util/unifycr/src/unifycr-runstate.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "toml.h"
+#include "unifycr.h"
+
+static int
+write_runstate_file(unifycr_runstate_t *runstate, const char *file)
+{
+    int ret = 0;
+    uint32_t i = 0;
+    FILE *fp = NULL;
+
+    fp = fopen(file, "w");
+    if (!fp)
+        return -errno;
+
+    fprintf(fp, "mountpoint = %s\n", runstate->mountpoint);
+    fprintf(fp, "cleanup = %d\n", runstate->cleanup);
+    fprintf(fp, "consistency = %s\n",
+                unifycr_write_consistency(runstate->consistency));
+
+    if (runstate->transfer_in)
+        fprintf(fp, "transfer_in = %s\n", runstate->transfer_in);
+    if (runstate->transfer_out)
+        fprintf(fp, "transfer_out = %s\n", runstate->transfer_out);
+
+    fprintf(fp, "n_nodes = %d\n", runstate->n_nodes);
+    fprintf(fp, "nodes = [ ");
+
+    for (i = 0; i < runstate->n_nodes; i++) {
+        fprintf(fp, "%s%s",
+                    runstate->nodes[i],
+                    i == runstate->n_nodes - 1 ? " ]\n" : ", ");
+    }
+
+    fclose(fp);
+
+    return ret;
+}
+
+int unifycr_write_runstate(unifycr_resource_t *resource,
+                           unifycr_sysconf_t *sysconf,
+                           unifycr_env_t *env,
+                           unifycr_args_t *cmdargs)
+{
+    char runstatefile[4096] = { 0, };
+    unifycr_runstate_t runstate = { 0, };
+
+    /*
+     * apply options from the sysconf
+     */
+    runstate.consistency = sysconf->consistency;
+    runstate.mountpoint = sysconf->mountpoint;
+
+    /*
+     * environmental variables
+     */
+    runstate.mountpoint = env->unifycr_mt;
+
+    /*
+     * command-line arguments
+     */
+    runstate.cleanup = cmdargs->cleanup;
+    runstate.consistency = cmdargs->consistency;
+    runstate.mountpoint = cmdargs->mountpoint;
+    runstate.transfer_in = cmdargs->transfer_in;
+    runstate.transfer_out = cmdargs->transfer_out;
+
+    /*
+     * resources
+     */
+    runstate.n_nodes = resource->n_nodes;
+    runstate.nodes = resource->nodes;
+
+    sprintf(runstatefile, "%s/unifycr-runstate.conf", sysconf->runstatedir);
+
+    return write_runstate_file(&runstate, runstatefile);
+}
+

--- a/util/unifycr/src/unifycr-sysconf.c
+++ b/util/unifycr/src/unifycr-sysconf.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "toml.h"
+#include "unifycr.h"
+
+static const char *sysconf_file = CONFDIR "/unifycr.conf";
+
+enum {
+    CONF_ENTRY_STRING = 0,
+    CONF_ENTRY_INT,
+};
+
+struct _conf_entry {
+    char *name;
+    char *val;
+    int type;
+};
+
+typedef struct _conf_entry conf_entry_t;
+
+struct _conf_section {
+    char *title;
+    conf_entry_t *entries;
+    int (*read)(toml_table_t *tab, unifycr_sysconf_t *sysconf);
+};
+
+typedef struct _conf_section conf_section_t;
+
+static conf_entry_t global_entries[] = {
+    { "runstatedir", 0, CONF_ENTRY_STRING },
+    { 0, 0, 0 },
+};
+
+static int global_read(toml_table_t *tab, unifycr_sysconf_t *sysconf)
+{
+    int ret = 0;
+    const char *val = NULL;
+    char *str = NULL;
+
+    /* runstatedir */
+    val = toml_raw_in(tab, "runstatedir");
+    if (val) {
+        ret = toml_rtos(val, &str);
+        if (ret)
+            return -errno;
+
+        sysconf->runstatedir = str;
+    }
+
+    return 0;
+}
+
+static conf_entry_t filesystem_entries[] = {
+    { "mountpoint", 0, CONF_ENTRY_STRING },
+    { "consistency", 0, CONF_ENTRY_STRING },
+    { 0, 0, 0 },
+};
+
+static int filesystem_read(toml_table_t *tab, unifycr_sysconf_t *sysconf)
+{
+    int ret = 0;
+    const char *val = NULL;
+    char *str = NULL;
+
+    /* mountpoint */
+    val = toml_raw_in(tab, "mountpoint");
+    if (val) {
+        ret = toml_rtos(val, &str);
+        if (ret)
+            return -errno;
+
+        sysconf->mountpoint = str;
+    }
+
+    /* consistency */
+    val = toml_raw_in(tab, "consistency");
+    if (val) {
+        unifycr_cm_t consistency = UNIFYCR_CM_INVALID;
+
+        ret = toml_rtos(val, &str);
+        if (ret)
+            return -errno;
+
+        consistency = unifycr_read_consistency(str);
+
+        if (consistency == UNIFYCR_CM_INVALID)
+            return -EINVAL;
+
+        sysconf->consistency = consistency;
+    }
+
+    return 0;
+}
+
+static conf_section_t conf_sections[] = {
+    { "global", global_entries, &global_read },
+    { "filesystem", filesystem_entries, &filesystem_read },
+    { 0, 0, 0 },
+};
+
+static int readconf(toml_table_t *curtab, unifycr_sysconf_t *sysconf)
+{
+    int ret = 0;
+    toml_table_t *tab = NULL;
+    conf_section_t *section = NULL;
+
+    for (section = conf_sections; section->title; section++) {
+        tab = toml_table_in(curtab, section->title);
+        if (!tab)
+            continue;
+
+        ret = section->read(tab, sysconf);
+        if (ret)
+            return ret;
+    }
+
+    return 0;
+}
+
+int unifycr_read_sysconf(unifycr_sysconf_t *sysconf)
+{
+    int ret = 0;
+    FILE *fp = NULL;
+    char errbuf[1024] = { 0, };
+    toml_table_t *tab = NULL;
+
+    if (!sysconf)
+        return -EINVAL;
+
+    fp = fopen(sysconf_file, "r");
+    if (!fp)
+        return -errno;
+
+    tab = toml_parse_file(fp, errbuf, sizeof(errbuf));
+    if (!tab) {
+        fprintf(stderr, "%s\n", errbuf);
+        goto out_close;
+    }
+
+    ret = readconf(tab, sysconf);
+
+    toml_free(tab);
+
+out_close:
+    fclose(fp);
+
+    return ret;
+}
+

--- a/util/unifycr/src/unifycr.c
+++ b/util/unifycr/src/unifycr.c
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+
+#include "unifycr.h"
+
+/**
+ * @brief available actions.
+ */
+
+enum {
+    ACT_START        = 0,
+    ACT_TERMINATE,
+    N_ACT,
+};
+
+static char *actions[N_ACT] = { "start", "terminate" };
+
+static int unifycr_launch_daemon(void)
+{
+    return 0;
+}
+
+static int action = -1;
+static unifycr_args_t opts_cmd;
+static unifycr_env_t opts_env;
+static unifycr_sysconf_t opts_sysconf;
+static unifycr_resource_t resource;
+
+static struct option const long_opts[] = {
+    { "cleanup", 0, 0, 'c' },
+    { "consistency", 1, 0, 'C' },
+    { "debug", 0, 0, 'd' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "transfer-in", 1, 0, 'i' },
+    { "transfer-out", 1, 0, 'o' },
+    { 0, 0, 0, 0 },
+};
+
+static const char *program;
+static char *short_opts = "cC:dhm:i:o:";
+static char *usage_str =
+"\n"
+"Usage: %s <command> [options...]\n"
+"\n"
+"<command> should be one of the following:\n"
+"  start       start the unifycr server daemon\n"
+"  terminate   terminate the unifycr server daemon\n"
+"\n"
+"Available options for \"start\":\n"
+"  -C, --consistency=<model> consistency model (none, laminated, or posix)\n"
+"  -m, --mount=<path>        mount unifycr at <path>\n"
+"  -i, --transfer-in=<path>  stage in file(s) at <path>\n"
+"  -o, --transfer-out=<path> transfer file(s) to <path> on termination\n"
+"\n"
+"Available options for \"terminate\":\n"
+"  -c, --cleanup             clean up the unifycr storage on termination\n"
+"\n";
+
+static int debug;
+
+static void usage(int status)
+{
+    printf(usage_str, program);
+    exit(status);
+}
+
+static const char *basename(const char *path)
+{
+    const char *str = strrchr(path, '/');
+
+    if (str)
+        return &str[1];
+    else
+        return path;
+}
+
+static void parse_cmd_arguments(int argc, char **argv)
+{
+    int ch = 0;
+    int optidx = 2;
+    int cleanup = 0;
+    unifycr_cm_t consistency = UNIFYCR_CM_INVALID;
+    char *mountpoint = NULL;
+    char *transfer_in = NULL;
+    char *transfer_out = NULL;
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'c':
+            cleanup = 1;
+            break;
+
+        case 'C':
+            consistency = unifycr_read_consistency(optarg);
+            if (consistency < 0)
+                usage(1);
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'i':
+            transfer_in = strdup(optarg);
+            break;
+
+        case 'o':
+            transfer_out = strdup(optarg);
+            break;
+
+        case 'h':
+        default:
+            usage(0);
+            break;
+        }
+    }
+
+    opts_cmd.cleanup = cleanup;
+    opts_cmd.consistency = consistency;
+    opts_cmd.mountpoint = mountpoint;
+    opts_cmd.transfer_in = transfer_in;
+    opts_cmd.transfer_out = transfer_out;
+}
+
+int main(int argc, char **argv)
+{
+    int i = 0;
+    int ret = 0;
+    char *cmd = NULL;
+
+    program = basename(argv[0]);
+
+    if (argc < 2)
+        usage(1);
+
+    cmd = argv[1];
+
+    for (i = 0; i < N_ACT; i++) {
+        if (!strcmp(cmd, actions[i]))
+            action = i;
+    }
+
+    if (action < 0)
+        usage(1);
+
+    parse_cmd_arguments(argc, argv);
+
+    if (debug) {
+        printf("\n## options from the command line ##\n");
+        printf("cleanup:\t%d\n", opts_cmd.cleanup);
+        printf("consistency:\t%s\n",
+               unifycr_write_consistency(opts_cmd.consistency));
+        printf("mountpoint:\t%s\n", opts_cmd.mountpoint);
+        printf("transfer_in:\t%s\n", opts_cmd.transfer_in);
+        printf("transfer_out:\t%s\n", opts_cmd.transfer_out);
+    }
+
+    ret = unifycr_read_resource(&resource);
+    if (ret) {
+        fprintf(stderr, "failed to detect a resource manager\n");
+        goto out;
+    }
+
+    if (debug) {
+        printf("\n## job allocation (%llu nodes) ##\n",
+               (unsigned long long) resource.n_nodes);
+        for (i = 0; i < resource.n_nodes; i++)
+            printf("%s\n", resource.nodes[i]);
+    }
+
+    ret = unifycr_read_env(&opts_env);
+    if (ret) {
+        fprintf(stderr, "failed to environment variables\n");
+        goto out;
+    }
+
+    if (debug) {
+        printf("\n## options from the environmental variables ##\n");
+        printf("UNIFYCR_MT:\t%s\n", opts_env.unifycr_mt);
+    }
+
+    ret = unifycr_read_sysconf(&opts_sysconf);
+    if (ret) {
+        fprintf(stderr, "failed to read config file\n");
+        goto out;
+    }
+
+    if (debug) {
+        printf("\n## options read from %s ##\n", CONFDIR "/unifycr.conf");
+        printf("runstatedir:\t%s\n", opts_sysconf.runstatedir);
+        printf("consistency:\t%s\n",
+               unifycr_write_consistency(opts_sysconf.consistency));
+        printf("mountpoint:\t%s\n", opts_sysconf.mountpoint);
+    }
+
+    ret = unifycr_write_runstate(&resource, &opts_sysconf, &opts_env,
+                                 &opts_cmd);
+    if (ret) {
+        fprintf(stderr, "failed to write the runstate file\n");
+        goto out;
+    }
+
+    if (debug) {
+        char linebuf[4096] = { 0, };
+        FILE *fp = NULL;
+
+        sprintf(linebuf, "%s/unifycr-runstate.conf",
+                         opts_sysconf.runstatedir);
+
+        fp = fopen(linebuf, "r");
+        if (!fp)
+            perror("fopen");
+
+        while (fgets(linebuf, 4096, fp) != NULL)
+            fputs(linebuf, stdout);
+
+        if (ferror(fp))
+            perror("fgets");
+
+        fclose(fp);
+    }
+
+    ret = unifycr_launch_daemon();
+
+out:
+    return ret;
+}
+

--- a/util/unifycr/src/unifycr.h
+++ b/util/unifycr/src/unifycr.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Hyogi Sim
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ *
+ * Copyright (c) 2014, Los Alamos National Laboratory
+ *	All rights reserved.
+ *
+ */
+
+#ifndef __UNIFYCR_H
+#define __UNIFYCR_H
+
+#ifndef _CONFIG_H
+#define _CONFIG_H
+#include <config.h>
+#endif
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <string.h>
+
+/**
+ * @brief supported resource managers
+ */
+typedef enum {
+    UNIFYCR_RM_NONE     = 0,
+    UNIFYCR_RM_PBS,
+    UNIFYCR_RM_SLURM,
+    UNIFYCR_RM_LSF,
+} unifycr_rm_t;
+
+/**
+ * @brief supported consistency models
+ */
+typedef enum {
+    UNIFYCR_CM_INVALID    = -1,
+    UNIFYCR_CM_NONE       = 0,
+    UNIFYCR_CM_LAMINATED,
+    UNIFYCR_CM_POSIX,
+    N_UNIFYCR_CM,
+} unifycr_cm_t;
+
+/**
+ * @brief return consistency enum entry matching with the given string.
+ *
+ * @param str input string of the consistency model
+ *
+ * @return matching enum entry on success, UNIFYCR_CM_INVALID (-1) otherwise
+ */
+unifycr_cm_t unifycr_read_consistency(const char *str);
+
+/**
+ * @brief return the consistency string based on the given code.
+ *
+ * @param con the consistency code (integer)
+ *
+ * @return string that describes the consistency model
+ */
+const char *unifycr_write_consistency(unifycr_cm_t con);
+
+/*
+ * Runtime configurations are read from:
+ *
+ * 1. sysconfdir, $PREFIX/etc/unifycr/unifycr.conf. This file contains default
+ *    runtime options and cluster-wide global settings.
+ *
+ * 2. Environment variables, which can be defined by system or user.
+ *
+ * 3. Command line argument to this unifycr program.
+ *
+ * If a same configuration option is defined multiple times by above three
+ * cases, 3 overrides 2, which overrides 1.
+ *
+ * The final configuration is written to a temporary configuration file in
+ * runstatedir ($PREFIX/var/run/unifycr/unifycr-run.conf).
+ */
+
+/**
+ * @brief global options set by sysconf dir (unifycr.conf).
+ */
+struct _unifycr_sysconf {
+    /* global configuration */
+
+    /* the directory where unifycr-runtime.conf will be written */
+    char *runstatedir;
+
+    /* file system configuration */
+    unifycr_cm_t consistency;       /* consistency model */
+    char *mountpoint;               /* unifycr mountpoint */
+};
+
+typedef struct _unifycr_sysconf unifycr_sysconf_t;
+
+/**
+ * @brief options read from environmental variables
+ */
+struct _unifycr_env {
+    char *unifycr_mt;               /* unifycr mountpoint */
+};
+
+typedef struct _unifycr_env unifycr_env_t;
+
+/**
+ * @brief options read from command line arguments
+ */
+struct _unifycr_args {
+    int cleanup;                    /* cleanup on termination? (0 or 1) */
+    unifycr_cm_t consistency;       /* consistency model */
+    char *mountpoint;               /* mountpoint */
+    char *transfer_in;              /* data path to stage-in */
+    char *transfer_out;             /* data path to stage-out (drain) */
+};
+
+typedef struct _unifycr_args unifycr_args_t;
+
+/**
+ * @brief nodes allocated to the current job.
+ */
+struct _unifycr_resource {
+    uint64_t n_nodes;               /* number of nodes in job allocation */
+    char **nodes;                   /* allocated node names */
+};
+
+typedef struct _unifycr_resource unifycr_resource_t;
+
+/**
+ * @brief the final runtime configurations (/var/run/unifycr-run.conf).
+ */
+struct _unifycr_runstate {
+    char *mountpoint;               /* mountpoint */
+    char *transfer_in;              /* data path to stage-in */
+    char *transfer_out;             /* data path to stage-out (drain) */
+    int cleanup;                    /* cleanup on termination? */
+    int consistency;                /* consistency model */
+
+    uint32_t n_nodes;               /* number of nodes in job allocation */
+    char **nodes;                   /* allocdated node names */
+};
+
+typedef struct _unifycr_runstate unifycr_runstate_t;
+
+/**
+ * @brief detect a resource manager and find allocated nodes accordingly.
+ *
+ * @param resource the structure to be filled by this function
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+int unifycr_read_resource(unifycr_resource_t *resource);
+
+/**
+ * @brief reads unifycr environmental variables
+ *
+ * @param env the structure to be filled by this function
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+int unifycr_read_env(unifycr_env_t *env);
+
+/**
+ * @brief reads system configuration file (PREFIX/etc/unifycr/unifycr.conf)
+ *
+ * @param sysconf the structure to be filled by this function
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+int unifycr_read_sysconf(unifycr_sysconf_t *sysconf);
+
+/**
+ * @brief write runstate file (@runstatedir@/unifuycr/unifycr-runstate.conf)
+ *
+ * @param resource allocated node informantion read from resource manager
+ * @param sysconf options from sysconf file
+ * @param env options from environmental variables
+ * @param cmdargs options from command line arguments
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+int unifycr_write_runstate(unifycr_resource_t *resource,
+                           unifycr_sysconf_t *sysconf,
+                           unifycr_env_t *env,
+                           unifycr_args_t *cmdargs);
+
+#endif  /* __UNIFYCR_H */
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
This includes a basic implementation of the unifier command line utility, addressing issue #86 .

### Motivation and Context
See issue #86.

### Current status
It successfully read configurations from sysconf file (/etc/unifycr/unifycr.conf), environmental variables, and command line arguments. Also, it generates the dynamic configuration file under specified path (runstatedir/unifycr/unifycr-runtime.conf, which can be changed by sysconf file). It is not launching the daemon, yet. In specific, the following is the remaining work list:

1. Launching the server daemon (do we need to execute mpirun and daemonize?)
2. Node list parsing using scontrol (SLURM), or manually.
3. Plugins for individual resource managers.
4. Changes to the unifycrd (server daemon) to read configurations from the dynamically created runtime configuration file.

The test program is going to be included after the item 4. above (changing the unifycrd).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.