### PR TITLE
Global handling of file/directory creation

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -15,6 +15,8 @@ libunifycr_la_SOURCES = \
   unifycr-stdio.h \
   unifycr-sysio.c \
   unifycr-sysio.h \
+  unifycr-dirops.h \
+  unifycr-dirops.c \
   unifycr.c \
   unifycr.h \
   unifycr-internal.h \
@@ -40,6 +42,8 @@ libunifycr_gotcha_la_SOURCES = \
   unifycr-stdio.h \
   unifycr-sysio.c \
   unifycr-sysio.h \
+  unifycr-dirops.h \
+  unifycr-dirops.c \
   unifycr.c \
   unifycr.h \
   gotcha_map_unifycr_list.h \

--- a/client/src/gotcha_map_unifycr_list.h
+++ b/client/src/gotcha_map_unifycr_list.h
@@ -44,6 +44,18 @@ UNIFYCR_DEF(mmap64, void *, (void *addr, size_t length, int prot, int flags,
                              int fd, off_t offset));
 UNIFYCR_DEF(__fxstat, int, (int vers, int fd, struct stat *buf));
 UNIFYCR_DEF(close, int, (int fd));
+UNIFYCR_DEF(opendir, DIR *, (const char *name));
+UNIFYCR_DEF(fdopendir, DIR *, (int fd));
+UNIFYCR_DEF(closedir, int, (DIR *dirp));
+UNIFYCR_DEF(readdir, struct dirent *, (DIR *dirp));
+UNIFYCR_DEF(rewinddir, void, (DIR *dirp));
+UNIFYCR_DEF(dirfd, int, (DIR *dirp));
+UNIFYCR_DEF(telldir, long, (DIR *dirp));
+UNIFYCR_DEF(scandir, int, (const char *dirp, struct dirent **namelist,
+                           int (*filter)(const struct dirent *),
+                           int (*compar)(const struct dirent **,
+                                         const struct dirent **)));
+UNIFYCR_DEF(seekdir, void, (DIR *dirp, long loc));
 UNIFYCR_DEF(fopen, FILE *, (const char *path, const char *mode));
 UNIFYCR_DEF(freopen, FILE *, (const char *path, const char *mode,
                               FILE *stream));
@@ -126,6 +138,15 @@ struct gotcha_binding_t wrap_unifycr_list[] = {
     { "mmap64", UNIFYCR_WRAP(mmap64), &UNIFYCR_REAL(mmap64) },
     { "__fxstat", UNIFYCR_WRAP(__fxstat), &UNIFYCR_REAL(__fxstat) },
     { "close", UNIFYCR_WRAP(close), &UNIFYCR_REAL(close) },
+    { "opendir", UNIFYCR_WRAP(opendir), &UNIFYCR_REAL(opendir) },
+    { "fdopendir", UNIFYCR_WRAP(fdopendir), &UNIFYCR_REAL(fdopendir) },
+    { "closedir", UNIFYCR_WRAP(closedir), &UNIFYCR_REAL(closedir) },
+    { "readdir", UNIFYCR_WRAP(readdir), &UNIFYCR_REAL(readdir) },
+    { "rewinddir", UNIFYCR_WRAP(rewinddir), &UNIFYCR_REAL(rewinddir) },
+    { "dirfd", UNIFYCR_WRAP(dirfd), &UNIFYCR_REAL(dirfd) },
+    { "telldir", UNIFYCR_WRAP(telldir), &UNIFYCR_REAL(telldir) },
+    { "scandir", UNIFYCR_WRAP(scandir), &UNIFYCR_REAL(scandir) },
+    { "seekdir", UNIFYCR_WRAP(seekdir), &UNIFYCR_REAL(seekdir) },
     { "fopen", UNIFYCR_WRAP(fopen), &UNIFYCR_REAL(fopen) },
     { "freopen", UNIFYCR_WRAP(freopen), &UNIFYCR_REAL(freopen) },
     { "setvbuf", UNIFYCR_WRAP(setvbuf), &UNIFYCR_REAL(setvbuf) },

--- a/client/src/unifycr-dirops.c
+++ b/client/src/unifycr-dirops.c
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include "unifycr-sysio.h"
+
+/*
+ * TODO: the number of open directories clearly won't exceed the number of file
+ * descriptors. however, the current UNIFYCR_MAX_FILEDESCS value of 256 will
+ * quickly run out. if this value is fixed to be reasonably larger, then we
+ * would need a way to dynamically allocate the dirstreams instead of the
+ * following fixed size array.
+ */
+static unifycr_dirstream_t _dirstreams[UNIFYCR_MAX_FILEDESCS];
+
+/*
+ * TODO: currently, we just take the same indexed slot to our fid.
+ */
+#if 0
+static pthread_spinlock_t _dirstream_lock;
+static unifycr_dirstream_t *_dirstream_freelist;
+
+static unifycr_dirstream_t *unifycr_dirstream_alloc(void)
+{
+}
+
+static void unifycr_dirstream_free(unifycr_dirstream_t *dirp)
+{
+}
+#endif
+
+static inline unifycr_dirstream_t *unifycr_dirstream_alloc(int fid)
+{
+    unifycr_dirstream_t *dirp = &_dirstreams[fid];
+
+    memset((void *) dirp, 0, sizeof(*dirp));
+
+    return dirp;
+}
+
+static inline void unifycr_dirstream_free(unifycr_dirstream_t *dirp)
+{
+    return;
+}
+
+DIR *UNIFYCR_WRAP(opendir)(const char *name)
+{
+    int ret = 0;
+    int gfid = -1;
+    int fid = -1;
+    struct stat *sb = NULL;
+    unifycr_dirstream_t *_dirp = NULL;
+    unifycr_file_attr_t gfattr = { 0, };
+    unifycr_filemeta_t *meta = NULL;
+
+    if (!unifycr_intercept_path(name)) {
+        MAP_OR_FAIL(opendir);
+        return UNIFYCR_REAL(opendir)(name);
+    }
+
+    /*
+     * check the valid existence of the given entry in the global metadb.
+     * if valid, populate the local file meta cache accordingly.
+     */
+
+    gfid = unifycr_generate_gfid(name);
+    ret = unifycr_get_global_file_meta(gfid, &gfattr);
+    if (ret != UNIFYCR_SUCCESS) {
+        errno = ENOENT;
+        return NULL;
+    }
+
+    sb = &gfattr.file_attr;
+    if (!S_ISDIR(sb->st_mode)) {
+        errno = ENOTDIR;
+        return NULL;
+    }
+
+    fid = unifycr_get_fid_from_path(name);
+    if (fid >= 0) {
+        meta = unifycr_get_meta_from_fid(fid);
+
+        /*
+         * FIXME: We found an inconsistent status between local cache and
+         * global metadb. is it safe to invalidate the local entry and
+         * re-populate with the global data?
+         */
+        if (!meta->is_dir) {
+            errno = EIO;
+            return NULL;
+        }
+
+        /*
+         * FIXME: also, is it safe to oeverride this local data?
+         */
+        meta->size = sb->st_size;
+        meta->chunks = sb->st_blocks;
+        meta->real_size = sb->st_size;
+    } else {
+        fid = unifycr_fid_create_file(name);
+        if (fid < 0) {
+            errno = EIO;
+            return NULL;
+        }
+
+        meta = unifycr_get_meta_from_fid(fid);
+        meta->is_dir = 1;
+        meta->size = sb->st_size;
+        meta->chunks = sb->st_blocks;
+        meta->real_size = sb->st_size;
+    }
+
+    _dirp = unifycr_dirstream_alloc(fid);
+
+    return (DIR *) _dirp;
+}
+
+DIR *UNIFYCR_WRAP(fdopendir)(int fd)
+{
+    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
+    errno = ENOSYS;
+
+    return NULL;
+}
+
+int UNIFYCR_WRAP(closedir)(DIR *dirp)
+{
+    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
+    errno = ENOSYS;
+
+    return -1;
+}
+
+struct dirent *UNIFYCR_WRAP(readdir)(DIR *dirp)
+{
+    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
+    errno = ENOSYS;
+
+    return NULL;
+}
+
+void UNIFYCR_WRAP(rewinddir)(DIR *dirp)
+{
+    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
+
+    /* TODO: update the pos in the file descriptor (fd) via lseek */
+
+    _dirp->filepos = 0;
+}
+
+int UNIFYCR_WRAP(dirfd)(DIR *dirp)
+{
+    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
+
+    return _dirp->fid + unifycr_fd_limit;
+}
+
+long UNIFYCR_WRAP(telldir)(DIR *dirp)
+{
+    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
+
+    return _dirp->filepos;
+}
+
+int UNIFYCR_WRAP(scandir)(const char *dirp, struct dirent **namelist,
+                          int (*filter)(const struct dirent *),
+                          int (*compar)(const struct dirent **,
+                                        const struct dirent **))
+{
+    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
+    errno = ENOSYS;
+
+    return -1;
+}
+
+void UNIFYCR_WRAP(seekdir)(DIR *dirp, long loc)
+{
+    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
+    errno = ENOSYS;
+}
+

--- a/client/src/unifycr-dirops.h
+++ b/client/src/unifycr-dirops.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#ifndef __UNIFYCR_DIROPS_H
+#define __UNIFYCR_DIROPS_H
+
+#include <config.h>
+
+#include <sys/types.h>
+#include <dirent.h>
+#include <pthread.h>
+
+struct _unifycr_dirstream {
+    int fid;
+    unifycr_fd_t fd;
+    off_t filepos;
+};
+
+typedef struct _unifycr_dirstream unifycr_dirstream_t;
+
+/*
+ * FIXME: is this portable to use the linux dirent structure?
+ */
+
+/*
+ * standard clib functions to be wrapped:
+ *
+ * opendir(3)
+ * fdopendir(3)
+ * closedir(3)
+ * readdir(3)
+ * rewinddir(3)
+ * dirfd(3)
+ * telldir(3)
+ * scandir(3)
+ * seekdir(3)
+ */
+
+UNIFYCR_DECL(opendir, DIR *, (const char *name));
+UNIFYCR_DECL(fdopendir, DIR *, (int fd));
+UNIFYCR_DECL(closedir, int, (DIR *dirp));
+UNIFYCR_DECL(readdir, struct dirent *, (DIR *dirp));
+UNIFYCR_DECL(rewinddir, void, (DIR *dirp));
+UNIFYCR_DECL(dirfd, int, (DIR *dirp));
+UNIFYCR_DECL(telldir, long, (DIR *dirp));
+UNIFYCR_DECL(scandir, int, (const char *dirp, struct dirent **namelist,
+                            int (*filter)(const struct dirent *),
+                            int (*compar)(const struct dirent **,
+                                          const struct dirent **)));
+UNIFYCR_DECL(seekdir, void, (DIR *dirp, long loc));
+
+#endif /* __UNIFYCR_DIROPS_H */
+

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -524,9 +524,17 @@ int unifycr_match_received_ack(read_req_t *read_req, int count,
 int unifycr_locate_req(read_req_t *read_req, int count,
                        read_req_t *match_req);
 
+int unifycr_generate_gfid(const char *path);
+
+int unifycr_set_global_file_meta(const char *path, int fid, int gfid,
+                                 struct stat *sb);
+
+int unifycr_get_global_file_meta(int gfid, unifycr_file_attr_t *gfattr);
+
 // These require types/structures defined above
 #include "unifycr-fixed.h"
 #include "unifycr-stdio.h"
 #include "unifycr-sysio.h"
+#include "unifycr-dirops.h"
 
 #endif /* UNIFYCR_INTERNAL_H */

--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -112,4 +112,6 @@ int unifycr_fd_logreadlist(read_req_t *read_req, int count);
 int compare_read_req(const void *a, const void *b);
 int compare_index_entry(const void *a, const void *b);
 
+#include "unifycr-dirops.h"
+
 #endif /* UNIFYCR_SYSIO_H */

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -2,6 +2,8 @@ noinst_PROGRAMS = sysio-write-gotcha sysio-write-static \
                   sysio-read-gotcha sysio-read-static \
                   sysio-writeread-gotcha sysio-writeread-static \
                   sysio-writeread2-gotcha sysio-writeread2-static \
+                  sysio-dir-gotcha sysio-dir-static \
+                  sysio-stat-gotcha sysio-stat-static \
                   app-mpiio-gotcha app-mpiio-static \
                   app-btio-gotcha app-btio-static \
                   app-tileio-gotcha app-tileio-static
@@ -52,6 +54,26 @@ sysio_writeread2_static_SOURCES = sysio-writeread2.c
 sysio_writeread2_static_CPPFLAGS = $(test_cppflags)
 sysio_writeread2_static_LDADD   = $(test_static_ldadd)
 sysio_writeread2_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_dir_gotcha_SOURCES = sysio-dir.c
+sysio_dir_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_dir_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_dir_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_dir_static_SOURCES = sysio-dir.c
+sysio_dir_static_CPPFLAGS = $(test_cppflags)
+sysio_dir_static_LDADD   = $(test_static_ldadd)
+sysio_dir_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_stat_gotcha_SOURCES = sysio-stat.c
+sysio_stat_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_stat_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_stat_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_stat_static_SOURCES = sysio-stat.c
+sysio_stat_static_CPPFLAGS = $(test_cppflags)
+sysio_stat_static_LDADD   = $(test_static_ldadd)
+sysio_stat_static_LDFLAGS = $(test_static_ldflags)
 
 app_mpiio_gotcha_SOURCES = app-mpiio.c
 app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)

--- a/examples/src/sysio-dir.c
+++ b/examples/src/sysio-dir.c
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+static int standard;        /* not mounting unifycr when set */
+static int synchronous;     /* sync metadata for each op? (default: no)*/
+
+static int rank;
+static int total_ranks;
+
+static int debug;           /* pause for attaching debugger */
+static int unmount;         /* unmount unifycr after running the test */
+static uint64_t count = 10; /* number of directories each rank creates */
+static char *mountpoint = "/tmp";  /* unifycr mountpoint */
+static char *testdir = "testdir";  /* test directory under mountpoint */
+static char targetdir[NAME_MAX];   /* target file name */
+
+static char dirnamebuf[NAME_MAX];
+
+static int do_mkdir(void)
+{
+    int ret = 0;
+    uint64_t i = 0;
+    mode_t mode = 0700;
+    struct stat sb = { 0, };
+
+    ret = stat(targetdir, &sb);
+    if (ret < 0 && errno == ENOENT) {
+        ret = mkdir(targetdir, mode);
+        if (ret < 0) {
+            perror("mkdir");
+            return -1;
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    sprintf(dirnamebuf, "%s/rank-%d", targetdir, rank);
+
+    ret = mkdir(dirnamebuf, mode);
+    if (ret < 0) {
+        test_print(rank, "mkdir failed for %s", dirnamebuf);
+        ret = -errno;
+        goto out;
+    }
+
+    for (i = 0; i < count; i++) {
+        sprintf(dirnamebuf, "%s/rank-%d/dir-%lu", targetdir, rank, i);
+
+        ret = mkdir(dirnamebuf, mode);
+        if (ret < 0) {
+            test_print(rank, "mkdir failed for %s", dirnamebuf);
+            ret = -errno;
+            goto out;
+        }
+    }
+
+out:
+    return ret;
+}
+
+static int do_stat(void)
+{
+    int ret = 0;
+    uint64_t i = 0;
+    struct stat sb = { 0, };
+
+    sprintf(dirnamebuf, "%s/rank-%d", targetdir, rank);
+
+    ret = stat(dirnamebuf, &sb);
+    if (ret < 0) {
+        test_print(rank, "stat failed for %s", dirnamebuf);
+        ret = -errno;
+        goto out;
+    }
+
+    for (i = 0; i < count; i++) {
+        sprintf(dirnamebuf, "%s/rank-%d/dir-%lu", targetdir, rank, i);
+
+        ret = stat(dirnamebuf, &sb);
+        if (ret < 0) {
+            test_print(rank, "stat failed for %s", dirnamebuf);
+            ret = -errno;
+            goto out;
+        }
+
+        /* print some fields.. */
+        printf("\n## %s\n"
+               "ino: %lu\n"
+               "mode: %o\n"
+               "ctime: %lu\n"
+               "atime: %lu\n"
+               "mtime: %lu\n",
+               dirnamebuf,
+               sb.st_ino, sb.st_mode,
+               sb.st_ctime, sb.st_atime, sb.st_mtime);
+    }
+
+out:
+    return ret;
+}
+
+static int do_readdir(void)
+{
+    return 0;
+}
+
+static int do_rmdir(void)
+{
+    return 0;
+}
+
+enum {
+    DIRTEST_ALL = 0,
+    DIRTEST_MKDIR,
+    DIRTEST_STAT,
+    DIRTEST_READDIR,
+    DIRTEST_RMDIR,
+    N_DIRTESTS,
+};
+
+static int singletest;
+
+static const char *singletest_names[N_DIRTESTS] = {
+    "all", "mkdir", "stat", "readdir", "rmdir"
+};
+
+static int set_singletest(const char *testname)
+{
+    int i = 0;
+
+    if (singletest) {
+        fprintf(stderr, "Only a single test can be performed with "
+                        "--singletest option.\n");
+        exit(1);
+    }
+
+    for (i = 0; i < N_DIRTESTS; i++)
+        if (strcmp(testname, singletest_names[i]) == 0)
+            return i;
+
+    fprintf(stderr, "%s is not a valid test name.\n", testname);
+    exit(1);
+}
+
+typedef int (*dirtest_func_t)(void);
+
+static dirtest_func_t test_funcs[N_DIRTESTS] = {
+    0, do_mkdir, do_stat, do_readdir, do_rmdir
+};
+
+static struct option const long_opts[] = {
+    { "debug", 0, 0, 'd' },
+    { "dirname", 1, 0, 'D' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "count", 1, 0, 'n' },
+    { "synchronous", 0, 0, 'S' },
+    { "standard", 0, 0, 's' },
+    { "singletest", 1, 0, 't' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "dD:hm:n:Sst:u";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...]\n"
+"\n"
+"Available options:\n"
+" -d, --debug                      pause before running test\n"
+"                                  (handy for attaching in debugger)\n"
+" -D, --dirname=<dirname>          test directory name under mountpoint\n"
+"                                  (default: testdir)\n"
+" -h, --help                       help message\n"
+" -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+"                                  (default: /tmp)\n"
+" -n, --count=<NUM>                number of directories that each rank will\n"
+"                                  create (default: 10)\n"
+" -S, --synchronous                sync metadata on each write\n"
+" -s, --standard                   do not use unifycr but run standard I/O\n"
+" -t, --singletest=<operation>     only test a single operation\n"
+"                                  (operations: mkdir, stat, readdir, rmdir)\n"
+" -u, --unmount                    unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 2;
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'D':
+            testdir = strdup(optarg);
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'n':
+            count = strtoull(optarg, 0, 0);
+            break;
+
+        case 'S':
+            synchronous = 1;
+            break;
+
+        case 's':
+            standard = 1;
+            break;
+
+        case 't':
+            singletest = set_singletest(optarg);
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (static_linked(program) && standard) {
+        test_print_once(rank, "--standard, -s option only works when "
+                              "dynamically linked.\n");
+        exit(-1);
+    }
+
+    sprintf(targetdir, "%s/%s", mountpoint, testdir);
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    if (!standard) {
+        ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+        if (ret) {
+            test_print(rank, "unifycr_mount failed (return = %d)", ret);
+            exit(-1);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (singletest) {
+        test_print_once(rank, "only testing %s ..\n",
+                        singletest_names[singletest]);
+        ret = test_funcs[singletest]();
+        if (ret < 0) {
+            fprintf(stderr, "%s test failed.\n", singletest_names[singletest]);
+            goto out;
+        }
+        goto out_unmount;
+    }
+
+    ret = do_mkdir();
+    if (ret < 0) {
+        fprintf(stderr, "directory creation failed..\n");
+        goto out;
+    }
+
+    ret = do_stat();
+    if (ret < 0) {
+        fprintf(stderr, "directory stat failed..\n");
+        goto out;
+    }
+
+    ret = do_readdir();
+    if (ret < 0) {
+        fprintf(stderr, "directory read failed..\n");
+        goto out;
+    }
+
+    ret = do_rmdir();
+    if (ret < 0) {
+        fprintf(stderr, "directory  failed..\n");
+        goto out;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+out_unmount:
+    if (!standard && unmount && rank == 0)
+        unifycr_unmount();
+out:
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/examples/src/sysio-read.c
+++ b/examples/src/sysio-read.c
@@ -244,6 +244,7 @@ static const char *usage_str =
 "                                  (default: /tmp)\n"
 " -P, --pread                      use pread(2) instead of read(2)\n"
 " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
+"                                  (default: n1)\n"
 " -s, --standard                   do not use unifycr but run standard I/O\n"
 " -u, --unmount                    unmount the filesystem after test\n"
 "\n";

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <time.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+static int rank;
+static int total_ranks;
+static int debug;
+
+static char *mountpoint = "/tmp";  /* unifycr mountpoint */
+static char *filename = "/tmp";
+static int unmount;                /* unmount unifycr after running the test */
+
+#define FP_SPECIAL 1
+
+static void dump_stat(int rank, const struct stat *sb)
+{
+    printf("## [RANK %d] %s\n", rank, filename);
+    printf("File type:                ");
+
+    switch (sb->st_mode & S_IFMT) {
+    case S_IFREG:
+        printf("regular file\n");
+        break;
+    case S_IFDIR:
+        printf("directory\n");
+        break;
+    case S_IFCHR:
+        printf("character device\n");
+        break;
+    case S_IFBLK:
+        printf("block device\n");
+        break;
+    case S_IFLNK:
+        printf("symbolic (soft) link\n");
+        break;
+    case S_IFIFO:
+        printf("FIFO or pipe\n");
+        break;
+    case S_IFSOCK:
+        printf("socket\n");
+        break;
+    default:
+        printf("unknown file type?\n");
+        break;
+    }
+
+    printf("Device containing i-node: major=%ld   minor=%ld\n",
+            (long) major(sb->st_dev), (long) minor(sb->st_dev));
+
+    printf("I-node number:            %ld\n", (long) sb->st_ino);
+
+    printf("Mode:                     %lo\n",
+            (unsigned long) sb->st_mode);
+
+    if (sb->st_mode & (S_ISUID | S_ISGID | S_ISVTX))
+        printf("    special bits set:     %s%s%s\n",
+                (sb->st_mode & S_ISUID) ? "set-UID " : "",
+                (sb->st_mode & S_ISGID) ? "set-GID " : "",
+                (sb->st_mode & S_ISVTX) ? "sticky " : "");
+
+    printf("Number of (hard) links:   %ld\n", (long) sb->st_nlink);
+
+    printf("Ownership:                UID=%ld   GID=%ld\n",
+            (long) sb->st_uid, (long) sb->st_gid);
+
+    if (S_ISCHR(sb->st_mode) || S_ISBLK(sb->st_mode))
+        printf("Device number (st_rdev):  major=%ld; minor=%ld\n",
+                (long) major(sb->st_rdev), (long) minor(sb->st_rdev));
+
+    printf("File size:                %lld bytes\n", (long long) sb->st_size);
+    printf("Optimal I/O block size:   %ld bytes\n", (long) sb->st_blksize);
+    printf("512B blocks allocated:    %lld\n", (long long) sb->st_blocks);
+
+    printf("Last file access:         %s", ctime(&sb->st_atime));
+    printf("Last file modification:   %s", ctime(&sb->st_mtime));
+    printf("Last status change:       %s\n\n", ctime(&sb->st_ctime));
+}
+
+static struct option const long_opts[] = {
+    { "debug", 0, 0, 'd' },
+    { "filename", 1, 0, 'f' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "df:hm:u";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...]\n"
+"\n"
+"Available options:\n"
+" -d, --debug                      pause before running test\n"
+"                                  (handy for attaching in debugger)\n"
+" -f, --filename=<filename>        filename of the target entry\n"
+"                                  (default: /tmp)\n"
+" -h, --help                       help message\n"
+" -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+"                                  (default: /tmp)\n"
+" -u, --unmount                    unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 0;
+    struct stat sb = { 0, };
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'f':
+            filename = strdup(optarg);
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+    if (ret) {
+        test_print(rank, "unifycr_mount failed (return = %d)", ret);
+        exit(-1);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ret = stat(filename, &sb);
+    if (ret < 0)
+        test_print(rank, "stat failed on \"%s\"\n", filename);
+    else
+        dump_stat(rank, &sb);
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (unmount && rank == 0)
+        unifycr_unmount();
+
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -195,6 +195,7 @@ static const char *usage_str =
 "                                  (default: /tmp)\n"
 " -P, --pwrite                     use pwrite(2) instead of write(2)\n"
 " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
+"                                  (default: n1)\n"
 " -S, --synchronous                sync metadata on each write\n"
 " -s, --standard                   do not use unifycr but run standard I/O\n"
 " -u, --unmount                    unmount the filesystem after test\n"

--- a/examples/src/testlib.h
+++ b/examples/src/testlib.h
@@ -21,6 +21,9 @@
 #include <string.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <mpi.h>
 
 extern int errno;

--- a/server/src/unifycr_cmd_handler.c
+++ b/server/src/unifycr_cmd_handler.c
@@ -82,7 +82,7 @@ int delegator_handle_command(char *ptr_cmd, int sock_id)
     case COMM_META_GET:
         (void)0;
         /*get file attribute*/
-        unifycr_file_attr_t attr_val;
+        unifycr_file_attr_t attr_val = { 0, };
 
         fattr_key_t _fattr_key = *((int *)(ptr_cmd + 1 * sizeof(int)));
 


### PR DESCRIPTION
This patch allows UnifyCR to correctly send file and directory attributes to
the global metadata server, addressing #148 and #166. In specific:

- Directories are now created globally by sending directory attributes to the
global metadata server.
- File stat data is also properly populated globally.
- Some improvement/refactoring in unifycr.c.

TEST_CHECKPATCH_SKIP_FILES="client/src/gotcha_map_unifycr_list.h"

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
