### PR TITLE
Fix 0001-setup.t test failure

### DIFF
--- a/t/0001-setup.t
+++ b/t/0001-setup.t
@@ -39,14 +39,21 @@ unifycrd_cleanup
 unifycrd_start_daemon
 
 #
-# Make sure unifycrd stays running for 5 seconds to catch cases where
+# Make sure the unifycrd process starts.
+#
+if ! process_is_running unifycrd 5 ; then
+    echo not ok 1 - unifycrd running
+    exit 1
+fi
+
+#
+# Make sure unifycrd stays running for 5 more seconds to catch cases where
 # it dies during initialization.
 #
 if process_is_not_running unifycrd 5; then
     echo not ok 1 - unifycrd running
     exit 1
-else
-    echo ok 1 - unifycrd running
 fi
 
+echo ok 1 - unifycrd running
 exit 0

--- a/t/sharness.d/02-functions.sh
+++ b/t/sharness.d/02-functions.sh
@@ -72,7 +72,7 @@ unifycrd_start_daemon()
        ! mkdir $UNIFYCR_META_DB_PATH; then
             return 1
     fi
-    ( $UNIFYCRD < /dev/null > /dev/null 2>&1 & )
+    $UNIFYCRD
 }
 
 # Kill UnifyCR daemon.


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test 0001-setup.t might fail if the 'process_is_not_running'
shell function runs before the unifycrd process is created.
Make sure the process exists before running that function by not
launching it in the background from a subshell. That construct is
not longer needed since unifycrd now properly daemonizes itself.
Furthermore, update the test script so it checks both that the
unifycrd is successfully created and that it doesn't die within
5 seconds.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
