### PR TITLE
Fix pointer calculation bug in the command handler

### DIFF
--- a/server/src/unifycr_cmd_handler.c
+++ b/server/src/unifycr_cmd_handler.c
@@ -83,7 +83,7 @@ int delegator_handle_command(char *ptr_cmd, int sock_id)
         /*get file attribute*/
         unifycr_file_attr_t attr_val;
 
-        fattr_key_t _fattr_key = *((int *)(ptr_cmd + 2 * sizeof(int)));
+        fattr_key_t _fattr_key = *((int *)(ptr_cmd + 1 * sizeof(int)));
 
         rc = meta_process_attr_get(&_fattr_key, &attr_val);
 


### PR DESCRIPTION
The previous commit (#768dc09) calculates a wrong address for
handling COMM_META_GET, which leads to a failure when looking for
an existing file. This fixes it.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.