### PR TITLE
Some additional clean up to the metadata bits.

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -339,15 +339,6 @@ extern long unifycr_key_slice_range;
 #define UNIFYCR_CLI_TIME_OUT 5000
 
 typedef enum {
-    COMM_MOUNT,
-    COMM_META,
-    COMM_READ,
-    COMM_UNMOUNT,
-    COMM_DIGEST,
-    COMM_SYNC_DEL,
-} cmd_lst_t;
-
-typedef enum {
     ACK_SUCCESS,
     ACK_FAIL,
 } ack_status_t;

--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -1655,13 +1655,11 @@ int UNIFYCR_WRAP(fsync)(int fd)
         }
 
         /*put indices to key-value store*/
-        int cmd = COMM_META;
-        int flag = 3;
+        int cmd = COMM_META_FSYNC;
         int res = -1;
 
         memset(cmd_buf, 0, sizeof(cmd_buf));
         memcpy(cmd_buf, &cmd, sizeof(int));
-        memcpy(cmd_buf + sizeof(int), &flag, sizeof(int));
 
         res = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
 
@@ -1685,7 +1683,7 @@ int UNIFYCR_WRAP(fsync)(int fd)
                             return -1;
                         } else {
                             /**/
-                            if (*((int *)cmd_buf) != COMM_META ||
+                            if (*((int *)cmd_buf) != COMM_META_FSYNC ||
                                     *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 return -1;
                             } else {

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -945,14 +945,11 @@ static int unifycr_get_global_fid(const char *path, int *gfid)
  * */
 static int set_global_file_meta(unifycr_file_attr_t *f_meta)
 {
-    int cmd = COMM_META;
-    int flag = 2;
+    int cmd = COMM_META_SET;
 
     memset(cmd_buf, 0, sizeof(cmd_buf));
     memcpy(cmd_buf, &cmd, sizeof(int));
-    memcpy(cmd_buf + sizeof(int), &flag, sizeof(int));
-    memcpy(cmd_buf + sizeof(int) + sizeof(int),
-           f_meta, sizeof(unifycr_file_attr_t));
+    memcpy(cmd_buf + sizeof(int), f_meta, sizeof(unifycr_file_attr_t));
 
     int rc = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
     if (rc != 0) {
@@ -975,8 +972,8 @@ static int set_global_file_meta(unifycr_file_attr_t *f_meta)
                             /*remote connection is closed*/
                             return -1;
                         } else {
-                            if (*((int *)cmd_buf) != COMM_META || *((int *)cmd_buf + 1)
-                                != ACK_SUCCESS) {
+                            if (*((int *)cmd_buf) != COMM_META_SET
+                                || *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 /*encounter delegator-side error*/
                                 return -1;
                             } else {
@@ -1015,14 +1012,11 @@ static int set_global_file_meta(unifycr_file_attr_t *f_meta)
 static int get_global_file_meta(int gfid, unifycr_file_attr_t **file_meta)
 {
     /* format value length, payload 1, payload 2*/
-    int cmd = COMM_META;
-    int flag = 1;
+    int cmd = COMM_META_GET;
 
     memset(cmd_buf, 0, sizeof(cmd_buf));
     memcpy(cmd_buf, &cmd, sizeof(int));
-    memcpy(cmd_buf + sizeof(int), &flag, sizeof(int));
-    memcpy(cmd_buf + sizeof(int) + sizeof(int),
-           &gfid, sizeof(int));
+    memcpy(cmd_buf + sizeof(int), &gfid, sizeof(int));
 
     int rc = __real_write(client_sockfd, cmd_buf, sizeof(cmd_buf));
     if (rc != 0) {
@@ -1045,8 +1039,8 @@ static int get_global_file_meta(int gfid, unifycr_file_attr_t **file_meta)
                             /*remote connection is closed*/
                             return -1;
                         } else {
-                            if (*((int *)cmd_buf) != COMM_META || *((int *)cmd_buf + 1)
-                                != ACK_SUCCESS) {
+                            if (*((int *)cmd_buf) != COMM_META_GET
+                            || *((int *)cmd_buf + 1) != ACK_SUCCESS) {
                                 *file_meta = NULL;
                                 return -1;
                             } else {

--- a/common/src/unifycr_meta.h
+++ b/common/src/unifycr_meta.h
@@ -19,6 +19,20 @@
 
 #include "unifycr_const.h"
 
+/**
+ * Server commands
+ */
+typedef enum {
+    COMM_MOUNT,
+    COMM_META_FSYNC,
+    COMM_META_GET,
+    COMM_META_SET,
+    COMM_READ,
+    COMM_UNMOUNT,
+    COMM_DIGEST,
+    COMM_SYNC_DEL,
+} cmd_lst_t;
+
 typedef struct {
     int fid;
     int gfid;

--- a/server/src/unifycr_cmd_handler.c
+++ b/server/src/unifycr_cmd_handler.c
@@ -78,14 +78,59 @@ int delegator_handle_command(char *ptr_cmd, int sock_id)
         rc = sock_ack_cli(sock_id, ret_sz);
         return rc;
 
+    case COMM_META_GET:
+        (void)0;
+        /*get file attribute*/
+        unifycr_file_attr_t attr_val;
+
+        fattr_key_t _fattr_key = *((int *)(ptr_cmd + 2 * sizeof(int)));
+
+        rc = meta_process_attr_get(&_fattr_key, &attr_val);
+
+        ptr_ack = sock_get_ack_buf(sock_id);
+        ret_sz = pack_ack_msg(ptr_ack, cmd, rc,
+                                &attr_val, sizeof(unifycr_file_attr_t));
+        rc = sock_ack_cli(sock_id, ret_sz);
+
+        break;
+
+    case COMM_META_SET:
+        (void)0;
+        /*set file attribute*/
+        rc = meta_process_attr_set(ptr_cmd, sock_id);
+
+        ptr_ack = sock_get_ack_buf(sock_id);
+        ret_sz = pack_ack_msg(ptr_ack, cmd, rc, NULL, 0);
+        rc = sock_ack_cli(sock_id, ret_sz);
+        /*ToDo: deliver the error code/success to client*/
+
+        break;
+
+    case COMM_META_FSYNC:
+        /* synchronize both index and file attribute
+         * metadata to the key-value store
+         */
+
+        rc = meta_process_fsync(sock_id);
+
+        /*ack the result*/
+        ptr_ack = sock_get_ack_buf(sock_id);
+        ret_sz = pack_ack_msg(ptr_ack, cmd, rc, NULL, 0);
+        rc = sock_ack_cli(sock_id, ret_sz);
+
+        break;
+
+#if 0
     case COMM_META:
         (void)0;
         int type = *((int *)ptr_cmd + 1);
         if (type == 1) {
             /*get file attribute*/
             unifycr_file_attr_t attr_val;
-            rc = meta_process_attr_get(ptr_cmd,
-                                       sock_id, &attr_val);
+
+            fattr_key_t _fattr_key = *((int *)(ptr_cmd + 2 * sizeof(int)));
+
+            rc = meta_process_attr_get(&_fattr_key, &attr_val);
 
             ptr_ack = sock_get_ack_buf(sock_id);
             ret_sz = pack_ack_msg(ptr_ack, cmd, rc,
@@ -116,6 +161,7 @@ int delegator_handle_command(char *ptr_cmd, int sock_id)
             rc = sock_ack_cli(sock_id, ret_sz);
         }
         break;
+#endif
 
     case COMM_READ:
         (void)0;

--- a/server/src/unifycr_cmd_handler.h
+++ b/server/src/unifycr_cmd_handler.h
@@ -30,15 +30,6 @@
 #ifndef UNIFYCR_CMD_HANDLER_H
 #define UNIFYCR_CMD_HANDLER_H
 int delegator_handle_command(char *ptr_cmd, int sock_id);
-int sync_with_client(char *buf, int client_id);
-int open_log_file(app_config_t *app_config,
-                  int app_id, int client_id);
-int attach_to_shm(app_config_t *app_config,
-                  int app_id, int sock_id);
-int pack_ack_msg(char *ptr_cmd, int cmd,
-                 int rc, void *val,
-                 int val_len);
-int unifycr_broadcast_exit(int sock_id);
 int sync_with_client(char *cmd_buf, int sock_id);
 int open_log_file(app_config_t *app_config,
                   int app_id, int sock_id);

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -36,15 +36,6 @@
 #include "arraylist.h"
 
 typedef enum {
-    COMM_MOUNT, /*the list of addrs: appid, size of buffer, offset of data section, metadata section*/
-    COMM_META,
-    COMM_READ,
-    COMM_UNMOUNT,
-    COMM_DIGEST,
-    COMM_SYNC_DEL,
-} cmd_lst_t;
-
-typedef enum {
     XFER_COMM_DATA,
     XFER_COMM_EXIT,
 } service_cmd_lst_t;

--- a/server/src/unifycr_metadata.c
+++ b/server/src/unifycr_metadata.c
@@ -209,7 +209,7 @@ int meta_process_attr_set(char *buf, int sock_id)
     int rc = ULFS_SUCCESS;
 
     unifycr_file_attr_t *ptr_fattr =
-        (unifycr_file_attr_t *)(buf + 2 * sizeof(int));
+        (unifycr_file_attr_t *)(buf + 1 * sizeof(int));
 
     *fattr_keys[0] = ptr_fattr->gfid;
     fattr_vals[0]->file_attr = ptr_fattr->file_attr;
@@ -238,23 +238,23 @@ int meta_process_attr_set(char *buf, int sock_id)
 * @return success/error code
 */
 
-int meta_process_attr_get(char *buf, int sock_id,
+int meta_process_attr_get(fattr_key_t *_fattr_key,
                           unifycr_file_attr_t *ptr_attr_val)
 {
-    *fattr_keys[0] = *((int *)(buf + 2 * sizeof(int)));
+    //*fattr_keys[0] = *((int *)(buf + 2 * sizeof(int)));
     fattr_val_t *tmp_ptr_attr;
 
     int rc;
 
     md->primary_index = unifycr_indexes[1];
-    bgrm = mdhimGet(md, md->primary_index, fattr_keys[0],
+    bgrm = mdhimGet(md, md->primary_index, _fattr_key,
                     sizeof(fattr_key_t), MDHIM_GET_EQ);
 
     if (!bgrm || bgrm->error)
         rc = (int)UNIFYCR_ERROR_MDHIM;
     else {
         tmp_ptr_attr = (fattr_val_t *)bgrm->values[0];
-        ptr_attr_val->gfid = *fattr_keys[0];
+        ptr_attr_val->gfid = *_fattr_key;
 
         /*  LOG(LOG_DBG, "rank:%d, getting fattr key:%d\n",
                     glb_rank, *fattr_keys[0]); */

--- a/server/src/unifycr_metadata.h
+++ b/server/src/unifycr_metadata.h
@@ -79,7 +79,10 @@ int meta_free_indices();
 void print_fsync_indices(unifycr_key_t **unifycr_keys,
                          unifycr_val_t **unifycr_vals, long num_entries);
 int meta_process_attr_set(char *ptr_cmd, int sock_id);
-int meta_process_attr_get(char *buf, int sock_id,
+
+//int meta_process_attr_get(char *buf, int sock_id,
+//                          unifycr_file_attr_t *ptr_attr_val);
+int meta_process_attr_get(fattr_key_t *_fattr_key,
                           unifycr_file_attr_t *ptr_attr_val);
 
 #endif


### PR DESCRIPTION
- Remove duplicate definition of cmd_lst_enum
- Add dedicated commands for fsync,get and set to the enum
- remove the flag used for fsync,get and set from the socket communication

### Motivation and Context
cleaning up the code a little.

### How Has This Been Tested?
make check

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
