### PR TITLE
support cleanup-on-terminate as server CLI option

### DIFF
--- a/common/src/unifycr_configurator.h
+++ b/common/src/unifycr_configurator.h
@@ -64,7 +64,8 @@
 /* UNIFYCR_CONFIGS is the list of configuration settings, and should contain
    one macro definition per setting */
 #define UNIFYCR_CONFIGS \
-    UNIFYCR_CFG_CLI(unifycr, configfile, STRING, SYSCONFDIR/unifycr/unifycr.conf, "path to configuration file", configurator_file_check, 'C', "specify full path to config file") \
+    UNIFYCR_CFG_CLI(unifycr, cleanup, BOOL, off, "cleanup storage on server exit", NULL, 'C', "on|off") \
+    UNIFYCR_CFG_CLI(unifycr, configfile, STRING, SYSCONFDIR/unifycr/unifycr.conf, "path to configuration file", configurator_file_check, 'f', "specify full path to config file") \
     UNIFYCR_CFG_CLI(unifycr, consistency, STRING, LAMINATED, "consistency model", NULL, 'c', "specify consistency model (NONE | LAMINATED | POSIX)") \
     UNIFYCR_CFG_CLI(unifycr, daemonize, BOOL, on, "enable server daemonization", NULL, 'D', "on|off") \
     UNIFYCR_CFG_CLI(unifycr, debug, BOOL, off, "enable debug output", NULL, 'd', "on|off") \

--- a/util/unifycr/src/unifycr.c
+++ b/util/unifycr/src/unifycr.c
@@ -84,8 +84,8 @@ static char *usage_str =
     "Usage: %s <command> [options...]\n"
     "\n"
     "<command> should be one of the following:\n"
-    "  start       start the unifycr server daemon\n"
-    "  terminate   terminate the unifycr server daemon\n"
+    "  start       start the UnifyCR server daemons\n"
+    "  terminate   terminate the UnifyCR server daemons\n"
     "\n"
     "Common options:\n"
     "  -d, --debug               enable debug output\n"
@@ -94,13 +94,13 @@ static char *usage_str =
     "Command options for \"start\":\n"
     "  -C, --consistency=<model> consistency model (NONE | LAMINATED | POSIX)\n"
     "  -e, --exe=<path>          <path> where unifycrd is installed\n"
-    "  -m, --mount=<path>        mount unifycr at <path>\n"
+    "  -m, --mount=<path>        mount UnifyCR at <path>\n"
     "  -s, --script=<path>       <path> to custom launch script\n"
-    "  -i, --stage-in=<path>     stage in file(s) at <path>\n"
-    "  -o, --stage-out=<path>    stage out file(s) to <path> on termination\n"
+    "  -c, --cleanup             (NOT YET SUPPORTED) clean up the UnifyCR storage upon server exit\n"
+    "  -i, --stage-in=<path>     (NOT YET SUPPORTED) stage in file(s) at <path>\n"
+    "  -o, --stage-out=<path>    (NOT YET SUPPORTED) stage out file(s) to <path> on termination\n"
     "\n"
     "Command options for \"terminate\":\n"
-    "  -c, --cleanup             clean up the unifycr storage on termination\n"
     "  -s, --script=<path>       <path> to custom termination script\n"
     "\n";
 
@@ -128,6 +128,7 @@ static void parse_cmd_arguments(int argc, char **argv)
                              short_opts, long_opts, &optidx)) >= 0) {
         switch (ch) {
         case 'c':
+            printf("WARNING: cleanup not yet supported!\n");
             cleanup = 1;
             break;
 

--- a/util/unifycr/src/unifycr.h
+++ b/util/unifycr/src/unifycr.h
@@ -61,7 +61,7 @@ struct _unifycr_args {
     char *server_path;         /* full path to installed unifycrd */
     char *stage_in;            /* data path to stage-in */
     char *stage_out;           /* data path to stage-out (drain) */
-    char *script;              /* path to custom launch/cleanup script */
+    char *script;              /* path to custom launch/terminate script */
 };
 
 typedef struct _unifycr_args unifycr_args_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adds `-C,--unifycr-cleanup` as boolean command-line option to server, for use by `unifycr` CLI tool. Updates `unifycr` help to specify `--cleanup` option should be passed in `start` mode.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
