### PR TITLE
Fixes an offset calculation bug in unifycr_unpack_client_context.

### DIFF
--- a/common/src/unifycr_client_context.c
+++ b/common/src/unifycr_client_context.c
@@ -105,6 +105,7 @@ int unifycr_unpack_client_context(void *buffer, off_t *offset,
     *offset += sizeof(ctx->meta_offset);
 
     ctx->meta_size = *(long *)(buffer + *offset);
+    *offset += sizeof(ctx->meta_size);
 
     ctx->fmeta_offset = *(long *)(buffer + *offset);
     *offset += sizeof(ctx->fmeta_offset);


### PR DESCRIPTION
The `unifycr_client_unpack` function (https://github.com/LLNL/UnifyCR/commit/42ae7d60f2da0c0c7658afa76f26574bb85ba321) calculates offset incorrectly, which leads to read call unresponsive (poll deadlock?). This patch fixes the offset calculation.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)