### PR TITLE
Client: fix broken sorting in ins_file_meta()

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1091,19 +1091,21 @@ static int ins_file_meta(unifycr_fattr_buf_t *ptr_f_meta_log,
     int meta_cnt = *(ptr_f_meta_log->ptr_num_entries), i;
     unifycr_fattr_t *meta_entry = ptr_f_meta_log->meta_entry;
 
-    for (i = 0; i < meta_cnt - 1; i++) {
-        if (meta_entry[i].fid > ins_fattr->fid) {
+    /* TODO: Improve the search time */
+    for (i = meta_cnt - 1; i >= 0; i--) {
+        if (meta_entry[i].fid <= ins_fattr->fid) {
+            /* sort in acsending order */
             break;
         }
     }
+    int ins_pos = i + 1;
 
-    if (i == meta_cnt) {
+    if (ins_pos == meta_cnt) {
         meta_entry[meta_cnt] = *ins_fattr;
         (*ptr_f_meta_log->ptr_num_entries)++;
         return 0;
     }
 
-    int ins_pos = i;
     for (i = meta_cnt - 1; i >= ins_pos; i--) {
         meta_entry[i + 1] = meta_entry[i];
     }


### PR DESCRIPTION
Client: fix broken sorting in ins_file_meta()

### Description
The issue is with ins_file_meta() that doesn't add a new fattr entry
in acsending order which is required by bsearch().
This fix patches ins_file_meta() so it always inserts elements properly.

### Motivation and Context
When the second file is being written on the client,
it crashes with segfault in _chunk_write() because bsearch()
returns NULL.

### How Has This Been Tested?
How to test the changes:
- Make clients create more than one file with '-n' option, for example:
mdtest -n 100 -F -C

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
