### PR TITLE
define MPI build flags with m4 script

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -5,8 +5,10 @@ libunifycr_gotchadir = $(includedir)
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing
 
-libunifycr_HEADERS = unifycr.h
+include_HEADERS = unifycr.h
+
 libunifycr_la_SOURCES = \
+  unifycr.h \
   unifycr-fixed.c \
   unifycr-fixed.h \
   unifycr-stack.c \
@@ -28,12 +30,13 @@ libunifycr_la_CPPFLAGS = \
   -I$(top_builddir)/client \
   -I$(top_srcdir)/common/src
 
-libunifycr_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION)
+libunifycr_la_CFLAGS = $(MPI_CFLAGS)
+libunifycr_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(MPI_CLDFLAGS)
 libunifycr_la_LIBADD = $(top_builddir)/common/src/libunifycr_common.la \
 					   -lcrypto -lrt -lpthread
 
-libunifycr_gotcha_HEADERS = unifycr.h
 libunifycr_gotcha_la_SOURCES = \
+  unifycr.h \
   unifycr-fixed.c \
   unifycr-fixed.h \
   unifycr-stack.c \
@@ -57,8 +60,8 @@ libunifycr_gotcha_la_CPPFLAGS = \
   -I$(top_builddir)/client \
   -I$(top_srcdir)/common/src
 
-libunifycr_gotcha_la_CFLAGS = $(GOTCHA_CFLAGS)
-libunifycr_gotcha_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(GOTCHA_LDFLAGS)
+libunifycr_gotcha_la_CFLAGS = $(GOTCHA_CFLAGS) $(MPI_CFLAGS)
+libunifycr_gotcha_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(GOTCHA_LDFLAGS) $(MPI_CLDFLAGS)
 libunifycr_gotcha_la_LIBADD = $(top_builddir)/common/src/libunifycr_common.la \
                               -lgotcha -lcrypto -lrt -lpthread
 

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,6 @@ AM_SILENT_RULES([yes])
 
 AM_MAINTAINER_MODE([disable])
 
-AC_PROG_CC([mpicc])
 AC_PROG_CC_STDC
 AC_PROG_AWK
 AC_PROG_CPP
@@ -133,6 +132,9 @@ AC_TRY_COMPILE(
 )
 
 AC_CHECK_HEADERS(mntent.h sys/mount.h)
+
+# look for MPI and set flags
+LX_FIND_MPI
 
 # check leveldb
 PKG_CHECK_MODULES([LEVELDB], [leveldb], ,

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -10,10 +10,10 @@ noinst_PROGRAMS = sysio-write-gotcha sysio-write-static \
 
 noinst_HEADERS = testlib.h
 
-test_gotcha_ldadd = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm
+test_gotcha_ldadd = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm $(MPI_CLDFLAGS)
 test_static_ldadd = $(top_builddir)/client/src/libunifycr.la -lrt -lm
-test_static_ldflags = -static $(CP_WRAPPERS) $(AM_LDFLAGS)
-test_cppflags = $(AM_CPPFLAGS) -I$(top_srcdir)/client/src
+test_static_ldflags = -static $(CP_WRAPPERS) $(AM_LDFLAGS) $(MPI_CLDFLAGS)
+test_cppflags = $(AM_CPPFLAGS) -I$(top_srcdir)/client/src $(MPI_CFLAGS)
 
 sysio_write_gotcha_SOURCES = sysio-write.c
 sysio_write_gotcha_CPPFLAGS = $(test_cppflags)
@@ -36,9 +36,9 @@ sysio_read_static_LDADD   = $(test_static_ldadd)
 sysio_read_static_LDFLAGS = $(test_static_ldflags)
 
 sysio_writeread_posix_SOURCES = sysio-writeread.c
-sysio_writeread_posix_CPPFLAGS = $(AM_CPPFLAGS) -DNO_UNIFYCR
+sysio_writeread_posix_CPPFLAGS = $(AM_CPPFLAGS) -DNO_UNIFYCR $(MPI_CFLAGS)
 sysio_writeread_posix_LDADD = -lrt -lm
-sysio_writeread_posix_LDFLAGS = $(AM_LDFLAGS)
+sysio_writeread_posix_LDFLAGS = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
 
 sysio_writeread_gotcha_SOURCES = sysio-writeread.c
 sysio_writeread_gotcha_CPPFLAGS = $(test_cppflags)

--- a/m4/lx_find_mpi.m4
+++ b/m4/lx_find_mpi.m4
@@ -1,0 +1,162 @@
+##########################################################################
+# Written by Todd Gamblin, tgamblin@llnl.gov.
+#
+# LX_FIND_MPI()
+#  ------------------------------------------------------------------------
+# This macro finds an MPI compiler and extracts includes and libraries from
+# it for use in automake projects.  The script exports the following variables:
+#
+# AC_DEFINE variables:
+#     HAVE_MPI         AC_DEFINE'd to 1 if we found MPI
+#
+# AC_SUBST variables:
+#     MPICC            Name of MPI compiler
+#     MPI_CFLAGS       Includes and defines for MPI C compilation
+#     MPI_CLDFLAGS     Libraries and library paths for linking MPI C programs
+#
+#     MPICXX           Name of MPI C++ compiler
+#     MPI_CXXFLAGS     Includes and defines for MPI C++ compilation
+#     MPI_CXXLDFLAGS   Libraries and library paths for linking MPI C++ programs
+#
+#     MPIF77           Name of MPI Fortran 77 compiler
+#     MPI_F77FLAGS     Includes and defines for MPI Fortran 77 compilation
+#     MPI_F77LDFLAGS   Libraries and library paths for linking MPI Fortran 77 programs
+#
+#     MPIFC            Name of MPI Fortran compiler
+#     MPI_FFLAGS       Includes and defines for MPI Fortran compilation
+#     MPI_FLDFLAGS     Libraries and library paths for linking MPI Fortran programs
+#
+# Shell variables output by this macro:
+#     have_C_mpi       'yes' if we found MPI for C, 'no' otherwise
+#     have_CXX_mpi     'yes' if we found MPI for C++, 'no' otherwise
+#     have_F77_mpi     'yes' if we found MPI for F77, 'no' otherwise
+#     have_F_mpi       'yes' if we found MPI for Fortran, 'no' otherwise
+#
+##########################################################################
+AC_DEFUN([LX_FIND_MPI],
+[
+     AC_LANG_CASE(
+     [C], [
+         AC_REQUIRE([AC_PROG_CC])
+         if [[ ! -z "$MPICC" ]]; then
+             LX_QUERY_MPI_COMPILER(MPICC, [$MPICC], C)
+         else
+             LX_QUERY_MPI_COMPILER(MPICC, [mpicc mpiicc mpixlc mpipgcc], C)
+         fi
+     ],
+     [C++], [
+         AC_REQUIRE([AC_PROG_CXX])
+         if [[ ! -z "$MPICXX" ]]; then
+             LX_QUERY_MPI_COMPILER(MPICXX, [$MPICXX], CXX)
+         else
+             LX_QUERY_MPI_COMPILER(MPICXX, [mpicxx mpiCC mpic++ mpig++ mpiicpc mpipgCC mpixlC], CXX)
+         fi
+     ],
+     [F77], [
+         AC_REQUIRE([AC_PROG_F77])
+         if [[ ! -z "$MPIF77" ]]; then
+             LX_QUERY_MPI_COMPILER(MPIF77, [$MPIF77], F77)
+         else
+             LX_QUERY_MPI_COMPILER(MPIF77, [mpif77 mpiifort mpixlf77 mpixlf77_r], F77)
+         fi
+     ],
+     [Fortran], [
+         AC_REQUIRE([AC_PROG_FC])
+         if [[ ! -z "$MPIFC" ]]; then
+             LX_QUERY_MPI_COMPILER(MPIFC, [$MPIFC], F)
+         else
+             mpi_default_fc="mpif95 mpif90 mpigfortran mpif2003"
+             mpi_intel_fc="mpiifort"
+             mpi_xl_fc="mpixlf95 mpixlf95_r mpixlf90 mpixlf90_r mpixlf2003 mpixlf2003_r"
+             mpi_pg_fc="mpipgf95 mpipgf90"
+             LX_QUERY_MPI_COMPILER(MPIFC, [$mpi_default_fc $mpi_intel_fc $mpi_xl_fc $mpi_pg_fc], F)
+         fi
+     ])
+])
+
+
+#
+# LX_QUERY_MPI_COMPILER([compiler-var-name], [compiler-names], [output-var-prefix])
+#  ------------------------------------------------------------------------
+# AC_SUBST variables:
+#     MPI_<prefix>FLAGS       Includes and defines for MPI compilation
+#     MPI_<prefix>LDFLAGS     Libraries and library paths for linking MPI C programs
+#     MPI_<prefix>RPATH       RPath parameters extracted from the MPI C compiler
+#
+# Shell variables output by this macro:
+#     found_mpi_flags         'yes' if we were able to get flags, 'no' otherwise
+#
+AC_DEFUN([LX_QUERY_MPI_COMPILER],
+[
+     # Try to find a working MPI compiler from the supplied names
+     AC_PATH_PROGS($1, [$2], [not-found])
+
+     # Figure out what the compiler responds to to get it to show us the compile
+     # and link lines.  After this part of the macro, we'll have a valid
+     # lx_mpi_command_line
+     echo -n "Checking whether $$1 responds to '-showme:compile'... "
+     lx_mpi_compile_line=`$$1 -showme:compile 2>/dev/null`
+     if [[ "$?" -eq 0 ]]; then
+         echo yes
+         lx_mpi_link_line=`$$1 -showme:link 2>/dev/null`
+     else
+         echo no
+         echo -n "Checking whether $$1 responds to '-showme'... "
+         lx_mpi_command_line=`$$1 -showme 2>/dev/null`
+         if [[ "$?" -ne 0 ]]; then
+             echo no
+             echo -n "Checking whether $$1 responds to '-compile-info'... "
+             lx_mpi_compile_line=`$$1 -compile-info 2>/dev/null`
+             if [[ "$?" -eq 0 ]]; then
+                 echo yes
+                 lx_mpi_link_line=`$$1 -link-info 2>/dev/null`
+             else
+                 echo no
+                 echo -n "Checking whether $$1 responds to '-show'... "
+                 lx_mpi_command_line=`$$1 -show 2>/dev/null`
+                 if [[ "$?" -eq 0 ]]; then
+                     echo yes
+                 else
+                     echo no
+                 fi
+             fi
+         else
+             echo yes
+         fi
+     fi
+
+     if [[ ! -z "$lx_mpi_compile_line" -a ! -z "$lx_mpi_link_line" ]]; then
+         lx_mpi_command_line="$lx_mpi_compile_line $lx_mpi_link_line"
+     fi
+
+     if [[ ! -z "$lx_mpi_command_line" ]]; then
+         # Now extract the different parts of the MPI command line.  Do these separately in case we need to
+         # parse them all out in future versions of this macro.
+         lx_mpi_defines=`    echo "$lx_mpi_command_line" | grep -o -- '\(^\| \)-D\([[^\"[:space:]]]\+\|\"[[^\"[:space:]]]\+\"\)'`
+         lx_mpi_includes=`   echo "$lx_mpi_command_line" | grep -o -- '\(^\| \)-I\([[^\"[:space:]]]\+\|\"[[^\"[:space:]]]\+\"\)'`
+         lx_mpi_link_paths=` echo "$lx_mpi_command_line" | grep -o -- '\(^\| \)-L\([[^\"[:space:]]]\+\|\"[[^\"[:space:]]]\+\"\)'`
+         lx_mpi_libs=`       echo "$lx_mpi_command_line" | grep -o -- '\(^\| \)-l\([[^\"[:space:]]]\+\|\"[[^\"[:space:]]]\+\"\)'`
+         lx_mpi_link_args=`  echo "$lx_mpi_command_line" | grep -o -- '\(^\| \)-Wl,\([[^\"[:space:]]]\+\|\"[[^\"[:space:]]]\+\"\)'`
+
+         # Create variables and clean up newlines and multiple spaces
+         MPI_$3FLAGS="$lx_mpi_defines $lx_mpi_includes"
+         MPI_$3LDFLAGS="$lx_mpi_link_paths $lx_mpi_libs $lx_mpi_link_args"
+         MPI_$3FLAGS=`  echo "$MPI_$3FLAGS"   | tr '\n' ' ' | sed 's/^[[ \t]]*//;s/[[ \t]]*$//' | sed 's/  */ /g'`
+         MPI_$3LDFLAGS=`echo "$MPI_$3LDFLAGS" | tr '\n' ' ' | sed 's/^[[ \t]]*//;s/[[ \t]]*$//' | sed 's/  */ /g'`
+
+         # Add a define for testing at compile time.
+         AC_DEFINE([HAVE_MPI], [1], [Define to 1 if you have MPI libs and headers.])
+
+         # AC_SUBST everything.
+         AC_SUBST($1)
+         AC_SUBST(MPI_$3FLAGS)
+         AC_SUBST(MPI_$3LDFLAGS)
+
+         # set a shell variable that the caller can test outside this macro
+         have_$3_mpi='yes'
+     else
+         Echo Unable to find suitable MPI Compiler. Try setting $1.
+         have_$3_mpi='no'
+     fi
+])
+

--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -27,10 +27,12 @@ libmdhim_a_SOURCES = Mlog2/mlog2.c \
                      mdhim.h \
                      uthash/uthash.h
 
+libmdhim_a_LDFLAGS = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
+
 AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
               -I$(top_srcdir)/meta/src/uthash
 
-AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS)
+AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS) $(MPI_CFLAGS)
 AM_CFLAGS += -Wall
 
 CLEANFILES =

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -25,6 +25,7 @@ unifycrd_LDFLAGS = -static
 unifycrd_LDADD = $(top_builddir)/common/src/libunifycr_common.la \
                  $(top_builddir)/meta/src/libmdhim.a \
                  $(LEVELDB_LIBS) \
+                 $(MPI_CLDFLAGS) \
                  -lpthread -lm -lstdc++ -lrt
 
 AM_CPPFLAGS = -I$(top_srcdir)/common/src \
@@ -32,6 +33,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/common/src \
               -I$(top_srcdir)/meta/src/uthash \
               -I$(top_srcdir)/meta/src/Mlog2
 
-AM_CFLAGS = -Wall
+AM_CFLAGS = -Wall $(MPI_CFLAGS)
 
 CLEANFILES = $(bin_PROGRAMS)

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -35,13 +35,15 @@ libexec_PROGRAMS = \
 test_ldadd = \
 	$(top_builddir)/t/lib/libtap.la \
 	$(top_builddir)/t/lib/libtestutil.la \
-	$(top_builddir)/client/src/libunifycr_gotcha.la
+	$(top_builddir)/client/src/libunifycr_gotcha.la \
+        $(MPI_CLDFLAGS)
 
 test_cppflags = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/client/src \
 	-D_GNU_SOURCE \
-	$(AM_CPPFLAGS)
+	$(AM_CPPFLAGS) \
+        $(MPI_CFLAGS)
 
 sys_open_t_SOURCES = sys/open.c
 sys_open_t_CPPFLAGS = $(test_cppflags)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The spack build is getting confused with our use of AC_PROG_CC([mpicc]).  This patch uses a different method that determines the MPI build flags with an m4 script that is known to work with spack in other packages.

### Description
<!--- Describe your changes in detail -->
Adds new lx_find_mpi.m4 script to detect MPI build flags.  Adds CFLAGS and LDFLAGS to various Makefile.am to pick up those flags.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
