### PR TITLE
update broken link for Build & I/O interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ clustering and pipelining.
 ## Documentation
 Full UnifyCR documentation is contained [here](https://unifycr.readthedocs.io).
 
-Use [Build & I/O Interception](http://unifycr.readthedocs.io/en/latest/build-intercept.html)
+Use [Build & I/O Interception](http://unifycr.readthedocs.io/en/dev/build-intercept.html)
 for instructions on how to build and install UnifyCR.
 
 ## Build Status


### PR DESCRIPTION
Build & I/O interception link is broken because it points to "latest" docs. "Latest" should point to the latest stable release, which we don't currently have right now. Since dev and latest were the same thing, we are just using the dev branch to build the docs now. 