### PR TITLE
clean up numa m4, fix compile error in client when using numa

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -51,7 +51,7 @@
 #include <mpi.h>
 #include <openssl/md5.h>
 
-#ifdef ENABLE_NUMA_POLICY
+#ifdef HAVE_LIBNUMA
 #include <numa.h>
 #endif
 
@@ -128,9 +128,7 @@ static size_t
 unifycr_spillover_size;  /* number of bytes in spillover to be used for chunk storage */
 long    unifycr_spillover_max_chunks; /* maximum number of chunks that fit in spillover storage */
 
-
-
-#ifdef ENABLE_NUMA_POLICY
+#ifdef HAVE_LIBNUMA
 static char unifycr_numa_policy[10];
 static int unifycr_numa_bank = -1;
 #endif
@@ -1730,8 +1728,8 @@ static int unifycr_init(int rank)
         unifycr_max_fattr_entries =
             unifycr_fattr_buf_size / sizeof(unifycr_file_attr_t);
 
-#ifdef ENABLE_NUMA_POLICY
-        env = getenv("UNIFYCR_NUMA_POLICY");
+#ifdef HAVE_LIBNUMA
+        char *env = getenv("UNIFYCR_NUMA_POLICY");
         if (env) {
             sprintf(unifycr_numa_policy, env);
             DEBUG("NUMA policy used: %s\n", unifycr_numa_policy);

--- a/m4/check_numa.m4
+++ b/m4/check_numa.m4
@@ -3,79 +3,89 @@ dnl
 dnl This macro searches for an installed numa library. If nothing was
 dnl specified when calling configure, it searches first in /usr/local
 dnl and then in /usr. If the --with-numa=DIR is specified, it will try
-dnl to find it in DIR/include/numa.h and DIR/lib/libz.a. If
+dnl to find it in DIR/include/numa.h and DIR/lib/libnuma.a. If
 dnl --without-numa is specified, the library is not searched at all.
 dnl
-dnl If either the header file (numa.h) or the library (libz) is not
+dnl If either the header file (numa.h) or the library (libnuma) is not
 dnl found, the configuration exits on error, asking for a valid numa
 dnl installation directory or --without-numa.
 dnl
-dnl The macro defines the symbol HAVE_LIBZ if the library is found. You
+dnl The macro defines the symbol HAVE_LIBNUMA if the library is found. You
 dnl should use autoheader to include a definition for this symbol in a
 dnl config.h file. Sample usage in a C/C++ source is as follows:
 dnl
-dnl   #ifdef HAVE_LIBZ
+dnl   #ifdef HAVE_LIBNUMA
 dnl   #include <numa.h>
-dnl   #endif /* HAVE_LIBZ */
+dnl   #endif /* HAVE_LIBNUMA */
 dnl
 dnl @category InstalledPackages
 dnl @author Loic Dachary <loic@senga.org>
 dnl @version 2004-09-20
 dnl @license GPLWithACException
 
-AC_DEFUN([CHECK_NUMA],
+AC_DEFUN([CHECK_NUMA], [
 
 #
 # Handle user hints
 #
-[AC_MSG_CHECKING(if numa is wanted )
+LOOK_FOR_NUMA="no"
+AC_MSG_CHECKING(if numa is wanted )
 AC_ARG_WITH([numa],
-[AS_HELP_STRING([--with-numa=DIR],[root directory path of libnuma installation (defaults to /usr/local or /usr if not found in /usr/local)])],
-[if test "$withval" != no ; then
-  AC_MSG_RESULT(yes)
-  if test -d "$withval"
-  then
-    NUMA_HOME="$withval"
-    AC_DEFINE([ENABLE_NUMA_POLICY], [1], [Define if libnuma is available])
+  [AS_HELP_STRING([--with-numa=DIR],[root directory path of libnuma installation (defaults to /usr/local or /usr if not found in /usr/local)])],
+  [if test "$withval" != "no" ; then
+    AC_MSG_RESULT(yes)
+    LOOK_FOR_NUMA="yes"
+    if test "$withval" != "yes" ; then
+      #
+      # given a path to look in
+      #
+      NUMA_HOME="$withval"
+    fi
   else
-    AC_MSG_CHECKING([for libnuma installation in default locations])
-  fi
-else
-  AC_MSG_RESULT(no)
-fi])
+    AC_MSG_RESULT(no)
+  fi],
+  [AC_MSG_RESULT(no)]
+)
 
 #
 # Locate numa, if wanted
 #
-if test -n "${NUMA_HOME}"
-then
-        NUMA_OLD_LDFLAGS=$LDFLAGS
-        NUMA_OLD_CPPFLAGS=$LDFLAGS
-        LDFLAGS="$LDFLAGS -L${NUMA_HOME}/lib"
-        CPPFLAGS="$CPPFLAGS -I${NUMA_HOME}/include"
-        AC_LANG_SAVE
-        AC_LANG_C
-        AC_CHECK_LIB(numa, numa_num_possible_nodes, [numa_cv_libnuma=yes], [numa_cv_libnuma=no])
-        AC_CHECK_HEADER(numa.h, [numa_cv_numa_h=yes], [numa_cv_numa_h=no])
-        AC_LANG_RESTORE
-        if test "$numa_cv_libnuma" = "yes" -a "$numa_cv_numa_h" = "yes"
-        then
-                #
-                # If both library and header were found, use them
-                #
-                AC_CHECK_LIB(numa, numa_num_possible_nodes)
-                AC_MSG_CHECKING(numa in ${NUMA_HOME})
-                AC_MSG_RESULT(ok)
-        else
-                #
-                # If either header or library was not found, revert and bomb
-                #
-                AC_MSG_CHECKING(numa in ${NUMA_HOME})
-                LDFLAGS="$NUMA_OLD_LDFLAGS"
-                CPPFLAGS="$NUMA_OLD_CPPFLAGS"
-                AC_MSG_RESULT(failed)
-                AC_MSG_ERROR(either specify a valid numa installation with --with-numa=DIR or disable numa usage with --without-numa)
-        fi
+if test "$LOOK_FOR_NUMA" = "yes" ; then
+    #
+    # determine where to look for libnuma
+    #
+    if test -n "${NUMA_HOME}"
+    then
+        AC_MSG_NOTICE([include libnuma from ${NUMA_HOME}])
+
+        #
+        # Look for NUMA where user tells us it is first
+        #
+        CFLAGS="-I${NUMA_HOME}/include $CFLAGS"
+        LDFLAGS="-L${NUMA_HOME}/lib $LDFLAGS"
+    else
+        AC_MSG_NOTICE([checking for libnuma installation in default locations])
+    fi
+
+    #
+    # Locate numa
+    #
+    AC_LANG_SAVE
+    AC_LANG_C
+    AC_CHECK_HEADER(numa.h, [numa_cv_numa_h=yes], [numa_cv_numa_h=no])
+    AC_CHECK_LIB(numa, numa_num_possible_nodes, [numa_cv_libnuma=yes], [numa_cv_libnuma=no])
+    AC_LANG_RESTORE
+
+    #
+    # Determine whether we found it
+    #
+    if test "$numa_cv_libnuma" != "yes" -o "$numa_cv_numa_h" != "yes"
+    then
+            #
+            # If either header or library was not found, bomb
+            #
+            AC_MSG_ERROR(either specify a valid numa installation with --with-numa=DIR or disable numa usage with --without-numa)
+    fi
 fi
 
 ])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fixes up the NUMA m4 script to set HAVE_LIBNUMA if detected.  It also updates the client/src/unifycr.c so that it uses HAVE_LIBNUMA and adds a missing char* declare for an env variable when using NUMA.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
