### PR TITLE
Use posix_fallocate(3) instead of ftruncate(2) when possible

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([ftruncate getpagesize gettimeofday memset socket floor])
 AC_CHECK_FUNCS([gethostbyname strcasecmp strdup strerror strncasecmp strrchr])
-AC_CHECK_FUNCS([gethostname strstr strtoumax strtol uname])
+AC_CHECK_FUNCS([gethostname strstr strtoumax strtol uname posix_fallocate])
 
 # Debug build
 AC_ARG_ENABLE([debug],


### PR DESCRIPTION
Use posix_fallocate(3) instead of ftruncate(2) when possible for expanding the shared memory area.

### Description
- Adding the test of posix_fallocate(3) in configure.ac.
- Modifying the client/src/unifycr.c to use posix_fallocate(3) if available.

### Motivation and Context
This patch partially solves #59 and #72. When a system has `posix_fallocate(3)`, unifycr is built with the `posix_fallocate(3)` and gracefully fails if `/dev/shm` space is not sufficient. Currently, unifycr generates a runtime bus error in such a case.

IMO, the ultimate fix for this problem would be
- Use `posix_fallocate(3)` when available.
- Use traditional shm interface instead of posix shm_open/mmap interface, or
- Check the `/dev/shm` size with `statfs(2)` before calling `ftruncate(2)`?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)