### PR TITLE
Add missing GOTCHA wrapper for lio_listio

### DIFF
--- a/client/src/gotcha_map_unifycr_list.h
+++ b/client/src/gotcha_map_unifycr_list.h
@@ -17,6 +17,8 @@ UNIFYCR_DEF(creat, int, (const char *path, mode_t mode));
 UNIFYCR_DEF(creat64, int, (const char *path, mode_t mode));
 UNIFYCR_DEF(open, int, (const char *path, int flags, ...));
 UNIFYCR_DEF(open64, int, (const char *path, int flags, ...));
+UNIFYCR_DEF(lio_listio, int, (int mode, struct aiocb *const aiocb_list[],
+                              int nitems, struct sigevent *sevp));
 UNIFYCR_DEF(lseek, off_t, (int fd, off_t offset, int whence));
 UNIFYCR_DEF(lseek64, off64_t, (int fd, off64_t offset, int whence));
 UNIFYCR_DEF(posix_fadvise, int, (int fd, off_t offset, off_t len, int advice));
@@ -103,6 +105,7 @@ struct gotcha_binding_t wrap_unifycr_list[] = {
     { "creat64", UNIFYCR_WRAP(creat64), &UNIFYCR_REAL(creat64) },
     { "open", UNIFYCR_WRAP(open), &UNIFYCR_REAL(open) },
     { "open64", UNIFYCR_WRAP(open64), &UNIFYCR_REAL(open64) },
+    { "lio_listio", UNIFYCR_WRAP(lio_listio), &UNIFYCR_REAL(lio_listio) },
     { "lseek", UNIFYCR_WRAP(lseek), &UNIFYCR_REAL(lseek) },
     { "lseek64", UNIFYCR_WRAP(lseek64), &UNIFYCR_REAL(lseek64) },
     { "posix_fadvise", UNIFYCR_WRAP(posix_fadvise), &UNIFYCR_REAL(posix_fadvise) },

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -56,6 +56,7 @@
  * Common includes
  * -------------------------------
  */
+#include <aio.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -94,9 +94,8 @@ UNIFYCR_DECL(munmap, int, (void *addr, size_t length));
 UNIFYCR_DECL(msync, int, (void *addr, size_t length, int flags));
 UNIFYCR_DECL(__fxstat, int, (int vers, int fd, struct stat *buf));
 UNIFYCR_DECL(close, int, (int fd));
-/*UNIFYCR_DECL(lio_listio, ssize_t, (int mode,\
-   struct aiocb *const aiocb_list[], \
-                      int nitems, struct sigevent *sevp));*/
+UNIFYCR_DECL(lio_listio, int, (int mode, struct aiocb *const aiocb_list[],
+                               int nitems, struct sigevent *sevp));
 
 /* read count bytes info buf from file starting at offset pos,
  * returns number of bytes actually read in retcount,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The GOTCHA wrapper for lio_listio isn't getting invoked in any of the
-gotcha POSIX I/O tests that make this call (sysio-writeread-gotcha
and sysio-read-gotcha). This adds the missing UNIFYCR_DEF and
UNIFYCR_DECL so that GOTCHA can find our lio_listio wrapper.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The two POSIX tests that call lio_listio would often still appear to succeed
as libc would still pick up the call when our wrapper wasn't getting invoked.
This ensures that our lio_listio wrapper gets called when using gotcha.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Stepped through the sysio-writeread-gotcha and sysio-read-gotcha tests
in TotalView to verify our lio_listio wrapper was stepped into when lio_listio
was called.
This was verified when running the sysio-writeread-gotcha test with both the
 `-p 0` and `-p 1` options.
This was verified when running the sysio-read-gotcha test with the `-l` option.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.