### PR TITLE
Removing the fs_type_t constants (UNIFYCR_LOG)

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -310,12 +310,6 @@ typedef struct {
     int count;
 } index_set_t;
 
-typedef enum {
-    UNIFYCRFS,
-    UNIFYCR_LOG,
-    UNIFYCR_STRIPE,
-} fs_type_t;
-
 typedef struct {
     read_req_t read_reqs[UNIFYCR_MAX_READ_CNT];
     int count;
@@ -335,7 +329,6 @@ extern long shm_req_size;
 extern long shm_recv_size;
 extern char *shm_recvbuf;
 extern char *shm_reqbuf;
-extern fs_type_t fs_type;
 extern char cmd_buf[GEN_STR_LEN];
 extern char ack_msg[3];
 extern unifycr_fattr_buf_t unifycr_fattrs;

--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -234,6 +234,7 @@ int UNIFYCR_WRAP(truncate)(const char *path, off_t length)
     if (unifycr_intercept_path(path)) {
         /* lookup the fd for the path */
         int fid = unifycr_get_fid_from_path(path);
+
         if (fid < 0) {
             /* ERROR: file does not exist */
             DEBUG("Couldn't find entry for %s in UNIFYCR\n", path);
@@ -382,6 +383,9 @@ int UNIFYCR_WRAP(fstat)(int fd, struct stat *buf)
  * NOTE on __xstat(2), __lxstat(2), and __fxstat(2)
  * The additional parameter vers shall be 3 or the behavior of these functions
  * is undefined. (ISO POSIX(2003))
+ *
+ * from /sys/stat.h, it seems that we need to test if vers being _STAT_VER,
+ * instead of using the absolute value 3.
  */
 
 int UNIFYCR_WRAP(__xstat)(int vers, const char *path, struct stat *buf)
@@ -390,7 +394,7 @@ int UNIFYCR_WRAP(__xstat)(int vers, const char *path, struct stat *buf)
 
     DEBUG("xstat was called for %s....\n", path);
     if (unifycr_intercept_path(path)) {
-        if (vers != 3) {
+        if (vers != _STAT_VER) {
             errno = EINVAL;
             return -1;
         }
@@ -427,11 +431,10 @@ int UNIFYCR_WRAP(__lxstat)(int vers, const char *path, struct stat *buf)
 
     DEBUG("lxstat was called for %s....\n", path);
     if (unifycr_intercept_path(path)) {
-        if (vers != 3) {
+        if (vers != _STAT_VER) {
             errno = EINVAL;
             return -1;
         }
-
         if (!buf) {
             errno = EFAULT;
             return -1;
@@ -463,15 +466,22 @@ int UNIFYCR_WRAP(__fxstat)(int vers, int fd, struct stat *buf)
 {
     int ret = 0;
 
+    DEBUG("fxstat was called for fd %d....\n", fd);
+
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        if (vers != 3) {
+        if (vers != _STAT_VER) {
             errno = EINVAL;
             return -1;
         }
 
+        if (fd < 0) {
+            errno = EBADF;
+            return -1;
+        }
+
         if (!buf) {
-            errno = EFAULT;
+            errno = EINVAL;
             return -1;
         }
 
@@ -900,27 +910,20 @@ ssize_t UNIFYCR_WRAP(read)(int fd, void *buf, size_t count)
         /* read data from file */
         size_t retcount;
 
-        if (fs_type != UNIFYCR_LOG) {
-            int read_rc = unifycr_fd_read(fd, filedesc->pos, buf, count, &retcount);
-            if (read_rc != UNIFYCR_SUCCESS) {
-                errno = unifycr_err_map_to_errno(read_rc);
-                return (ssize_t) (-1);
-            }
+        read_req_t tmp_req;
 
-        } else {
-            read_req_t tmp_req;
-            tmp_req.buf = buf;
-            tmp_req.fid = fd + unifycr_fd_limit;
-            tmp_req.length = count;
-            tmp_req.offset = filedesc->pos;
+        tmp_req.buf = buf;
+        tmp_req.fid = fd + unifycr_fd_limit;
+        tmp_req.length = count;
+        tmp_req.offset = filedesc->pos;
 
-            int ret = unifycr_fd_logreadlist(&tmp_req, 1);
-            if (!ret) {
-                retcount = 0;
-            } else {
-                retcount = count;
-            }
-        }
+        int ret = unifycr_fd_logreadlist(&tmp_req, 1);
+
+        if (!ret)
+            retcount = 0;
+        else
+            retcount = count;
+
         /* update position */
         filedesc->pos += (off_t) retcount;
         /* return number of bytes read */
@@ -937,6 +940,8 @@ ssize_t UNIFYCR_WRAP(write)(int fd, const void *buf, size_t count)
 {
     ssize_t ret;
 
+    DEBUG("write was called for fd %d....\n", fd);
+
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
         /* get pointer to file descriptor structure */
@@ -947,24 +952,17 @@ ssize_t UNIFYCR_WRAP(write)(int fd, const void *buf, size_t count)
             return (ssize_t) (-1);
         }
 
-        if (fs_type != UNIFYCR_LOG) {
-            /* write data to file */
-            int write_rc = unifycr_fd_write(fd, filedesc->pos, buf, count);
-            if (write_rc != UNIFYCR_SUCCESS) {
-                errno = unifycr_err_map_to_errno(write_rc);
-                return (ssize_t) (-1);
-            }
-            ret = count;
-        } else {
-            fd += unifycr_fd_limit;
-            ret = pwrite(fd, buf, count, filedesc->pos);
-            /* pwrite() will set errno on error for us */
-            if (ret < 0)
-                return -1;
+        /* write data to file */
+        int write_rc = unifycr_fd_write(fd, filedesc->pos, buf, count);
+
+        if (write_rc != UNIFYCR_SUCCESS) {
+            errno = unifycr_err_map_to_errno(write_rc);
+            return (ssize_t) (-1);
         }
+        ret = count;
+
         /* update file position */
         filedesc->pos += ret;
-
     } else {
         MAP_OR_FAIL(write);
         ret = UNIFYCR_REAL(write)(fd, buf, count);
@@ -1513,26 +1511,20 @@ ssize_t UNIFYCR_WRAP(pread)(int fd, void *buf, size_t count, off_t offset)
         }
 
         size_t retcount;
-        if (fs_type != UNIFYCR_LOG) {
-            int read_rc = unifycr_fd_read(fd, offset, buf, count, &retcount);
-            if (read_rc != UNIFYCR_SUCCESS) {
-                errno = unifycr_err_map_to_errno(read_rc);
-                return (ssize_t) (-1);
-            }
-        } else {
-            read_req_t tmp_req;
-            tmp_req.buf = buf;
-            tmp_req.fid = fd + unifycr_fd_limit;
-            tmp_req.length = count;
-            tmp_req.offset = offset;
-            int read_rc =  unifycr_fd_logreadlist(&tmp_req, 1);
+        read_req_t tmp_req;
 
-            if (read_rc == 0) {
-                return count;
-            } else {
-                return 0;
-            }
-        }
+        tmp_req.buf = buf;
+        tmp_req.fid = fd + unifycr_fd_limit;
+        tmp_req.length = count;
+        tmp_req.offset = offset;
+
+        int read_rc =  unifycr_fd_logreadlist(&tmp_req, 1);
+
+        if (read_rc == 0)
+            return count;
+        else
+            return 0;
+
         /* return number of bytes read */
         return (ssize_t) retcount;
     } else {
@@ -1654,72 +1646,52 @@ int UNIFYCR_WRAP(fsync)(int fd)
             }
         }
 
-        if (fs_type == UNIFYCR_LOG) {
-            /*put indices to key-value store*/
-            int cmd = COMM_META;
-            memcpy(cmd_buf, &cmd, sizeof(int));
-            int flag = 3;
-            memcpy(cmd_buf + sizeof(int), &flag, sizeof(int));
-            int res = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
+        /*put indices to key-value store*/
+        int cmd = COMM_META;
+        int flag = 3;
+        int res = -1;
 
-            if (res != 0) {
-                int rc;
-                cmd_fd.events = POLLIN | POLLPRI;
-                cmd_fd.revents = 0;
+        memcpy(cmd_buf, &cmd, sizeof(int));
+        memcpy(cmd_buf + sizeof(int), &flag, sizeof(int));
 
-                rc = poll(&cmd_fd, 1, -1);
-                if (rc == 0) {
-                    /*time out event*/
-                } else if (rc > 0) {
-                    if (cmd_fd.revents != 0) {
-                        if (cmd_fd.revents == POLLIN) {
-                            int bytes_read = 0;
-                            bytes_read = __real_read(client_sockfd,
-                                                     cmd_buf, sizeof(cmd_buf));
-                            if (bytes_read == 0) {
+        res = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
+
+        if (res != 0) {
+            int rc;
+
+            cmd_fd.events = POLLIN | POLLPRI;
+            cmd_fd.revents = 0;
+
+            rc = poll(&cmd_fd, 1, -1);
+            if (rc == 0) {
+                /*time out event*/
+            } else if (rc > 0) {
+                if (cmd_fd.revents != 0) {
+                    if (cmd_fd.revents == POLLIN) {
+                        int bytes_read = 0;
+
+                        bytes_read = __real_read(client_sockfd,
+                                cmd_buf, sizeof(cmd_buf));
+                        if (bytes_read == 0) {
+                            return -1;
+                        } else {
+                            /**/
+                            if (*((int *)cmd_buf) != COMM_META ||
+                                    *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 return -1;
                             } else {
-                                /**/
-                                if (*((int *)cmd_buf) != COMM_META ||
-                                    *((int *)cmd_buf + 1) != ACK_SUCCESS) {
-                                    return -1;
-                                } else {
 
-                                }
                             }
-                        } else {
-                            return -1;
                         }
+                    } else {
+                        return -1;
                     }
-
-                } else {
-                    return -1;
                 }
+
+            } else {
+                return -1;
             }
-            /* TODO: if using spill over we may have some fsyncing to do */
-
-            /* nothing to do in our case */
-            return 0;
-        } else {
-            MAP_OR_FAIL(fsync);
-            int ret = UNIFYCR_REAL(fsync)(fd);
-            return ret;
         }
-    }
-
-
-
-
-    /* check whether we should intercept this file descriptor */
-    if (unifycr_intercept_fd(&fd)) {
-        /* get the file id for this file descriptor */
-        int fid = unifycr_get_fid_from_fd(fd);
-        if (fid < 0) {
-            /* ERROR: invalid file descriptor */
-            errno = EBADF;
-            return -1;
-        }
-
         /* TODO: if using spill over we may have some fsyncing to do */
 
         /* nothing to do in our case */

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -69,8 +69,12 @@ typedef struct {
     int rank;
 } name_rank_pair_t;
 
+#if 0
 int unifycr_mount(const char prefix[], int rank, size_t size,
                   int l_app_id, int subtype);
+#endif
+int unifycr_mount(const char prefix[], int rank, size_t size,
+                  int l_app_id);
 int unifycr_unmount(void);
 int compare_fattr(const void *a, const void *b);
 

--- a/client/tests/test_btio.c
+++ b/client/tests/test_btio.c
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
 	memset(buf, 0, elems_per_tile * SZ_PER_ELEM);
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	unifycr_mount("/tmp", rank, ranknum, 0, 1);
+	unifycr_mount("/tmp", rank, ranknum, 0);
 	MPI_Barrier(MPI_COMM_WORLD);
 
 	int fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);

--- a/client/tests/test_listread.c
+++ b/client/tests/test_listread.c
@@ -101,8 +101,7 @@ int main(int argc, char *argv[]) {
     struct aiocb **cb_list = (struct aiocb **)malloc (num_reqs * \
       sizeof (struct aiocb *)); /*list of read requests in lio_listio*/
 
-	unifycr_mount("/tmp", rank, rank_num,\
-	  		1, 1);
+	unifycr_mount("/tmp", rank, rank_num, 1);
 
 	if (pat == 1) {
 		sprintf(tmpfname, "%s%d", fname, rank);

--- a/client/tests/test_pread.c
+++ b/client/tests/test_pread.c
@@ -101,8 +101,7 @@ int main(int argc, char *argv[]) {
     struct aiocb **cb_list = (struct aiocb **)malloc (num_reqs * \
       sizeof (struct aiocb *)); /*list of read requests in lio_listio*/
 
-	unifycr_mount("/tmp", rank, rank_num,\
-	  		1, 1);
+	unifycr_mount("/tmp", rank, rank_num, 1);
 
 	if (pat == 1) {
 		sprintf(tmpfname, "%s%d", fname, rank);

--- a/client/tests/test_pwrite.c
+++ b/client/tests/test_pwrite.c
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
 		  }
 		}
 
-	unifycr_mount("/tmp", rank, rank_num, 0, 1);
+	unifycr_mount("/tmp", rank, rank_num, 0);
 
 	char *buf = malloc (tran_sz);
 	if (buf == NULL)

--- a/client/tests/test_read.c
+++ b/client/tests/test_read.c
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     struct aiocb **cb_list = (struct aiocb **)malloc (num_reqs * \
       sizeof (struct aiocb *)); /*list of read requests in lio_listio*/
 
-    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 1, 1);
+    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 1);
 
     if (mnt_success != 0 && rank == 0) {
         printf("unifycr mount call failed\n");

--- a/client/tests/test_tileio.c
+++ b/client/tests/test_tileio.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
 		memset(buf, 0, x_size * sz_per_elem);
 
 		MPI_Barrier(MPI_COMM_WORLD);
-		unifycr_mount("/tmp", rank, ranknum, 0, 1);
+		unifycr_mount("/tmp", rank, ranknum, 0);
 		MPI_Barrier(MPI_COMM_WORLD);
 
 		int fd;

--- a/client/tests/test_write.c
+++ b/client/tests/test_write.c
@@ -99,7 +99,7 @@ int main(int argc, char *argv[]) {
 		  }
 		}
 
-    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 0, 1);
+    int mnt_success = unifycr_mount("/tmp", rank, rank_num, 0);
 
     if (mnt_success != 0 && rank == 0) {
         printf("unifycr_mount call failed\n");

--- a/client/tests/test_writeread.c
+++ b/client/tests/test_writeread.c
@@ -100,7 +100,7 @@ int main(int argc, char *argv[]) {
 		  }
 		}
 
-	unifycr_mount("/tmp", rank, rank_num, 0, 1);
+	unifycr_mount("/tmp", rank, rank_num, 0);
 
 	char *buf = malloc (tran_sz);
 	if (buf == NULL)

--- a/t/sys/open.c
+++ b/t/sys/open.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
     /*
      * Verify unifycr_mount succeeds.
      */
-    rc = unifycr_mount(unifycr_root, rank, rank_num, 0, 1);
+    rc = unifycr_mount(unifycr_root, rank, rank_num, 0);
     ok(rc == 0, "unifycr_mount at %s (rc=%d)", unifycr_root, rc);
 
     testutil_rand_path(path, sizeof(path), unifycr_root);

--- a/t/unifycr_unmount.c
+++ b/t/unifycr_unmount.c
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     /*
      * Verify unifycr_mount succeeds.
      */
-    rc = unifycr_mount(unifycr_root, rank, rank_num, 0, 1);
+    rc = unifycr_mount(unifycr_root, rank, rank_num, 0);
     ok(rc == 0, "unifycr_mount at %s (rc=%d)", unifycr_root, rc);
 
     rc = unifycr_unmount();


### PR DESCRIPTION
This PR is to address #127, and partially #114.

- Removing the enum definition of fs_type_t, because UnifyCR technically
  assumes that it should always be UNIFYCR_LOG
- Removing the last argument (fs_type_t) in unifycr_mount()
- Modifying the test programs accordingly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
