### PR TITLE
create default config dirs if they don't exist

### DIFF
--- a/common/src/unifycr_configurator.c
+++ b/common/src/unifycr_configurator.c
@@ -978,18 +978,25 @@ int configurator_directory_check(const char *s,
                                  const char *val,
                                  char **o)
 {
-    int rc;
+    int mode, rc;
     struct stat st;
 
     if (val == NULL)
         return 0;
 
+    // check dir exists
     rc = stat(val, &st);
     if (rc == 0) {
         if (st.st_mode & S_IFDIR)
             return 0;
         else
             return ENOTDIR;
+    } else { // try to create it
+        mode = 0770; // S_IRWXU | S_IRWXG
+        rc = mkdir(val, mode);
+        if (rc == 0)
+            return 0;
+        else
+            return errno; // invalid
     }
-    return errno; // invalid
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

Updates configurator to attempt to create default directories.

### Motivation and Context

Resolves the problem of non-existent defaults preventing successful
startup of unifycrd due to a configurator check failing. For example, 
`/var/tmp/unifycr` (the default runstate file directory) needed
to be pre-created prior to starting the server if no custom dir was given.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
