### PR TITLE
Removing buggy lines in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,9 +267,6 @@ if test "x$runstatedir" = x; then
         AC_SUBST([runstatedir], ['${localstatedir}/run'])
 fi
 
-CFLAGS="$old_cflags"
-LIBS="$old_libs"
-
 AC_SUBST(unifycr_lib_path)
 AC_SUBST(unifycr_bin_path)
 AC_SUBST(LDFLAGS)


### PR DESCRIPTION
These buggy lines overwrites the CFLAG with the empty variables (`$old_xxx`) and blocks custom CFLAGS to be correctly applied.
