### PR TITLE
Fixing the mpirun adhoc mechanism in the unifycr command utility.

### DIFF
--- a/util/unifycr/src/unifycr-runstate.c
+++ b/util/unifycr/src/unifycr-runstate.c
@@ -117,6 +117,8 @@ static int create_runstatedir(const char *path)
         *ch = '/';
     }
 
+    ret = 0;
+
 out:
     free(buf);
 


### PR DESCRIPTION
Fixing the mpirun adhoc mechanism in the unifycr command utility.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

