### PR TITLE
Moving test programs in /client/tests to /examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-clocal.m4
+aclocal.m4
 autom4te.cache
 build
 config.*
@@ -53,12 +53,36 @@ util/unifycr/src/unifycr
 # generated package files
 client/unifycr-config
 client/unifycr.pc
+extras/unifycr.conf
+libtool
+m4/libtool.m4
+m4/ltoptions.m4
+m4/ltsugar.m4
+m4/ltversion.m4
+m4/lt~obsolete.m4
+meta/src/Mlog2/.dirstamp
+t/sys/.dirstamp
 
 # test files
 client/tests/test_read_gotcha
 client/tests/test_read_static
 client/tests/test_write_gotcha
 client/tests/test_write_static
+client/unifycr-runtime-config.h
+examples/src/app-btio-gotcha
+examples/src/app-btio-static
+examples/src/app-mpiio-gotcha
+examples/src/app-mpiio-static
+examples/src/sysio-read-gotcha
+examples/src/sysio-read-static
+examples/src/app-tileio-gotcha
+examples/src/app-tileio-static
+examples/src/sysio-write-gotcha
+examples/src/sysio-write-static
+examples/src/sysio-writeread-gotcha
+examples/src/sysio-writeread-static
+examples/src/sysio-writeread2-gotcha
+examples/src/sysio-writeread2-static
 t/sys/open.t
 t/test-results/
 t/unifycr_unmount.t

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = common meta server client extras t util
+SUBDIRS = common meta server client examples extras t util
 
 CONFIG = ordered
 

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_TYPES([ptrdiff_t])
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/socket.h sys/time.h])
 AC_CHECK_HEADERS([unistd.h arpa/inet.h inttypes.h netdb.h netinet/in.h])
-AC_CHECK_HEADERS([stddef.h stdint.h strings.h syslog.h])
+AC_CHECK_HEADERS([stddef.h stdint.h libgen.h strings.h syslog.h])
 AC_CHECK_HEADERS([inttypes.h wchar.h wctype.h])
 AC_CHECK_HEADER([openssl/md5.h], [], [AC_MSG_FAILURE([
         *** openssl/md5.h missing, openssl-devel package required])])
@@ -69,7 +69,7 @@ AC_ARG_ENABLE([debug],
 BUILD_DEBUG=no
 if test "x$enable_debug" = "xyes"; then
         BUILD_DEBUG=yes
-        CFLAGS=`echo $CFLAGS | sed -e s/O2/O0/`
+        CFLAGS=`echo $CFLAGS | sed -e s/O2/O1/`
 else
         BUILD_DEBUG=no
 fi
@@ -296,6 +296,8 @@ AC_CONFIG_FILES([Makefile
                  client/src/Makefile
                  client/tests/Makefile
                  client/unifycr.pc
+                 examples/Makefile
+                 examples/src/Makefile
                  extras/Makefile
                  extras/unifycr.conf
                  t/Makefile

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -1,0 +1,84 @@
+noinst_PROGRAMS = sysio-write-gotcha sysio-write-static \
+                  sysio-read-gotcha sysio-read-static \
+                  sysio-writeread-gotcha sysio-writeread-static \
+                  sysio-writeread2-gotcha sysio-writeread2-static \
+                  app-mpiio-gotcha app-mpiio-static \
+                  app-btio-gotcha app-btio-static \
+                  app-tileio-gotcha app-tileio-static
+
+noinst_HEADERS = testlib.h
+
+test_gotcha_ldadd = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm
+test_static_ldadd = $(top_builddir)/client/src/libunifycr.la -lrt -lm
+test_static_ldflags = -static $(CP_WRAPPERS) $(AM_LDFLAGS)
+test_cppflags = $(AM_CPPFLAGS) -I$(top_srcdir)/client/src
+
+sysio_write_gotcha_SOURCES = sysio-write.c
+sysio_write_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_write_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_write_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_write_static_SOURCES = sysio-write.c
+sysio_write_static_CPPFLAGS = $(test_cppflags)
+sysio_write_static_LDADD   = $(test_static_ldadd)
+sysio_write_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_read_gotcha_SOURCES = sysio-read.c
+sysio_read_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_read_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_read_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_read_static_SOURCES = sysio-read.c
+sysio_read_static_CPPFLAGS = $(test_cppflags)
+sysio_read_static_LDADD   = $(test_static_ldadd)
+sysio_read_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_writeread_gotcha_SOURCES = sysio-writeread.c
+sysio_writeread_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_writeread_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_writeread_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_writeread_static_SOURCES = sysio-writeread.c
+sysio_writeread_static_CPPFLAGS = $(test_cppflags)
+sysio_writeread_static_LDADD   = $(test_static_ldadd)
+sysio_writeread_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_writeread2_gotcha_SOURCES = sysio-writeread2.c
+sysio_writeread2_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_writeread2_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_writeread2_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_writeread2_static_SOURCES = sysio-writeread2.c
+sysio_writeread2_static_CPPFLAGS = $(test_cppflags)
+sysio_writeread2_static_LDADD   = $(test_static_ldadd)
+sysio_writeread2_static_LDFLAGS = $(test_static_ldflags)
+
+app_mpiio_gotcha_SOURCES = app-mpiio.c
+app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)
+app_mpiio_gotcha_LDADD   = $(test_gotcha_ldadd)
+app_mpiio_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+app_mpiio_static_SOURCES = app-mpiio.c
+app_mpiio_static_CPPFLAGS = $(test_cppflags)
+app_mpiio_static_LDADD   = $(test_static_ldadd)
+app_mpiio_static_LDFLAGS = $(test_static_ldflags)
+
+app_btio_gotcha_SOURCES = app-btio.c
+app_btio_gotcha_CPPFLAGS = $(test_cppflags)
+app_btio_gotcha_LDADD   = $(test_gotcha_ldadd)
+app_btio_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+app_btio_static_SOURCES = app-btio.c
+app_btio_static_CPPFLAGS = $(test_cppflags)
+app_btio_static_LDADD   = $(test_static_ldadd)
+app_btio_static_LDFLAGS = $(test_static_ldflags)
+
+app_tileio_gotcha_SOURCES = app-tileio.c
+app_tileio_gotcha_CPPFLAGS = $(test_cppflags)
+app_tileio_gotcha_LDADD   = $(test_gotcha_ldadd)
+app_tileio_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+app_tileio_static_SOURCES = app-tileio.c
+app_tileio_static_CPPFLAGS = $(test_cppflags)
+app_tileio_static_LDADD   = $(test_static_ldadd)
+app_tileio_static_LDFLAGS = $(test_static_ldflags)

--- a/examples/src/app-btio.c
+++ b/examples/src/app-btio.c
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Teng Wang, Adam Moody, Weikuan Yu, Kento Sato, Kathryn Mohror
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * code Written by
+ *   Raghunath Rajachandrasekar <rajachan@cse.ohio-state.edu>
+ *   Kathryn Mohror <kathryn@llnl.gov>
+ *   Adam Moody <moody20@llnl.gov>
+ * All rights reserved.
+ * This file is part of CRUISE.
+ * For details, see https://github.com/hpc/cruise
+ * Please also read this file LICENSE.CRUISE
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mpi.h>
+#include <math.h>
+#include <sys/time.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <aio.h>
+#include <strings.h>
+#include <unifycr.h>
+
+#define GEN_STR_LEN 1024
+#define SZ_PER_ELEM 40 /*size of each data point in BTIO*/
+
+struct timeval readstart, readend;
+double readtime;
+
+struct timeval writestart, writeend;
+double writetime;
+
+struct timeval metastart, metaend;
+double metatime;
+
+struct timeval fsync_data_start, fsync_data_end;
+
+struct timeval fsync_metadata_start, fsync_metadata_end;
+
+double interval;
+
+typedef struct {
+    int fid;
+    long offset;
+    long length;
+    char *buf;
+
+} read_req_t;
+
+int main(int argc, char *argv[])
+{
+    static const char *opts = "g:d:f:";
+
+    int direction = 0, ranknum, rank, dir;
+    long nr_grid_points = 0;
+    char fname[GEN_STR_LEN] = {0};
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &ranknum);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    int c;
+
+    while ((c = getopt(argc, argv, opts)) != -1) {
+        switch (c) {
+        case 'g': /* number of elements in each dimension. Adjust this value to
+                   * generate various problem sizes
+                   */
+            nr_grid_points = atol(optarg); break;
+        case 'd': /* 0: write then read 1: only write*/
+            direction = atoi(optarg); break;
+        case 'f':
+            strcpy(fname, optarg); break;
+        default:
+            return -1;
+        }
+    }
+
+    long **cell_coord, **cell_size, **cell_low, **cell_high;
+    long nr_tiles; //# of tiles per dimension
+    int dim = 3;
+
+    nr_tiles = sqrt(ranknum); /* for Block-Triangle (BT) partitioning in BTIO,
+                               * the number of tiles per dimension is the
+                               * square root of rank count
+                               */
+
+    long nr_tiles_per_proc = nr_tiles; /* the number of cubic cells per proc is
+                                        * nr_tiles
+                                        */
+
+    cell_coord = (long **) malloc(nr_tiles_per_proc * sizeof(long *));
+    cell_size = (long **) malloc(nr_tiles_per_proc * sizeof(long *));
+    cell_low = (long **) malloc(nr_tiles_per_proc * sizeof(long *));
+    cell_high = (long **) malloc(nr_tiles_per_proc * sizeof(long *));
+
+
+    /*The following lines generate the coordinates for each cell in
+     * BT partitioning
+     */
+    long i, j;
+
+    for (i = 0; i < nr_tiles_per_proc; i++) {
+        cell_coord[i] = (long *) malloc(dim * sizeof(long));
+        cell_size[i] = (long *) malloc(dim * sizeof(long));
+        cell_low[i] = (long *) malloc(dim * sizeof(long));
+        cell_high[i] = (long *) malloc(dim * sizeof(long));
+    }
+
+    cell_coord[0][0] = rank%nr_tiles;
+    cell_coord[0][1] = rank/nr_tiles;
+    cell_coord[0][2] = 0;
+
+    for (c = 1; c < nr_tiles; c++) {
+        cell_coord[c][0] = (cell_coord[c-1][0]+1)%nr_tiles;
+        cell_coord[c][1] = (cell_coord[c-1][1]-1+nr_tiles)%nr_tiles;
+        cell_coord[c][2] = c;
+    }
+
+    for (dir = 0; dir < dim; dir++)
+        for (c = 0; c < nr_tiles; c++)
+            cell_coord[c][dir] = cell_coord[c][dir] + 1;
+
+    long elems_per_tile;
+
+    for (dir = 0; dir < dim; dir++) {
+        elems_per_tile = nr_grid_points/nr_tiles;
+
+        for (c = 0; c < nr_tiles_per_proc; c++) {
+            cell_size[c][dir] = elems_per_tile;
+            cell_low[c][dir] = (cell_coord[c][dir] - 1)*elems_per_tile;
+            cell_high[c][dir] = cell_low[c][dir] + elems_per_tile - 1;
+        }
+    }
+
+    /* calculate the number of I/O requests of writing these 3D cells */
+    long num_reqs = elems_per_tile * elems_per_tile * nr_tiles_per_proc;
+
+    read_req_t *r_w_reqs = (read_req_t *) malloc(num_reqs*sizeof(read_req_t));
+
+    /*initialize these I/O requests */
+    long cursor = 0, tot_sz;
+
+    for (c = 0; c < nr_tiles_per_proc; c++) {
+        for (i = cell_low[c][2]; i <= cell_high[c][2]; i++) {
+            for (j = cell_low[c][1]; j <= cell_high[c][1]; j++) {
+                r_w_reqs[cursor].offset = (cell_low[c][0] + j*nr_grid_points
+                        + i*nr_grid_points*nr_grid_points)*SZ_PER_ELEM;
+                r_w_reqs[cursor].length = elems_per_tile*SZ_PER_ELEM;
+                cursor++;
+            }
+        }
+    }
+    tot_sz = nr_grid_points * nr_grid_points * nr_grid_points * SZ_PER_ELEM;
+
+    char *buf = malloc(elems_per_tile * SZ_PER_ELEM);
+
+    memset(buf, 0, elems_per_tile * SZ_PER_ELEM);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    unifycr_mount("/tmp", rank, ranknum, 0);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0600);
+
+    if (fd < 0) {
+        printf("rank:%d, open failure.\n", rank);
+        fflush(stdout);
+    }
+
+    gettimeofday(&writestart, NULL);
+
+    long rc;
+
+    for (i = 0; i < num_reqs; i++) {
+        rc = pwrite(fd, buf, r_w_reqs[i].length, r_w_reqs[i].offset);
+
+        if (rc < 0) {
+            printf("rank:%d, write error\n", rank);
+            fflush(stdout);
+        }
+    }
+    gettimeofday(&metastart, NULL);
+    fsync(fd);
+    gettimeofday(&metaend, NULL);
+    metatime += 1000000*(metaend.tv_sec-metastart.tv_sec)
+                + metaend.tv_usec - metastart.tv_usec;
+    metatime /= 1000000;
+
+    gettimeofday(&writeend, NULL);
+    writetime += 1000000*(writeend.tv_sec-writestart.tv_sec)
+                 + writeend.tv_usec - writestart.tv_usec;
+    writetime = writetime/1000000;
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    double wr_bw = (double) tot_sz/ranknum/1048576/writetime;
+    double aggwrbw;
+    double max_wr_time;
+
+    MPI_Reduce(&wr_bw, &aggwrbw, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&writetime, &max_wr_time, 1, MPI_DOUBLE, MPI_MAX,
+               0, MPI_COMM_WORLD);
+
+    double min_wr_bw;
+
+    min_wr_bw = (double) tot_sz/1048576/max_wr_time;
+
+    if (direction != 0) {/*only write without reading*/
+        close(fd);
+        if (rank == 0) {
+            unifycr_unmount();
+            printf("Aggregated Write BW is %lf, Min Write BW is %lf\n",
+                    aggwrbw, min_wr_bw);
+            fflush(stdout);
+        }
+    }
+
+    if (direction == 0) {
+        struct aiocb *aiocb_list = (struct aiocb *) malloc(num_reqs *
+                                      sizeof(struct aiocb));
+        struct aiocb **cb_list = (struct aiocb **) malloc(num_reqs *
+                                    sizeof(struct aiocb *));
+        char *read_buf = (char *) malloc(tot_sz/ranknum);
+
+        memset(read_buf, 0, tot_sz/ranknum);
+        gettimeofday(&readstart, NULL);
+        cursor = 0;
+
+        for (i = 0; i < num_reqs; i++) {
+            aiocb_list[cursor].aio_fildes = fd;
+            aiocb_list[cursor].aio_buf = read_buf +
+                                         i * elems_per_tile * SZ_PER_ELEM;
+            aiocb_list[cursor].aio_nbytes = r_w_reqs[cursor].length;
+            aiocb_list[cursor].aio_offset = r_w_reqs[cursor].offset;
+            aiocb_list[cursor].aio_lio_opcode = LIO_READ;
+            cb_list[cursor] = &aiocb_list[cursor];
+            cursor++;
+        }
+
+        int ret = lio_listio(LIO_WAIT, cb_list, num_reqs, NULL);
+
+        if (ret < 0) {
+            perror("lio_listio");
+            exit(-1);
+        }
+
+        gettimeofday(&readend, NULL);
+        readtime = (readend.tv_sec - readstart.tv_sec)*1000000
+                   + readend.tv_usec - readstart.tv_usec;
+        readtime = readtime/1000000;
+        close(fd);
+        MPI_Barrier(MPI_COMM_WORLD);
+
+        if (rank == 0)
+            unifycr_unmount();
+
+        free(aiocb_list);
+        free(cb_list);
+
+        double aggrdbw;
+        double rd_bw = (double)tot_sz/ranknum/1048576/readtime;
+        double max_rd_time;
+
+        MPI_Reduce(&rd_bw, &aggrdbw, 1, MPI_DOUBLE, MPI_SUM,
+                   0, MPI_COMM_WORLD);
+        MPI_Reduce(&readtime, &max_rd_time, 1, MPI_DOUBLE, MPI_MAX,
+                   0, MPI_COMM_WORLD);
+
+        double min_rd_bw;
+
+        min_rd_bw = (double) tot_sz/1048576/max_rd_time;
+
+        if (rank == 0) {
+            printf("Aggregated Read BW is %lfMB/s\n"
+                   "Aggregated Write BW is %lf, Min Read BW is %lf\n"
+                   "Min Write BW is %lf\n",
+                   aggrdbw, aggwrbw, min_rd_bw, min_wr_bw);
+            fflush(stdout);
+        }
+    }
+
+    free(r_w_reqs);
+    free(buf);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+static uint64_t blocksize = 1<<20;          /* 1MB */
+static uint64_t nblocks = 128;              /* Each process writes 128MB */
+static uint64_t chunksize = 64*(1<<10);     /* 64KB for each write(2) call */
+
+static int type;            /* 0 for write (default), 1 for read */
+static int pattern;         /* N to 1 (N1, default) or N to N (NN) */
+static MPI_File fh;         /* MPI file handle */
+static MPI_Status status;   /* MPI I/O status */
+static int iomode = MPI_MODE_CREATE | MPI_MODE_RDWR;
+
+static int standard;        /* not mounting unifycr when set */
+
+/* time statistics */
+static struct timeval iostart, ioend;
+
+#define BUFSIZE 128
+static char hostname[BUFSIZE];
+static int rank;
+static int total_ranks;
+
+static int debug;                   /* pause for attaching debugger */
+static int unmount;                 /* unmount unifycr after test */
+static char *buf;                   /* I/O buffer */
+static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *filename = "testfile"; /* testfile name under mountpoint */
+static char targetfile[NAME_MAX];   /* target file name */
+
+/* MPI checker
+ * from: https://stackoverflow.com/questions/22859269/
+ */
+static int mpierror;
+
+static inline void mpi_handle_error(int err, char *str)
+{
+    char msg[MPI_MAX_ERROR_STRING];
+    int len = 0;
+
+    MPI_Error_string(err, msg, &len);
+    fprintf(stderr, "[%s:%d] %s: %s\n", hostname, rank, str, msg);
+
+    mpierror = 1;
+}
+
+#define MPI_CHECK(fn) do {                                      \
+            int err = (fn);                                     \
+            if (err != MPI_SUCCESS)                             \
+                mpi_handle_error(err, #fn);                     \
+        } while (0)
+
+static int read_test_type(const char *str)
+{
+    if (strcmp("write", str) == 0)
+        return 0;
+    else if (strcmp("read", str) == 0) {
+        iomode = MPI_MODE_RDONLY;
+        return 1;
+    } else
+        return -1;
+}
+
+static int do_write(MPI_File *fh)
+{
+    int ret = 0;
+    uint64_t i, j, offset;
+    uint64_t nchunks = blocksize / chunksize;
+
+    gettimeofday(&iostart, NULL);
+
+    for (i = 0; i < nblocks; i++) {
+        for (j = 0; j < nchunks; j++) {
+            if (pattern == IO_PATTERN_N1)
+                offset = i*total_ranks*blocksize + rank*blocksize
+                         + j*chunksize;
+            else
+                offset = i*blocksize + j*chunksize;
+
+            MPI_CHECK(MPI_File_seek(*fh, offset, MPI_SEEK_SET));
+            MPI_CHECK(MPI_File_write(*fh, buf, chunksize, MPI_CHAR, &status));
+
+            if (mpierror)
+                goto out;
+        }
+    }
+
+out:
+    MPI_File_close(fh);
+
+    gettimeofday(&ioend, NULL);
+
+    return ret;
+}
+
+static int do_read(MPI_File *fh)
+{
+    int ret = 0;
+    uint64_t i, j, offset;
+    uint64_t nchunks = blocksize / chunksize;
+
+    gettimeofday(&iostart, NULL);
+
+    for (i = 0; i < nblocks; i++) {
+        for (j = 0; j < nchunks; j++) {
+            if (pattern == IO_PATTERN_N1)
+                offset = i*total_ranks*blocksize + rank*blocksize
+                         + j*chunksize;
+            else
+                offset = i*blocksize + j*chunksize;
+
+            MPI_CHECK(MPI_File_seek(*fh, offset, MPI_SEEK_SET));
+            MPI_CHECK(MPI_File_read(*fh, buf, chunksize, MPI_CHAR, &status));
+
+            if (mpierror)
+                goto out;
+        }
+    }
+
+out:
+    MPI_File_close(fh);
+
+    gettimeofday(&ioend, NULL);
+
+    return ret;
+}
+
+static void report_result(void)
+{
+    double io_bw = .0F;
+    double agg_io_bw = .0F;
+    double max_io_time = .0F;
+    double min_io_bw = .0F;
+    double io_time = .0F;
+
+    io_time = timediff_sec(&iostart, &ioend);
+    io_bw = 1.0*blocksize*nblocks/io_time/(1<<20);
+
+    MPI_Reduce(&io_bw, &agg_io_bw,
+               1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&io_time, &max_io_time,
+               1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+    min_io_bw = 1.0*blocksize*nblocks*total_ranks/max_io_time/(1<<20);
+
+    errno = 0;
+
+    test_print_once(rank,
+                    "\n"
+                    "Number of processes:     %d\n"
+                    "I/O type:                %s\n"
+                    "Each process performed:  %lf MB\n"
+                    "Total I/O size:          %lf MB\n"
+                    "I/O pattern:             %s\n"
+                    "I/O request size:        %llu B\n"
+                    "Aggregate I/O bandwidth: %lf MB/s\n"
+                    "Min. I/O bandwidth:      %lf MB/s\n"
+                    "Total I/O time:          %lf sec.\n\n",
+                    total_ranks,
+                    type ? "read" : "write",
+                    1.0*blocksize*nblocks/(1<<20),
+                    1.0*total_ranks*blocksize*nblocks/(1<<20),
+                    io_pattern_string(pattern),
+                    chunksize,
+                    agg_io_bw,
+                    min_io_bw,
+                    max_io_time);
+}
+
+static struct option const long_opts[] = {
+    { "blocksize", 1, 0, 'b' },
+    { "nblocks", 1, 0, 'n' },
+    { "chunksize", 1, 0, 'c' },
+    { "debug", 0, 0, 'd' },
+    { "filename", 1, 0, 'f' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "pattern", 1, 0, 'p' },
+    { "standard", 0, 0, 's' },
+    { "type", 1, 0, 't' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "b:n:c:df:hm:p:Pst:u";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...]\n"
+"\n"
+"Available options:\n"
+" -b, --blocksize=<size in bytes>  logical block size for the target file\n"
+"                                  (default 1048576, 1MB)\n"
+" -n, --nblocks=<count>            count of blocks each process will write\n"
+"                                  (default 128)\n"
+" -c, --chunksize=<size in bytes>  I/O chunk size for each write operation\n"
+"                                  (default 64436, 64KB)\n"
+" -d, --debug                      pause before running test\n"
+"                                  (handy for attaching in debugger)\n"
+" -f, --filename=<filename>        target file name (default: testfile)\n"
+" -h, --help                       help message\n"
+" -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+"                                  (default: /tmp)\n"
+" -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
+" -s, --standard                   do not use unifycr but run standard I/O\n"
+" -t, --type=<write|read>          I/O type\n"
+"                                  should be 'write' (default) or 'read'\n"
+" -u, --unmount                    unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 2;
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    gethostname(hostname, BUFSIZE);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'b':
+            blocksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'n':
+            nblocks = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'c':
+            chunksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'f':
+            filename = strdup(optarg);
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'p':
+            pattern = read_io_pattern(optarg);
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 's':
+            standard = 1;
+            break;
+
+        case 't':
+            type = read_test_type(optarg);
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (type == -1) {
+        test_print_once(rank, "type should be 'write' or 'read'\n");
+        exit(-1);
+    }
+
+    if (blocksize < chunksize || blocksize % chunksize > 0) {
+        test_print_once(rank, "blocksize should be larger than "
+                              "and divisible by chunksize.\n");
+        exit(-1);
+    }
+
+    sprintf(targetfile, "%s/%s", mountpoint, filename);
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    if (!standard) {
+        ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+        if (ret) {
+            test_print(rank, "unifycr_mount failed (return = %d)", ret);
+            exit(-1);
+        }
+    }
+
+    buf = calloc(1, chunksize);
+    if (!buf) {
+        test_print(rank, "calloc failed");
+        exit(-1);
+    }
+
+    if (pattern == IO_PATTERN_NN)
+        sprintf(&targetfile[strlen(targetfile)], "-%d", rank);
+
+    if (!standard)
+        printf("[%d]: unifycr mounted at %s\n", rank, mountpoint);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    printf("[%d]: opening %s\n", rank, targetfile);
+
+    MPI_CHECK(MPI_File_open(MPI_COMM_WORLD,
+                            targetfile,
+                            iomode,
+                            MPI_INFO_NULL, &fh));
+
+    if (debug)
+        test_pause(rank, "Attempting to perform I/O");
+
+    if (type == 0)
+        ret = do_write(&fh);
+    else
+        ret = do_read(&fh);
+
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (!standard && unmount && rank == 0)
+        unifycr_unmount();
+
+    if (ret == 0)
+        report_result();
+    else
+        MPI_Abort(MPI_COMM_WORLD, 1);
+
+    free(buf);
+
+    MPI_Finalize();
+
+    return ret;
+}

--- a/examples/src/app-tileio.c
+++ b/examples/src/app-tileio.c
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Teng Wang, Adam Moody, Weikuan Yu, Kento Sato, Kathryn Mohror
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * code Written by
+ *   Raghunath Rajachandrasekar <rajachan@cse.ohio-state.edu>
+ *   Kathryn Mohror <kathryn@llnl.gov>
+ *   Adam Moody <moody20@llnl.gov>
+ * All rights reserved.
+ * This file is part of CRUISE.
+ * For details, see https://github.com/hpc/cruise
+ * Please also read this file LICENSE.CRUISE
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mpi.h>
+#include <math.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <mpi.h>
+#include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <aio.h>
+#include <strings.h>
+#include <unifycr.h>
+
+#define GEN_STR_LEN 1024
+
+struct timeval readstart, readend;
+double readtime;
+
+struct timeval writestart, writeend;
+double writetime;
+
+struct timeval metastart, metaend;
+double metatime;
+
+struct timeval fsync_data_start, fsync_data_end;
+
+struct timeval fsync_metadata_start, fsync_metadata_end;
+
+double interval;
+
+typedef struct {
+    int fid;
+    long offset;
+    long length;
+    char *buf;
+
+} read_req_t;
+
+static const char *opts = "h:v:d:f:p:n:";
+
+int main(int argc, char *argv[])
+{
+    int direction = 0, ranknum, rank;
+    long h_grid_points = 0, v_grid_points = 0;
+    char fname[GEN_STR_LEN] = {0};
+    int sz_per_elem = 0;
+    int r_ranks = 0; //, c_ranks;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &ranknum);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    int c;
+
+    while ((c = getopt(argc, argv, opts)) != -1) {
+        switch (c)  {
+        case 'h': /*number of elements along horizontal direction*/
+            h_grid_points = atol(optarg); break;
+        case 'v': /*number of elements along vertical direction*/
+            v_grid_points = atol(optarg); break;
+        case 'n': /*number of ranks along the x dimension*/
+            r_ranks = atoi(optarg); break;
+        case 'd': /*0: read 1: write*/
+            direction = atoi(optarg); break;
+        case 'f':
+            strcpy(fname, optarg); break;
+        case 'p': /*size of each elements*/
+            sz_per_elem = atoi(optarg); break;
+        default:
+            return -1;
+        }
+    }
+
+    long nr_r_tiles; //, nr_c_tiles; //# of tiles per dimension
+    //int dim = 2;
+
+    nr_r_tiles = r_ranks; /* number of tiles on each row, each rank has one
+                           * tile
+                           */
+#if 0
+    nr_c_tiles = ranknum / r_ranks;/* number of tiles on each column, each rank
+                                    * has one tile
+                                    */
+#endif
+
+    long i;
+    long x_low, y_low;
+    //long x_high, y_high;
+    long y_high;
+    long x_size, y_size;
+
+    /*The following determines the coordinate*/
+    x_low = rank % nr_r_tiles;
+    y_low = rank / nr_r_tiles;
+
+    x_size = h_grid_points / r_ranks;
+    y_size = v_grid_points / (ranknum / r_ranks);
+    x_low = x_low * x_size;
+    y_low = y_low * y_size;
+    //x_high = x_low + x_size - 1;
+    y_high = y_low + y_size - 1;
+
+    long num_reqs = y_size; /*number of I/O requests*/
+
+    read_req_t *r_w_reqs = (read_req_t *) malloc(num_reqs*sizeof(read_req_t));
+
+    /*initialize the I/O requests*/
+    long cursor = 0, tot_sz;
+
+    for (i = y_low; i <= y_high; i++) {
+        r_w_reqs[cursor].offset = (x_low + h_grid_points * i) * sz_per_elem;
+        r_w_reqs[cursor].length = x_size * sz_per_elem;
+        cursor++;
+    }
+    tot_sz = v_grid_points * h_grid_points * sz_per_elem;
+
+    char *buf = malloc(x_size * sz_per_elem);
+
+    memset(buf, 0, x_size * sz_per_elem);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    unifycr_mount("/tmp", rank, ranknum, 0);
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    int fd;
+
+    fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0600);
+
+    if (fd < 0) {
+        printf("rank:%d, open failure\n", rank);
+        fflush(stdout);
+    }
+
+    gettimeofday(&writestart, NULL);
+
+    long rc;
+
+    for (i = 0; i < num_reqs; i++) {
+        rc = pwrite(fd, buf, r_w_reqs[i].length, r_w_reqs[i].offset);
+        if (rc < 0) {
+            printf("rank:%d, write failure\n", rank);
+            fflush(stdout);
+        }
+
+    }
+    gettimeofday(&metastart, NULL);
+    fsync(fd);
+    gettimeofday(&metaend, NULL);
+
+    metatime += 1000000*(metaend.tv_sec-metastart.tv_sec)
+                + metaend.tv_usec - metastart.tv_usec;
+    metatime /= 1000000;
+
+    gettimeofday(&writeend, NULL);
+
+    writetime += 1000000*(writeend.tv_sec - writestart.tv_sec)
+                + writeend.tv_usec - writestart.tv_usec;
+
+    writetime = writetime / 1000000;
+
+    if (direction == 1) {
+        if (rank == 0)
+            unifycr_unmount();
+        close(fd);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    double wr_bw = (double) tot_sz/ranknum/1048576/writetime;
+    double aggrdbw;
+    double aggwrbw;
+    double max_wr_time;
+    double min_wr_bw;
+
+    MPI_Reduce(&wr_bw, &aggwrbw, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&writetime, &max_wr_time, 1, MPI_DOUBLE, MPI_MAX,
+               0, MPI_COMM_WORLD);
+
+    min_wr_bw = (double) tot_sz/1048576/max_wr_time;
+
+    if (direction == 1) {
+        if (rank == 0) {
+            printf("Aggregated Write BW is %lf, Min Write BW is %lf\n",
+                    aggwrbw, min_wr_bw);
+            fflush(stdout);
+        }
+    }
+
+    char  *read_buf;
+
+    if (direction == 0) {
+        struct aiocb *aiocb_list = (struct aiocb *) malloc(num_reqs *
+                                   sizeof(struct aiocb));
+        struct aiocb **cb_list = (struct aiocb **) malloc(num_reqs *
+                                  sizeof(struct aiocb *));
+
+        read_buf = (char *) malloc(tot_sz/ranknum);
+        memset(read_buf, 0, tot_sz/ranknum);
+
+        gettimeofday(&readstart, NULL);
+        cursor = 0;
+
+        for (i = 0; i < num_reqs; i++) {
+            aiocb_list[cursor].aio_fildes = fd;
+            aiocb_list[cursor].aio_buf = read_buf + i*x_size*sz_per_elem;
+            aiocb_list[cursor].aio_nbytes = r_w_reqs[cursor].length;
+            aiocb_list[cursor].aio_offset = r_w_reqs[cursor].offset;
+            aiocb_list[cursor].aio_lio_opcode = LIO_READ;
+            cb_list[cursor] = &aiocb_list[cursor];
+            cursor++;
+        }
+
+        int ret = lio_listio(LIO_WAIT, cb_list, num_reqs, NULL);
+
+        if (ret < 0) {
+            perror("lio_listio");
+            exit(-1);
+        }
+
+        gettimeofday(&readend, NULL);
+        readtime = (readend.tv_sec - readstart.tv_sec)*1000000
+                   + readend.tv_usec - readstart.tv_usec;
+        readtime = readtime/1000000;
+
+        MPI_Barrier(MPI_COMM_WORLD);
+        close(fd);
+
+        if (rank == 0)
+            unifycr_unmount();
+
+        double rd_bw = (double)tot_sz/ranknum/1048576/readtime;
+        double max_rd_time;
+        double min_rd_bw;
+
+        MPI_Reduce(&rd_bw, &aggrdbw, 1, MPI_DOUBLE, MPI_SUM,
+                   0, MPI_COMM_WORLD);
+        MPI_Reduce(&readtime, &max_rd_time, 1, MPI_DOUBLE, MPI_MAX,
+                   0, MPI_COMM_WORLD);
+
+        min_rd_bw = (double) tot_sz/1048576/max_rd_time;
+
+        if (rank == 0) {
+            printf("Aggregated Read BW is %lfMB/s\n"
+                   "Aggregated Write BW is %lf, Min Read BW is %lf\n"
+                   "Min Write BW is %lf\n",
+                   aggrdbw, aggwrbw, min_rd_bw, min_wr_bw);
+            fflush(stdout);
+        }
+
+        free(read_buf);
+        free(aiocb_list);
+        free(cb_list);
+    }
+
+    free(r_w_reqs);
+    free(buf);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/examples/src/sysio-read.c
+++ b/examples/src/sysio-read.c
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <aio.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+static uint64_t blocksize = 1<<20;          /* 1MB */
+static uint64_t nblocks = 128;              /* Each process reads 128MB */
+static uint64_t chunksize = 64*(1<<10);     /* 64KB for each read(2) call */
+
+static int use_listio;      /* use lio_listio(2) */
+static int use_pread;       /* use pread(2) */
+static int pattern;         /* N to 1 (N1, default) or N to N (NN) */
+static int fd;              /* target file descriptor */
+
+static int standard;        /* not mounting unifycr when set */
+
+/* time statistics */
+static struct timeval read_start, read_end;
+
+static int rank;
+static int total_ranks;
+
+static int debug;           /* pause for attaching debugger */
+static int unmount;         /* unmount unifycr after running the test */
+static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *filename = "testfile"; /* testfile name under mountpoint */
+static char targetfile[NAME_MAX];   /* target file name */
+
+static char *buf;                   /* I/O buffer */
+static uint64_t n_aiocb_list;       /* number of aio requests */
+static struct aiocb **aiocb_list;   /* aio request list */
+static struct aiocb *aiocb_items;   /* aio requests */
+
+static int do_read(void)
+{
+    int ret = 0;
+    uint64_t i, j, offset;
+    uint64_t nchunks = blocksize / chunksize;
+
+    gettimeofday(&read_start, NULL);
+
+    for (i = 0; i < nblocks; i++) {
+        for (j = 0; j < nchunks; j++) {
+            if (pattern == IO_PATTERN_N1)
+                offset = i*total_ranks*blocksize + rank*blocksize
+                         + j*chunksize;
+            else
+                offset = i*blocksize + j*chunksize;
+
+            if (use_pread)
+                ret = pread(fd, buf, chunksize, offset);
+            else {
+                lseek(fd, offset, SEEK_SET);
+                ret = read(fd, buf, chunksize);
+            }
+
+            if (ret < 0) {
+                test_print(rank, "%s failed",
+                                 use_pread ? "pread()" : "read()");
+                return -1;
+            }
+        }
+    }
+
+    gettimeofday(&read_end, NULL);
+
+    return 0;
+}
+
+static int do_listread(void)
+{
+    int ret = 0;
+    uint64_t i, j;
+    uint64_t nchunks = blocksize / chunksize;
+    uint64_t current_ix = 0;
+    struct aiocb *current = NULL;
+
+    gettimeofday(&read_start, NULL);
+
+    for (i = 0; i < nblocks; i++) {
+        for (j = 0; j < nchunks; j++) {
+            current_ix = i*nchunks + j;
+
+            current = &aiocb_items[current_ix];
+            aiocb_list[current_ix] = current;
+
+            current->aio_fildes = fd;
+            current->aio_buf = &buf[current_ix*chunksize];
+            current->aio_nbytes = chunksize;
+            current->aio_lio_opcode = LIO_READ;
+
+            if (pattern == IO_PATTERN_N1)
+                current->aio_offset = i*total_ranks*blocksize
+                                      + rank*blocksize + j*chunksize;
+            else
+                current->aio_offset = i*blocksize + j*chunksize;
+        }
+    }
+
+    ret = lio_listio(LIO_WAIT, aiocb_list, n_aiocb_list, NULL);
+    if (ret < 0) {
+        test_print(rank, "lio_listio failed");
+        return -1;
+    }
+
+    gettimeofday(&read_end, NULL);
+
+    return ret;
+}
+
+static void report_result(void)
+{
+    double read_bw = .0F;
+    double agg_read_bw = .0F;
+    double max_read_time = .0F;
+    double min_read_bw = .0F;
+    double read_time = .0F;
+
+    read_time = timediff_sec(&read_start, &read_end);
+    read_bw = 1.0*blocksize*nblocks/read_time/(1<<20);
+
+    MPI_Reduce(&read_bw, &agg_read_bw,
+               1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&read_time, &max_read_time,
+               1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+    min_read_bw = 1.0*blocksize*nblocks*total_ranks
+                    /max_read_time/(1<<20);
+
+    test_print_once(rank,
+                    "\n"
+                    "Number of processes:      %d\n"
+                    "Each process wrote:       %lf MB\n"
+                    "Total reads:              %lf MB\n"
+                    "I/O pattern:              %s\n"
+                    "I/O request size:         %llu B\n"
+                    "Aggregate read bandwidth: %lf MB/s\n"
+                    "Min. read bandwidth:      %lf MB/s\n"
+                    "Total Read time:          %lf sec.\n\n",
+                    total_ranks,
+                    1.0*blocksize*nblocks/(1<<20),
+                    1.0*total_ranks*blocksize*nblocks/(1<<20),
+                    io_pattern_string(pattern),
+                    chunksize,
+                    agg_read_bw,
+                    min_read_bw,
+                    max_read_time);
+}
+
+static struct option const long_opts[] = {
+    { "blocksize", 1, 0, 'b' },
+    { "nblocks", 1, 0, 'n' },
+    { "chunksize", 1, 0, 'c' },
+    { "debug", 0, 0, 'd' },
+    { "filename", 1, 0, 'f' },
+    { "help", 0, 0, 'h' },
+    { "listio", 0, 0, 'l' },
+    { "mount", 1, 0, 'm' },
+    { "pattern", 1, 0, 'p' },
+    { "pread", 0, 0, 'P' },
+    { "standard", 0, 0, 's' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "b:n:c:df:hlm:Pp:su";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...]\n"
+"\n"
+"Available options:\n"
+" -b, --blocksize=<size in bytes>  logical block size for the target file\n"
+"                                  (default 1048576, 1MB)\n"
+" -n, --nblocks=<count>            count of blocks each process will read\n"
+"                                  (default 128)\n"
+" -c, --chunksize=<size in bytes>  I/O chunk size for each read operation\n"
+"                                  (default 64436, 64KB)\n"
+" -d, --debug                      pause before running test\n"
+"                                  (handy for attaching in debugger)\n"
+" -f, --filename=<filename>        target file name under mountpoint\n"
+"                                  (default: testfile)\n"
+" -h, --help                       help message\n"
+" -l, --listio                     use lio_listio(2) instead of read(2)\n"
+" -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+"                                  (default: /tmp)\n"
+" -P, --pread                      use pread(2) instead of read(2)\n"
+" -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
+" -u, --unmount                    unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 2;
+    uint64_t bufsize = 0;
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'b':
+            blocksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'n':
+            nblocks = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'c':
+            chunksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'f':
+            filename = strdup(optarg);
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'l':
+            use_listio = 1;
+            break;
+
+        case 'P':
+            use_pread = 1;
+            break;
+
+        case 'p':
+            pattern = read_io_pattern(optarg);
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 's':
+            standard = 1;
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (pattern < 0) {
+        test_print_once(rank, "pattern should be 'n1' or 'nn'\n");
+        exit(-1);
+    }
+
+    if (blocksize < chunksize || blocksize % chunksize > 0) {
+        test_print_once(rank, "blocksize should be larger than "
+                              "and divisible by chunksize.\n");
+        exit(-1);
+    }
+
+    if (use_listio && use_pread) {
+        test_print_once(rank,
+                        "--listio and --pread should be set exclusively\n");
+        exit(-1);
+    }
+
+    if (use_listio) {
+        bufsize = blocksize*nblocks;
+        n_aiocb_list = blocksize*nblocks/chunksize;
+    } else
+        bufsize = chunksize;
+
+    sprintf(targetfile, "%s/%s", mountpoint, filename);
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    if (!standard) {
+        ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+        if (ret) {
+            test_print(rank, "unifycr_mount failed (return = %d)", ret);
+            exit(-1);
+        }
+    }
+
+    buf = calloc(1, bufsize);
+    if (!buf) {
+        test_print(rank, "calloc failed");
+        exit(-1);
+    }
+
+    if (use_listio) {
+        aiocb_list = calloc(n_aiocb_list, sizeof(*aiocb_list));
+        aiocb_items = calloc(n_aiocb_list, sizeof(*aiocb_items));
+
+        if (!aiocb_list || !aiocb_items) {
+            test_print(rank, "calloc failed");
+            exit(-1);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (pattern == IO_PATTERN_NN)
+        sprintf(&targetfile[strlen(targetfile)], "-%d", rank);
+
+    fd = open(targetfile, O_RDONLY, 0600);
+    if (fd < 0) {
+        test_print(rank, "open failed");
+        exit(-1);
+    }
+
+    ret = use_listio ? do_listread() : do_read();
+
+    close(fd);
+
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (!standard && unmount && rank == 0)
+        unifycr_unmount();
+
+    if (ret == 0)
+        report_result();
+
+    free(buf);
+
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+/*
+ * I/O test:
+ *
+ * Each process will write @blocksize*@nblocks. @chunksize denotes I/O request
+ * size for each write(2) call. Each block is split into multiple chunks,
+ * meaning that @blocksize should be larger than and multiple of @chunksize.
+ */
+
+static uint64_t blocksize = 1<<20;          /* 1MB */
+static uint64_t nblocks = 128;              /* Each process writes 128MB */
+static uint64_t chunksize = 64*(1<<10);     /* 64KB for each write(2) call */
+
+static int use_pwrite;      /* use pwrite(2) */
+static int pattern;         /* N to 1 (N1, default) or N to N (NN) */
+static int fd;              /* target file descriptor */
+static int synchronous;     /* sync metadata for each write? (default: no)*/
+
+static int standard;        /* not mounting unifycr when set */
+
+/* time statistics */
+static struct timeval write_start, meta_start, write_end;
+
+static int rank;
+static int total_ranks;
+
+static int debug;           /* pause for attaching debugger */
+static int unmount;         /* unmount unifycr after running the test */
+static char *buf;           /* I/O buffer */
+static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *filename = "testfile"; /* testfile name under mountpoint */
+static char targetfile[NAME_MAX];   /* target file name */
+
+static int do_write(void)
+{
+    int ret = 0;
+    uint64_t i, j, offset;
+    uint64_t nchunks = blocksize / chunksize;
+
+    gettimeofday(&write_start, NULL);
+
+    for (i = 0; i < nblocks; i++) {
+        for (j = 0; j < nchunks; j++) {
+            if (pattern == IO_PATTERN_N1)
+                offset = i*total_ranks*blocksize + rank*blocksize
+                         + j*chunksize;
+            else
+                offset = i*blocksize + j*chunksize;
+
+            if (use_pwrite)
+                ret = pwrite(fd, buf, chunksize, offset);
+            else {
+                lseek(fd, offset, SEEK_SET);
+                ret = write(fd, buf, chunksize);
+            }
+
+            if (ret < 0) {
+                test_print(rank, "%s failed",
+                                 use_pwrite ? "pwrite()" : "write()");
+                return -1;
+            }
+
+            if (synchronous)
+                fsync(fd);
+        }
+    }
+
+    gettimeofday(&meta_start, NULL);
+
+    fsync(fd);
+
+    gettimeofday(&write_end, NULL);
+
+    return 0;
+}
+
+static void report_result(void)
+{
+    double write_bw = .0F;
+    double agg_write_bw = .0F;
+    double max_write_time = .0F;
+    double min_write_bw = .0F;
+    double write_time = .0F;
+    double meta_time = .0F;
+    double max_meta_time = .0F;
+
+    write_time = timediff_sec(&write_start, &write_end);
+    write_bw = 1.0*blocksize*nblocks/write_time/(1<<20);
+
+    meta_time = timediff_sec(&meta_start, &write_end);
+
+    MPI_Reduce(&write_bw, &agg_write_bw,
+               1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&write_time, &max_write_time,
+               1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    MPI_Reduce(&meta_time, &max_meta_time,
+               1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+
+    min_write_bw = 1.0*blocksize*nblocks*total_ranks
+                    /max_write_time/(1<<20);
+
+    test_print_once(rank,
+                    "\n"
+                    "Number of processes:       %d\n"
+                    "Each process wrote:        %lf MB\n"
+                    "Total writes:              %lf MB\n"
+                    "I/O pattern:               %s\n"
+                    "I/O request size:          %llu B\n"
+                    "Aggregate write bandwidth: %lf MB/s\n"
+                    "Min. write bandwidth:      %lf MB/s\n"
+                    "Total Write time:          %lf sec. (%lf for fsync)\n\n",
+                    total_ranks,
+                    1.0*blocksize*nblocks/(1<<20),
+                    1.0*total_ranks*blocksize*nblocks/(1<<20),
+                    io_pattern_string(pattern),
+                    chunksize,
+                    agg_write_bw,
+                    min_write_bw,
+                    max_write_time,
+                    max_meta_time);
+}
+
+static struct option const long_opts[] = {
+    { "blocksize", 1, 0, 'b' },
+    { "nblocks", 1, 0, 'n' },
+    { "chunksize", 1, 0, 'c' },
+    { "debug", 0, 0, 'd' },
+    { "filename", 1, 0, 'f' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "pattern", 1, 0, 'p' },
+    { "pwrite", 0, 0, 'P' },
+    { "synchronous", 0, 0, 'S' },
+    { "standard", 0, 0, 's' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "b:n:c:df:hm:p:PSsu";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...]\n"
+"\n"
+"Available options:\n"
+" -b, --blocksize=<size in bytes>  logical block size for the target file\n"
+"                                  (default 1048576, 1MB)\n"
+" -n, --nblocks=<count>            count of blocks each process will write\n"
+"                                  (default 128)\n"
+" -c, --chunksize=<size in bytes>  I/O chunk size for each write operation\n"
+"                                  (default 64436, 64KB)\n"
+" -d, --debug                      pause before running test\n"
+"                                  (handy for attaching in debugger)\n"
+" -f, --filename=<filename>        target file name under mountpoint\n"
+"                                  (default: testfile)\n"
+" -h, --help                       help message\n"
+" -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+"                                  (default: /tmp)\n"
+" -P, --pwrite                     use pwrite(2) instead of write(2)\n"
+" -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
+" -S, --synchronous                sync metadata on each write\n"
+" -s, --standard                   do not use unifycr but run standard I/O\n"
+" -u, --unmount                    unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 2;
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'b':
+            blocksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'n':
+            nblocks = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'c':
+            chunksize = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'f':
+            filename = strdup(optarg);
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'P':
+            use_pwrite = 1;
+            break;
+
+        case 'p':
+            pattern = read_io_pattern(optarg);
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'S':
+            synchronous = 1;
+            break;
+
+        case 's':
+            standard = 1;
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (pattern < 0) {
+        test_print_once(rank, "pattern should be 'n1' or 'nn'\n");
+        exit(-1);
+    }
+
+    if (blocksize < chunksize || blocksize % chunksize > 0) {
+        test_print_once(rank, "blocksize should be larger than "
+                              "and divisible by chunksize.\n");
+        exit(-1);
+    }
+
+    sprintf(targetfile, "%s/%s", mountpoint, filename);
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    if (!standard) {
+        ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+        if (ret) {
+            test_print(rank, "unifycr_mount failed (return = %d)", ret);
+            exit(-1);
+        }
+    }
+
+    buf = calloc(1, chunksize);
+    if (!buf) {
+        test_print(rank, "calloc failed");
+        exit(-1);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (pattern == IO_PATTERN_NN)
+        sprintf(&targetfile[strlen(targetfile)], "-%d", rank);
+
+    fd = open(targetfile, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        test_print(rank, "open failed");
+        exit(-1);
+    }
+
+    ret = do_write();
+
+    close(fd);
+
+    fflush(stdout);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (!standard && unmount && rank == 0)
+        unifycr_unmount();
+
+    if (ret == 0)
+        report_result();
+
+    free(buf);
+
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/examples/src/sysio-writeread.c
+++ b/examples/src/sysio-writeread.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * Copyright (c) 2017, Florida State University. Contributions from
+ * the Computer Architecture and Systems Research Laboratory (CASTL)
+ * at the Department of Computer Science.
+ *
+ * Written by: Teng Wang, Adam Moody, Weikuan Yu, Kento Sato, Kathryn Mohror
+ * LLNL-CODE-728877. All rights reserved.
+ *
+ * This file is part of burstfs.
+ * For details, see https://github.com/llnl/burstfs
+ * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
+ */
+
+/*
+ * Copyright (c) 2013, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ * code Written by
+ *   Raghunath Rajachandrasekar <rajachan@cse.ohio-state.edu>
+ *   Kathryn Mohror <kathryn@llnl.gov>
+ *   Adam Moody <moody20@llnl.gov>
+ * All rights reserved.
+ * This file is part of CRUISE.
+ * For details, see https://github.com/hpc/cruise
+ * Please also read this file LICENSE.CRUISE
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <mpi.h>
+#include <sys/time.h>
+#include <aio.h>
+#include <unifycr.h>
+
+#define GEN_STR_LEN 1024
+
+struct timeval read_start, read_end;
+double readtime;
+
+struct timeval write_start, write_end;
+double write_time;
+
+struct timeval meta_start, meta_end;
+double meta_time;
+
+struct timeval read_start, read_end;
+double read_time;
+
+typedef struct {
+    int fid;
+    long offset;
+    long length;
+    char *buf;
+} read_req_t;
+
+int main(int argc, char *argv[])
+{
+    static const char *opts = "b:s:t:f:p:u:";
+    char tmpfname[GEN_STR_LEN], fname[GEN_STR_LEN];
+    long blk_sz = 0, seg_num = 0, tran_sz = 0, num_reqs = 0;
+    int pat = 0, c, rank_num, rank, fd, to_unmount = 0;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &rank_num);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((c = getopt(argc, argv, opts)) != -1) {
+        switch (c) {
+        case 'b': /*size of block*/
+            blk_sz = atol(optarg); break;
+        case 's': /*number of blocks each process writes*/
+            seg_num = atol(optarg); break;
+        case 't': /*size of each write */
+            tran_sz = atol(optarg); break;
+        case 'f':
+            strcpy(fname, optarg); break;
+        case 'p':
+            pat = atoi(optarg); break; /* 0: N-1 segment/strided, 1: N-N*/
+        case 'u':
+            to_unmount = atoi(optarg); break;
+        }
+    }
+
+    unifycr_mount("/tmp", rank, rank_num, 0);
+
+    char *buf = malloc(tran_sz);
+
+    if (buf == NULL)
+        return -1;
+
+    memset(buf, 0, tran_sz);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (pat == 1)
+        sprintf(tmpfname, "%s%d", fname, rank);
+    else
+        sprintf(tmpfname, "%s", fname);
+
+    fd = open(tmpfname, O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        printf("open file failure\n");
+        fflush(stdout);
+        return -1;
+    }
+
+    gettimeofday(&write_start, NULL);
+
+    long i, j, offset = 0, rc;
+
+    for (i = 0; i < seg_num; i++) {
+        for (j = 0; j < blk_sz/tran_sz; j++) {
+            if (pat == 0)
+                offset = i*rank_num*blk_sz + rank*blk_sz + j*tran_sz;
+            else if (pat == 1)
+                offset = i*blk_sz + j*tran_sz;
+            rc = pwrite(fd, buf, tran_sz, offset);
+
+            if (rc < 0)
+                perror("pwrite failed");
+        }
+    }
+
+    gettimeofday(&meta_start, NULL);
+    fsync(fd);
+    gettimeofday(&meta_end, NULL);
+    meta_time += 1000000 * (meta_end.tv_sec - meta_start.tv_sec)
+                 + meta_end.tv_usec - meta_start.tv_usec;
+    meta_time /= 1000000;
+    gettimeofday(&write_end, NULL);
+    write_time += 1000000 * (write_end.tv_sec - write_start.tv_sec)
+                + write_end.tv_usec - write_start.tv_usec;
+    write_time = write_time/1000000;
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    free(buf);
+
+    num_reqs = blk_sz*seg_num/tran_sz;
+
+    char *read_buf = malloc(blk_sz * seg_num); /*read buffer*/
+    struct aiocb *aiocb_list = (struct aiocb *)malloc(num_reqs
+            * sizeof(struct aiocb));
+    struct aiocb **cb_list = (struct aiocb **)malloc(num_reqs *
+            sizeof(struct aiocb *)); /*list of read requests in lio_listio*/
+
+    gettimeofday(&read_start, NULL);
+
+    long index;
+
+    if (pat == 0) { /* N-1 */
+        long i, j;
+
+        for (i = 0; i < seg_num; i++) {
+            for (j = 0; j < blk_sz/tran_sz; j++) {
+                index = i * (blk_sz/tran_sz) + j;
+                aiocb_list[index].aio_fildes = fd;
+                aiocb_list[index].aio_buf = read_buf + index*tran_sz;
+                aiocb_list[index].aio_nbytes = tran_sz;
+                aiocb_list[index].aio_offset = i*rank_num*blk_sz
+                                               + rank*blk_sz + j*tran_sz;
+                aiocb_list[index].aio_lio_opcode = LIO_READ;
+                cb_list[index] = &aiocb_list[index];
+            }
+        }
+    } else {
+        if (pat == 1) { /* N-N */
+            long i, j;
+
+            for (i = 0; i < seg_num; i++) {
+                for (j = 0; j < blk_sz/tran_sz; j++) {
+                    index = i * (blk_sz/tran_sz) + j;
+                    aiocb_list[index].aio_fildes = fd;
+                    aiocb_list[index].aio_buf = read_buf + index * tran_sz;
+                    aiocb_list[index].aio_nbytes = tran_sz;
+                    aiocb_list[index].aio_offset = i * blk_sz + j * tran_sz;
+                    aiocb_list[index].aio_lio_opcode = LIO_READ;
+                    cb_list[index] = &aiocb_list[index];
+                }
+            }
+
+        } else {
+            printf("unsupported I/O pattern");
+            fflush(stdout);
+        }
+    }
+
+    int ret = lio_listio(LIO_WAIT, cb_list, num_reqs, NULL);
+
+    if (ret < 0)
+        perror("lio_listio failed");
+
+    gettimeofday(&read_end, NULL);
+
+    read_time = (read_end.tv_sec - read_start.tv_sec)*1000000
+                + read_end.tv_usec - read_start.tv_usec;
+    read_time = read_time/1000000;
+
+    close(fd);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (to_unmount) {
+        if (rank == 0)
+            unifycr_unmount();
+    }
+    free(read_buf);
+
+    double write_bw = (double) blk_sz*seg_num/1048576/write_time;
+    double agg_write_bw;
+
+    MPI_Reduce(&write_bw, &agg_write_bw, 1, MPI_DOUBLE, MPI_SUM,
+               0, MPI_COMM_WORLD);
+
+    double max_write_time;
+
+    MPI_Reduce(&write_time, &max_write_time, 1, MPI_DOUBLE, MPI_MAX,
+               0, MPI_COMM_WORLD);
+
+    double min_write_bw;
+
+    min_write_bw = (double) blk_sz*seg_num*rank_num/1048576/max_write_time;
+
+    if (rank == 0) {
+        printf("Aggregate Write BW is %lfMB/s\n"
+               "Min Write BW is %lfMB/s\n",
+               agg_write_bw, min_write_bw);
+        fflush(stdout);
+    }
+
+    double read_bw = (double) blk_sz*seg_num/1048576/read_time;
+    double agg_read_bw;
+    double max_read_time, min_read_bw;
+
+    MPI_Reduce(&read_bw, &agg_read_bw, 1, MPI_DOUBLE, MPI_SUM,
+               0, MPI_COMM_WORLD);
+    MPI_Reduce(&read_time, &max_read_time, 1, MPI_DOUBLE, MPI_MAX,
+               0, MPI_COMM_WORLD);
+
+    min_read_bw = (double) blk_sz*seg_num*rank_num/1048576/max_read_time;
+    if (rank == 0) {
+        printf("Aggregate Read BW is %lfMB/s\n"
+               "Min Read BW is %lf\n",
+               agg_read_bw,  min_read_bw);
+        fflush(stdout);
+    }
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/examples/src/sysio-writeread2.c
+++ b/examples/src/sysio-writeread2.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+// build:  mpigcc -g -O3 -o test_ramdisk test_ramdisk.c
+// run:    srun -n64 -N4 ./test_ramdisk
+
+#include <config.h>
+
+#define _GNU_SOURCE 1
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+//size_t filesize = 100*1024*1024;
+size_t filesize = 1024*1024;
+int times = 5;
+int seconds;
+int rank = -1;
+int ranks;
+
+/* reliable read from file descriptor
+ * (retries, if necessary, until hard error)
+ */
+int reliable_read(int fd, void *buf, size_t size)
+{
+    size_t n = 0;
+    int retries = 10;
+    int rank;
+    char host[128];
+
+    while (n < size) {
+        int rc = read(fd, (char *) buf + n, size - n);
+
+        if (rc  > 0)
+            n += rc;
+        else if (rc == 0)
+            return n; /* EOF */
+        else { /* (rc < 0) */
+            /* got an error, check whether it was serious */
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+
+            /* something worth printing an error about */
+            retries--;
+
+            if (retries) {
+                /* print an error and try again */
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                gethostname(host, sizeof(host));
+                printf("%d on %s: ERROR: Error reading: "
+                       "read(%d, %p, %ld) errno=%d %s @ %s:%d\n",
+                        rank, host, fd, (char *) buf + n, size - n,
+                        errno, strerror(errno), __FILE__, __LINE__);
+            } else {
+                /* too many failed retries, give up */
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                gethostname(host, sizeof(host));
+                printf("%d on %s: ERROR: Giving up read: "
+                       "read(%d, %p, %ld) errno=%d %s @ %s:%d\n",
+                       rank, host, fd, (char *) buf + n, size - n,
+                       errno, strerror(errno), __FILE__, __LINE__);
+                MPI_Abort(MPI_COMM_WORLD, 0);
+            }
+        }
+    }
+    return size;
+}
+
+/* reliable write to file descriptor (retries, if necessary, until hard error)
+ */
+int reliable_write(int fd, const void *buf, size_t size)
+{
+    size_t n = 0;
+    int retries = 10;
+    int rank;
+    char host[128];
+
+    while (n < size) {
+        int rc = write(fd, (char *) buf + n, size - n);
+
+        if (rc > 0)
+            n += rc;
+        else if (rc == 0) {
+            /* something bad happened, print an error and abort */
+            MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+            gethostname(host, sizeof(host));
+            printf("%d on %s: ERROR: Error writing: "
+                   "write(%d, %p, %ld) returned 0 @ %s:%d\n",
+                   rank, host, fd, (char *) buf + n, size - n,
+                   __FILE__, __LINE__);
+            MPI_Abort(MPI_COMM_WORLD, 0);
+        } else { /* (rc < 0) */
+            /* got an error, check whether it was serious */
+            if (errno == EINTR || errno == EAGAIN)
+                continue;
+
+            /* something worth printing an error about */
+            retries--;
+
+            if (retries) {
+                /* print an error and try again */
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                gethostname(host, sizeof(host));
+                printf("%d on %s: ERROR: Error writing: "
+                       "write(%d, %p, %ld) errno=%d %s @ %s:%d\n",
+                       rank, host, fd, (char *) buf + n, size - n,
+                       errno, strerror(errno), __FILE__, __LINE__);
+            } else {
+                /* too many failed retries, give up */
+                MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+                gethostname(host, sizeof(host));
+                printf("%d on %s: ERROR: Giving up write: "
+                       "write(%d, %p, %ld) errno=%d %s @ %s:%d\n",
+                       rank, host, fd, (char *) buf + n, size - n,
+                       errno, strerror(errno), __FILE__, __LINE__);
+                MPI_Abort(MPI_COMM_WORLD, 0);
+            }
+        }
+    }
+    return size;
+}
+
+/* initialize buffer with some well-known value based on rank */
+int init_buffer(char *buf, size_t size, int rank, int ckpt)
+{
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        char c = 'a' + (char)((rank + ckpt + i) & 32);
+
+        buf[i] = c;
+    }
+
+    return 0;
+}
+
+/* checks buffer for expected value */
+int check_buffer(char *buf, size_t size, int rank, int ckpt)
+{
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        char c = 'a' + (char)((rank + ckpt + i) & 32);
+
+        if (buf[i] != c) {
+            printf("check failed at byte %d, should be %c is %c\n",
+                   (int) i, c, buf[i]);
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/* read the checkpoint data from file into buf, and return whether the read was
+ * successful
+ */
+int read_checkpoint(int fd, int *rank, int *ckpt, char *buf, size_t size)
+{
+    int ret;
+    unsigned long n;
+    char rank_buf[7];
+    char ckpt_buf[7];
+    size_t field_size = 6;
+
+    /* read the rank id */
+    n = reliable_read(fd, rank_buf, field_size);
+    if (n != field_size) {
+        printf("Failed to read rank\n");
+        return 0;
+    }
+    rank_buf[6] = '\0';
+
+    /* read the checkpoint id */
+    n = reliable_read(fd, ckpt_buf, field_size);
+    if (n != field_size) {
+        printf("Failed to read timestep\n");
+        return 0;
+    }
+    ckpt_buf[6] = '\0';
+
+    /* read the checkpoint data, and check the file size */
+    n = reliable_read(fd, buf, size+1);
+    if (n != size) {
+        printf("Filesize not correct\n");
+        return 0;
+    }
+
+    /* if the file looks good, set the timestep and return */
+    ret = sscanf(rank_buf, "%6d", rank);
+    ret = sscanf(ckpt_buf, "%6d", ckpt);
+
+    if (ret == EOF)
+        perror("sscanf");
+
+    return 0;
+}
+
+/* write the checkpoint data to fd, and return whether the write was successful
+ */
+int write_checkpoint(int fd, int rank, int ckpt, char *buf, size_t size)
+{
+    int rc;
+    int valid = 0;
+    char rank_buf[7];
+    char ckpt_buf[7];
+    size_t field_size = 6;
+
+    /* write the rank id */
+    sprintf(rank_buf, "%06d", rank);
+    rc = reliable_write(fd, rank_buf, field_size);
+    if (rc < 0)
+        valid = 0;
+
+    /* write the checkpoint id (application timestep) */
+    sprintf(ckpt_buf, "%06d", ckpt);
+    rc = reliable_write(fd, ckpt_buf, field_size);
+    if (rc < 0)
+        valid = 0;
+
+    /* write the checkpoint data */
+    rc = reliable_write(fd, buf, size);
+    if (rc < 0)
+        valid = 0;
+
+    return valid;
+}
+
+void checkdata(char *file, size_t size, int times)
+{
+    char *buf = malloc(size);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (times > 0) {
+        /* write the checkpoint file */
+        int i;
+
+        for (i = 0; i < times; i++) {
+            int rc;
+            int valid = 0;
+
+            rc = init_buffer(buf, size, rank, i);
+
+            if (rank == 0) {
+                printf("Writing checkpoint %d.\n", i);
+                fflush(stdout);
+            }
+
+            /* open the file and write the checkpoint */
+            int fd_me = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+            if (fd_me > 0) {
+                valid = 1;
+
+                /* write the checkpoint data */
+                rc = write_checkpoint(fd_me, rank, i, buf, size);
+                if (rc < 0)
+                    valid = 0;
+
+                /* force the data to storage */
+                rc = fsync(fd_me);
+                if (rc < 0)
+                    valid = 0;
+
+                /* make sure the close is without error */
+                rc = close(fd_me);
+                if (rc < 0)
+                    valid = 0;
+            }
+
+            if (!valid) {
+                printf("failed to write checkpoint\n");
+                continue;
+            }
+
+            if (rank == 0) {
+                printf("Completed checkpoint %d.\n", i);
+                fflush(stdout);
+            }
+
+            if (rank == 0) {
+                printf("Reading checkpoint %d.\n", i);
+                fflush(stdout);
+            }
+
+            memset(buf, 0, size);
+
+            /* open the file and write the checkpoint */
+            int read_rank, read_timestep;
+
+            fd_me = open(file, O_RDONLY);
+            if (fd_me > 0) {
+                valid = 1;
+
+                /* write the checkpoint data */
+                rc = read_checkpoint(fd_me, &read_rank, &read_timestep, buf,
+                                     size);
+                if (rc < 0)
+                    valid = 0;
+
+                /* make sure the close is without error */
+                rc = close(fd_me);
+                if (rc < 0)
+                    valid = 0;
+            }
+
+            if (!valid) {
+                printf("failed to read checkpoint");
+                continue;
+            }
+
+            if (read_rank != rank || read_timestep != i) {
+                printf("INVALID HEADER on rank %d in step %d\n", rank, i);
+                fflush(stdout);
+
+                MPI_Abort(MPI_COMM_WORLD, 0);
+            }
+
+            rc = check_buffer(buf, size, rank, i);
+            if (!rc) {
+                printf("INVALID DATA on rank %d in step %d\n", rank, i);
+                fflush(stdout);
+
+                MPI_Abort(MPI_COMM_WORLD, 0);
+            }
+
+            if (rank == 0) {
+                printf("Verified checkpoint %d.\n", read_timestep);
+                fflush(stdout);
+            }
+
+            /* optionally sleep for some time */
+            if (seconds > 0) {
+                if (rank == 0) {
+                    printf("Sleeping for %d seconds...\n", seconds);
+                    fflush(stdout);
+                }
+                sleep(seconds);
+            }
+
+            unlink(file);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (buf != NULL) {
+        free(buf);
+        buf = NULL;
+    }
+
+    return;
+}
+
+int main(int argc, char *argv[])
+{
+    /* check that we got an appropriate number of arguments */
+    if (argc != 1 && argc != 4) {
+        printf("Usage: test_correctness [filesize times sleep_secs]\n");
+        return 1;
+    }
+
+    /* read parameters from command line, if any */
+    if (argc > 1) {
+        filesize = (size_t) atol(argv[1]);
+        times = atoi(argv[2]);
+        seconds = atoi(argv[3]);
+    }
+
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &ranks);
+
+    unifycr_mount("/tmp", rank, ranks, 0);
+
+    char name[256];
+
+    sprintf(name, "/tmp/rank.%d", rank);
+
+    /* allocate space for the checkpoint data (make filesize a function of rank
+     * for some variation)
+     */
+    filesize = filesize + rank;
+
+    /* verify data integrity in file */
+    checkdata(name, filesize, times);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/examples/src/testlib.h
+++ b/examples/src/testlib.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#ifndef __TESTLIB_H
+#define __TESTLIB_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <mpi.h>
+
+extern int errno;
+
+static inline
+void test_print(int rank, const char *fmt, ...)
+{
+    va_list args;
+
+    printf("[%d] ", rank);
+
+    va_start(args, fmt);
+
+    vfprintf(stdout, fmt, args);
+
+    va_end(args);
+
+    if (errno)
+        fprintf(stdout, " (errno=%d, %s)\n", errno, strerror(errno));
+}
+
+static inline
+void test_print_once(int rank, const char *fmt, ...)
+{
+    if (rank == 0) {
+        va_list args;
+
+        va_start(args, fmt);
+
+        vfprintf(stdout, fmt, args);
+
+        va_end(args);
+
+        if (errno)
+            fprintf(stdout, " (errno=%d, %s)\n", errno, strerror(errno));
+    }
+}
+
+static inline
+void test_pause(int rank, const char *fmt, ...)
+{
+    if (rank == 0) {
+        va_list args;
+
+        va_start(args, fmt);
+
+        vfprintf(stderr, fmt, args);
+
+        va_end(args);
+
+        fprintf(stderr, " ENTER to continue ... ");
+
+        (void) getchar();
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* internal accept() call from mpi may set errno */
+    errno = 0;
+}
+
+static inline
+double timediff_usec(struct timeval *before, struct timeval *after)
+{
+    if (!before || !after)
+        return -1.0F;
+
+    return 1000000.0*(after->tv_sec - before->tv_sec) +
+            1.0*(after->tv_usec - before->tv_usec);
+}
+
+static inline
+double timediff_sec(struct timeval *before, struct timeval *after)
+{
+    return timediff_usec(before, after)*.000001;
+}
+
+#define IO_PATTERN_N1   0
+#define IO_PATTERN_NN   1
+
+static inline int read_io_pattern(const char *pstr)
+{
+    int pattern = -1;
+
+    if (strcmp(pstr, "n1") == 0)
+        pattern = IO_PATTERN_N1;
+    else if (strcmp(pstr, "nn") == 0)
+        pattern = IO_PATTERN_NN;
+
+    return pattern;
+}
+
+static inline const char *io_pattern_string(int pattern)
+{
+    if (pattern == IO_PATTERN_N1)
+        return "N to 1";
+    else if (pattern == IO_PATTERN_NN)
+        return "N to N";
+    else
+        return "Unknown";
+}
+
+#endif /* __TESTLIB_H */


### PR DESCRIPTION
- Rewrote tests for read(2), write(2), pread(2), pwrite(2), lio_listio(2),
  and mpiio.
- Integrated btio and tileio test programs to the build script.
  Also, corrected code style to comply the check script.

<!--- Provide a general summary of your changes in the Title above -->

### Description
This patch is the first attempt to reorganize test programs in `client/tests` into `examples/src`. Some programs are just copied from the old location, while there are a few newly written.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
