### PR TITLE
add config option to control daemonization

### DIFF
--- a/common/src/unifycr_configurator.h
+++ b/common/src/unifycr_configurator.h
@@ -66,6 +66,7 @@
 #define UNIFYCR_CONFIGS \
     UNIFYCR_CFG_CLI(unifycr, configfile, STRING, SYSCONFDIR/unifycr/unifycr.conf, "path to configuration file", configurator_file_check, 'C', "specify full path to config file") \
     UNIFYCR_CFG_CLI(unifycr, consistency, STRING, LAMINATED, "consistency model", NULL, 'c', "specify consistency model (NONE | LAMINATED | POSIX)") \
+    UNIFYCR_CFG_CLI(unifycr, daemonize, BOOL, on, "enable server daemonization", NULL, 'D', "on|off") \
     UNIFYCR_CFG_CLI(unifycr, debug, BOOL, off, "enable debug output", NULL, 'd', "on|off") \
     UNIFYCR_CFG_CLI(unifycr, mountpoint, STRING, /unifycr, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYCR_CFG(client, max_files, INT, UNIFYCR_MAX_FILES, "client max file count", NULL) \

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -121,13 +121,18 @@ int main(int argc, char *argv[])
 {
     int provided;
     int rc;
+    bool daemon = true;
     char dbg_fname[UNIFYCR_MAX_FILENAME] = {0};
 
     rc = unifycr_config_init(&server_cfg, argc, argv);
     if (rc != 0)
         exit(1);
 
-    daemonize();
+    rc = configurator_bool_val(server_cfg.unifycr_daemonize, &daemon);
+    if (rc != 0)
+        exit(1);
+    if (daemon)
+        daemonize();
 
     rc = unifycr_write_runstate(&server_cfg);
     if (rc != (int)UNIFYCR_SUCCESS)


### PR DESCRIPTION

### Description
Adds a `unifycr.daemonize` config option, and corresponding CLI arg (`-D,--unifycr-daemonize <bool>`) to control whether the server attempts to daemonize. Default value is still "on", so use the CLI args to disable via `-Doff` or `--unifycr-daemonize=off`.

### Motivation and Context
This is a workaround for Issue #145 

### How Has This Been Tested?
Verified that CLI args properly control unifycrd behavior.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.