### PR TITLE
Add pure POSIX version of sysio-writeread example

### DIFF
--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -1,6 +1,6 @@
 noinst_PROGRAMS = sysio-write-gotcha sysio-write-static \
                   sysio-read-gotcha sysio-read-static \
-                  sysio-writeread-gotcha sysio-writeread-static \
+                  sysio-writeread-gotcha sysio-writeread-static sysio-writeread-posix \
                   sysio-writeread2-gotcha sysio-writeread2-static \
                   sysio-dir-gotcha sysio-dir-static \
                   sysio-stat-gotcha sysio-stat-static \
@@ -34,6 +34,11 @@ sysio_read_static_SOURCES = sysio-read.c
 sysio_read_static_CPPFLAGS = $(test_cppflags)
 sysio_read_static_LDADD   = $(test_static_ldadd)
 sysio_read_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_writeread_posix_SOURCES = sysio-writeread.c
+sysio_writeread_posix_CPPFLAGS = $(AM_CPPFLAGS) -DNO_UNIFYCR
+sysio_writeread_posix_LDADD = -lrt -lm
+sysio_writeread_posix_LDFLAGS = $(AM_LDFLAGS)
 
 sysio_writeread_gotcha_SOURCES = sysio-writeread.c
 sysio_writeread_gotcha_CPPFLAGS = $(test_cppflags)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

This commit updates the sysio-writeread.c example to allow for a pure POSIX build,
which doesn't include `unifycr.h` and does not call `unifycr_mount` and `unifycr_unmount`.

This pure POSIX version is the baseline used for recent Summitdev experiments.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
