### PR TITLE
Read bug fix and a file copy example using read(2)/write(2) syscalls.

### DIFF
--- a/client/src/unifycr-dirops.c
+++ b/client/src/unifycr-dirops.c
@@ -106,7 +106,7 @@ DIR *UNIFYCR_WRAP(opendir)(const char *name)
          */
         meta->size = sb->st_size;
         meta->chunks = sb->st_blocks;
-        meta->real_size = sb->st_size;
+        meta->log_size = 0; /* no need of local storage for dir operations */
     } else {
         fid = unifycr_fid_create_file(name);
         if (fid < 0) {
@@ -118,7 +118,7 @@ DIR *UNIFYCR_WRAP(opendir)(const char *name)
         meta->is_dir = 1;
         meta->size = sb->st_size;
         meta->chunks = sb->st_blocks;
-        meta->real_size = sb->st_size;
+        meta->log_size = 0;
     }
 
     _dirp = unifycr_dirstream_alloc(fid);

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -258,7 +258,7 @@ typedef struct {
 
 typedef struct {
     off_t size;                     /* current file size */
-    off_t real_size;                                /* real size of the file for logio*/
+    off_t log_size;                 /* real size of the file for logio*/
     int is_dir;                     /* is this file a directory */
     pthread_spinlock_t fspinlock;   /* file lock variable */
     enum flock_enum flock_status;   /* file lock status */
@@ -267,7 +267,6 @@ typedef struct {
 
     off_t chunks;                   /* number of chunks allocated to file */
     unifycr_chunkmeta_t *chunk_meta; /* meta data for chunks */
-
 } unifycr_filemeta_t;
 
 /* path to fid lookup struct */

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -850,7 +850,7 @@ int unifycr_fid_create_file(const char *path)
     meta->size    = 0;
     meta->chunks  = 0;
     meta->is_dir  = 0;
-    meta->real_size = 0;
+    meta->log_size = 0;
     meta->storage = FILE_STORAGE_NULL;
     meta->flock_status = UNLOCKED;
     /* PTHREAD_PROCESS_SHARED allows Process-Shared Synchronization*/
@@ -1231,7 +1231,7 @@ int unifycr_fid_open(const char *path, int flags, mode_t mode, int *outfid,
 
         meta = unifycr_get_meta_from_fid(fid);
 
-        meta->real_size = gfattr.file_attr.st_size;
+        meta->size = gfattr.file_attr.st_size;
         gfattr.fid = fid;
         gfattr.gfid = gfid;
 

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -4,6 +4,7 @@ libexec_PROGRAMS = sysio-write-gotcha sysio-write-static \
                   sysio-writeread2-gotcha sysio-writeread2-static \
                   sysio-dir-gotcha sysio-dir-static \
                   sysio-stat-gotcha sysio-stat-static \
+                  sysio-cp-gotcha sysio-cp-static \
                   app-mpiio-gotcha app-mpiio-static \
                   app-btio-gotcha app-btio-static \
                   app-tileio-gotcha app-tileio-static
@@ -79,6 +80,16 @@ sysio_stat_static_SOURCES = sysio-stat.c
 sysio_stat_static_CPPFLAGS = $(test_cppflags)
 sysio_stat_static_LDADD   = $(test_static_ldadd)
 sysio_stat_static_LDFLAGS = $(test_static_ldflags)
+
+sysio_cp_gotcha_SOURCES = sysio-cp.c
+sysio_cp_gotcha_CPPFLAGS = $(test_cppflags)
+sysio_cp_gotcha_LDADD = $(test_gotcha_ldadd)
+sysio_cp_gotcha_LDFLAGS = $(AM_LDFLAGS)
+
+sysio_cp_static_SOURCES = sysio-cp.c
+sysio_cp_static_CPPFLAGS = $(test_cppflags)
+sysio_cp_static_LDADD   = $(test_static_ldadd)
+sysio_cp_static_LDFLAGS = $(test_static_ldflags)
 
 app_mpiio_gotcha_SOURCES = app-mpiio.c
 app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)

--- a/examples/src/app-btio.c
+++ b/examples/src/app-btio.c
@@ -193,7 +193,7 @@ int main(int argc, char *argv[])
     memset(buf, 0, elems_per_tile * SZ_PER_ELEM);
 
     MPI_Barrier(MPI_COMM_WORLD);
-    unifycr_mount("/tmp", rank, ranknum, 0);
+    unifycr_mount("/unifycr", rank, ranknum, 0);
     MPI_Barrier(MPI_COMM_WORLD);
 
     int fd = open(fname, O_RDWR | O_CREAT | O_TRUNC, 0600);

--- a/examples/src/app-hdf5-writeread.c
+++ b/examples/src/app-hdf5-writeread.c
@@ -59,7 +59,7 @@ static int writeonly;
 static int debug;           /* pause for attaching debugger */
 static int standard;        /* not mounting unifycr when set */
 static int unmount;         /* unmount unifycr after running the test */
-static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *mountpoint = "/unifycr";   /* unifycr mountpoint */
 static char *filename = "test.h5";  /* testfile name under mountpoint */
 static char targetfile[NAME_MAX];   /* target file name */
 
@@ -85,10 +85,10 @@ static const char *usage_str =
 " -d, --debug                      pause before running test\n"
 "                                  (handy for attaching in debugger)\n"
 " -f, --filename=<filename>        target file name under mountpoint\n"
-"                                  (default: testfile)\n"
+"                                  (default: test.h5)\n"
 " -h, --help                       help message\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -r, --readonly                   only read the dataset\n"
 "                                  (default: write then read)\n"
 " -s, --standard                   do not use unifycr but run standard I/O\n"

--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -53,7 +53,7 @@ static int total_ranks;
 static int debug;                   /* pause for attaching debugger */
 static int unmount;                 /* unmount unifycr after test */
 static char *buf;                   /* I/O buffer */
-static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *mountpoint = "/unifycr";   /* unifycr mountpoint */
 static char *filename = "testfile"; /* testfile name under mountpoint */
 static char targetfile[NAME_MAX];   /* target file name */
 
@@ -229,7 +229,7 @@ static const char *usage_str =
 " -f, --filename=<filename>        target file name (default: testfile)\n"
 " -h, --help                       help message\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
 " -s, --standard                   do not use unifycr but run standard I/O\n"
 " -t, --type=<write|read>          I/O type\n"

--- a/examples/src/app-tileio.c
+++ b/examples/src/app-tileio.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
     memset(buf, 0, x_size * sz_per_elem);
 
     MPI_Barrier(MPI_COMM_WORLD);
-    unifycr_mount("/tmp", rank, ranknum, 0);
+    unifycr_mount("/unifycr", rank, ranknum, 0);
     MPI_Barrier(MPI_COMM_WORLD);
 
     int fd;

--- a/examples/src/sysio-cp.c
+++ b/examples/src/sysio-cp.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <time.h>
+#include <mpi.h>
+#include <unifycr.h>
+
+#include "testlib.h"
+
+static int rank;
+static int total_ranks;
+static int rank_worker;
+static int debug;
+
+static char *mountpoint = "/unifycr";  /* unifycr mountpoint */
+static int unmount;                /* unmount unifycr after running the test */
+
+static char *srcpath;
+static char *dstpath;
+
+static unsigned long bufsize = 64*(1<<10);
+
+static int resolve_dstpath(char *path)
+{
+    int ret = 0;
+    struct stat sb = { 0, };
+    char *tmp = NULL;
+    char *tmpdir = NULL;
+    char *filename = basename(srcpath); /* do not free(3) */
+
+    if (path[strlen(path)-1] == '/')
+        path[strlen(path)-1] = '\0';
+
+    if (path[0] != '/') {
+        tmp = realpath(path, NULL);
+        if (!tmp)
+            return errno;
+    } else
+        tmp = strdup(path);
+
+    ret = stat(tmp, &sb);
+    if (ret == 0 && S_ISDIR(sb.st_mode)) {
+        dstpath = calloc(1, strlen(tmp)+strlen(filename)+2);
+        if (!dstpath)
+            return ENOMEM;
+
+        sprintf(dstpath, "%s/%s", tmp, filename);
+        free(tmp);
+    } else
+        dstpath = tmp;  /* further error will be resolved when open(2) */
+
+    return 0;
+}
+
+static int do_copy(void)
+{
+    int ret = 0;
+    int fd_src = 0;
+    int fd_dst = 0;
+    ssize_t n_read = 0;
+    ssize_t n_written = 0;
+    ssize_t n_left = 0;
+    char *buf = malloc(bufsize);
+
+    if (!buf)
+        return ENOMEM;
+
+    fd_src = open(srcpath, O_RDONLY);
+    if (fd_src < 0)
+        return errno;
+
+    fd_dst = open(dstpath, O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    if (fd_dst < 0) {
+        ret = errno;
+        goto out_close_src;
+    }
+
+    while (1) {
+        n_read = read(fd_src, buf, bufsize);
+        if (n_read == 0)    /* EOF */
+            break;
+
+        if (n_read < 0) {   /* error */
+            ret = errno;
+            goto out_close_dst;
+        }
+
+        n_left = n_read;
+
+        do {
+            n_written = write(fd_dst, buf, n_left);
+            if (n_written < 0) {
+                ret = errno;
+                goto out_close_dst;
+            }
+
+            if (n_written == 0 && errno && errno != EAGAIN) {
+                ret = errno;
+                goto out_close_dst;
+            }
+
+            n_left -= n_written;
+        } while (n_left);
+    }
+
+    fsync(fd_dst);
+
+out_close_dst:
+    close(fd_dst);
+out_close_src:
+    close(fd_src);
+
+    return ret;
+}
+
+static struct option const long_opts[] = {
+    { "bufsize", 1, 0, 'b' },
+    { "debug", 0, 0, 'd' },
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "rank", 1, 0, 'r' },
+    { "unmount", 0, 0, 'u' },
+    { 0, 0, 0, 0},
+};
+
+static char *short_opts = "b:dhm:r:u";
+
+static const char *usage_str =
+"\n"
+"Usage: %s [options...] <source path> <destination path>\n"
+"\n"
+"Available options:\n"
+" -b, --bufsize=<buffersize>   use <buffersize> for copy buffer\n"
+"                              (default: 64KB)\n"
+" -d, --debug                  pause before running test\n"
+"                              (handy for attaching in debugger)\n"
+" -h, --help                   help message\n"
+" -m, --mount=<mountpoint>     use <mountpoint> for unifycr\n"
+"                              (default: /unifycr)\n"
+" -r, --rank=<rank>            use <rank> to copy the file (default: 0)\n"
+" -u, --unmount                unmount the filesystem after test\n"
+"\n";
+
+static char *program;
+
+static void print_usage(void)
+{
+    test_print_once(rank, usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char **argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 0;
+    struct stat sb = { 0, };
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'b':
+            bufsize = strtoul(optarg, NULL, 0);
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'r':
+            rank_worker = atoi(optarg);
+            break;
+
+        case 'u':
+            unmount = 1;
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (argc - optind != 2)
+        print_usage();
+
+    srcpath = strdup(argv[optind++]);
+
+    if (srcpath[strlen(srcpath)-1] == '/')
+        srcpath[strlen(srcpath)-1] = '\0';
+
+    if (debug)
+        test_pause(rank, "Attempting to mount");
+
+    ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
+    if (ret) {
+        test_print(rank, "unifycr_mount failed (return = %d)", ret);
+        goto out;
+    }
+
+    if (rank_worker >= total_ranks) {
+        test_print(rank, "%d is not a valid rank");
+        goto out;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (rank != rank_worker)
+        goto donothing;
+
+    ret = stat(srcpath, &sb);
+    if (ret < 0) {
+        test_print(rank, "stat failed on \"%s\"\n", srcpath);
+        goto out;
+    }
+
+    ret = resolve_dstpath(argv[optind]);
+    if (ret) {
+        test_print(rank, "cannot resolve the destination path \"%s\" (%s)\n",
+                         dstpath, strerror(ret));
+        goto out;
+    }
+
+    ret = do_copy();
+    if (ret)
+        test_print(rank, "copy failed (%d: %s)\n", ret, strerror(ret));
+
+    free(dstpath);
+    free(srcpath);
+
+donothing:
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (unmount && rank == 0)
+        unifycr_unmount();
+
+out:
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/examples/src/sysio-dir.c
+++ b/examples/src/sysio-dir.c
@@ -41,7 +41,7 @@ static int total_ranks;
 static int debug;           /* pause for attaching debugger */
 static int unmount;         /* unmount unifycr after running the test */
 static uint64_t count = 10; /* number of directories each rank creates */
-static char *mountpoint = "/tmp";  /* unifycr mountpoint */
+static char *mountpoint = "/unifycr";  /* unifycr mountpoint */
 static char *testdir = "testdir";  /* test directory under mountpoint */
 static char targetdir[NAME_MAX];   /* target file name */
 
@@ -205,7 +205,7 @@ static const char *usage_str =
 "                                  (default: testdir)\n"
 " -h, --help                       help message\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -n, --count=<NUM>                number of directories that each rank will\n"
 "                                  create (default: 10)\n"
 " -S, --synchronous                sync metadata on each write\n"

--- a/examples/src/sysio-read.c
+++ b/examples/src/sysio-read.c
@@ -51,7 +51,7 @@ static int total_ranks;
 
 static int debug;           /* pause for attaching debugger */
 static int unmount;         /* unmount unifycr after running the test */
-static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *mountpoint = "/unifycr"; /* unifycr mountpoint */
 static char *filename = "testfile"; /* testfile name under mountpoint */
 static char targetfile[NAME_MAX];   /* target file name */
 
@@ -241,7 +241,7 @@ static const char *usage_str =
 " -L, --lipsum                     check contents written by write test\n"
 " -l, --listio                     use lio_listio(2) instead of read(2)\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -P, --pread                      use pread(2) instead of read(2)\n"
 " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
 "                                  (default: n1)\n"

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -37,8 +37,8 @@ static int rank;
 static int total_ranks;
 static int debug;
 
-static char *mountpoint = "/tmp";  /* unifycr mountpoint */
-static char *filename = "/tmp";
+static char *mountpoint = "/unifycr";  /* unifycr mountpoint */
+static char *filename = "/unifycr";
 static int unmount;                /* unmount unifycr after running the test */
 
 #define FP_SPECIAL 1
@@ -109,27 +109,24 @@ static void dump_stat(int rank, const struct stat *sb)
 
 static struct option const long_opts[] = {
     { "debug", 0, 0, 'd' },
-    { "filename", 1, 0, 'f' },
     { "help", 0, 0, 'h' },
     { "mount", 1, 0, 'm' },
     { "unmount", 0, 0, 'u' },
     { 0, 0, 0, 0},
 };
 
-static char *short_opts = "df:hm:u";
+static char *short_opts = "dhm:u";
 
 static const char *usage_str =
 "\n"
-"Usage: %s [options...]\n"
+"Usage: %s [options...] <filename>\n"
 "\n"
 "Available options:\n"
 " -d, --debug                      pause before running test\n"
 "                                  (handy for attaching in debugger)\n"
-" -f, --filename=<filename>        filename of the target entry\n"
-"                                  (default: /tmp)\n"
 " -h, --help                       help message\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -u, --unmount                    unmount the filesystem after test\n"
 "\n";
 
@@ -161,10 +158,6 @@ int main(int argc, char **argv)
             debug = 1;
             break;
 
-        case 'f':
-            filename = strdup(optarg);
-            break;
-
         case 'm':
             mountpoint = strdup(optarg);
             break;
@@ -179,6 +172,11 @@ int main(int argc, char **argv)
             break;
         }
     }
+
+    if (argc - optind != 1)
+        print_usage();
+
+    filename = argv[optind];
 
     if (debug)
         test_pause(rank, "Attempting to mount");

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -59,7 +59,7 @@ static int total_ranks;
 static int debug;           /* pause for attaching debugger */
 static int unmount;         /* unmount unifycr after running the test */
 static char *buf;           /* I/O buffer */
-static char *mountpoint = "/tmp";   /* unifycr mountpoint */
+static char *mountpoint = "/unifycr";   /* unifycr mountpoint */
 static char *filename = "testfile"; /* testfile name under mountpoint */
 static char targetfile[NAME_MAX];   /* target file name */
 
@@ -192,7 +192,7 @@ static const char *usage_str =
 " -h, --help                       help message\n"
 " -L, --lipsum                     generate contents to verify correctness\n"
 " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
-"                                  (default: /tmp)\n"
+"                                  (default: /unifycr)\n"
 " -P, --pwrite                     use pwrite(2) instead of write(2)\n"
 " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
 "                                  (default: n1)\n"

--- a/examples/src/sysio-writeread2.c
+++ b/examples/src/sysio-writeread2.c
@@ -392,11 +392,11 @@ int main(int argc, char *argv[])
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &ranks);
 
-    unifycr_mount("/tmp", rank, ranks, 0);
+    unifycr_mount("/unifycr", rank, ranks, 0);
 
     char name[256];
 
-    sprintf(name, "/tmp/rank.%d", rank);
+    sprintf(name, "/unifycr/rank.%d", rank);
 
     /* allocate space for the checkpoint data (make filesize a function of rank
      * for some variation)


### PR DESCRIPTION
This patch adds a file copy example program. Also fixes the read bug (#183, #185) and the close issue (#186).

- Fixes bug in __wrap_read (to return the corret bytecount).
- Fixes bug in read/pread to return EOF or EINVAL properly.
- Internally syncs file metadata when `close(2)` is called for files opened for writing.
- Changed the default mount point to /unifycr (from /tmp) in example programs.
- (minor) Correctly default file name in help messages for hdf5 examples.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
