### PR TITLE
fixed read alignment bug

### DIFF
--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -1276,7 +1276,6 @@ int unifycr_match_received_ack(read_req_t *read_req, int count,
     read_req_t match_end = *match_req;
     read_req_t tmp_req_start, tmp_req_end;
     match_end.offset += match_end.length - 1;
-    char *src = match_req->buf + sizeof(shm_meta_t);
 
     int start_pos = unifycr_locate_req(read_req, count, &match_start);
     int end_pos = unifycr_locate_req(read_req, count, &match_end);
@@ -1309,7 +1308,7 @@ int unifycr_match_received_ack(read_req_t *read_req, int count,
 
 
         int copy_offset = match_start.offset - tmp_req_start.offset;
-        memcpy(tmp_req_start.buf + copy_offset, src,
+        memcpy(tmp_req_start.buf + copy_offset, match_req->buf,
                match_req->length);
 
         return 0;
@@ -1349,19 +1348,21 @@ int unifycr_match_received_ack(read_req_t *read_req, int count,
          * middle*/
         long copy_offset = match_start.offset - tmp_start_req_start.offset;
         long copy_length = tmp_start_req_end.offset - match_start.offset + 1;
-        memcpy(tmp_start_req_start.buf + copy_offset, src, copy_length);
+        memcpy(tmp_start_req_start.buf + copy_offset, match_req->buf,
+               copy_length);
 
 
         long cursor = copy_length;
         for (i = start_pos + 1; i < end_pos; i++) {
-            memcpy(read_req[i].buf, src + cursor, read_req[i].length);
-
+            memcpy(read_req[i].buf, match_req->buf + cursor,
+                   read_req[i].length);
             cursor += read_req[i].length;
         }
 
         copy_offset = 0;
         copy_length = match_end.offset - tmp_end_req_start.offset + 1;
-        memcpy(tmp_end_req_start.buf + copy_offset, src, copy_length);
+        memcpy(tmp_end_req_start.buf + copy_offset, match_req->buf,
+               copy_length);
 
         return 0;
     }

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -439,8 +439,8 @@ int rm_process_received_msg(int app_id, int sock_id,
 
         memcpy(2 * sizeof(int)
                + app_config->shm_recv_bufs[client_id] + *ptr_size,
-               (void *)tmp_recv_msg,
-               tmp_recv_msg->length + sizeof(recv_msg_t));
+               (void *)(tmp_recv_msg + 1),
+               tmp_recv_msg->length);
 
         *ptr_tot_sz -= tmp_recv_msg->length;
         recv_cursor += tmp_recv_msg->length;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Prior versions of UnifyCR and BurstFS had a bug in the rm_process_received_msg function (in unifycr_request_manager.c). The copy of the data from the MPI message buffer to the client's shared memory was mis-aligned, cause the results returned to be corrupted. The first 24 bytes of the returned read data contained the struct that preceded the data in the MPI message buffer, and the data was offset by 24 bytes.

An attempt to fix this defect was introduced to resolve issue #94.  However, this fix copies the data incorrectly, but it introduced a corresponding adjustment in the client code to accommodate the error. The result of this change was that data was written 24 bytes beyond the correct location, but it was then copied from shared memory into the client's read buffer by adjusting to this mis-alignment.

### Motivation and Context
This fix was originally pursued to fix the prior bug in a fork that predated the fix from #94. Upon discovering #94, the mis-alignment for the copy to shared memory in that fix was identified. Since the current dev branch did not work correctly with the fix to rm_process_received_msg in place, it became clear that a the client was adjusted to make the read work. Hence, this fix reverts the client code (in the unifycr_match_received_ack function in unifycr_sysio.c) to its prior state, and it also puts the correct code (the correct address to copy from and length to copy) into the server (rm_process_received_msg).

This fixes issue #139.

### How Has This Been Tested?

The test_write, test_read, and test_listread test programs were modified to test the fix:

1. Instrumented "test_write" program to set contents of 4k transfer writes to contain incremented byte values: 0,1,2,... (i.e., all zeros in the first write, all 1s in the second write, etc.)
2. Completed 128 transfers in the test program
3. Instrumented test_read to to verify content of reads.

The test_listread program was modified to request non-contiguous segments of a file, and tracing was used to verify that the fix was correct for an MPI message response with  more than one read result.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commit messages are properly formatted.
