### PR TITLE
Fix open64 wrapper bug

### DIFF
--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -773,9 +773,9 @@ int UNIFYCR_WRAP(open64)(const char *path, int flags, ...)
     if (unifycr_intercept_path(path)) {
         /* Call open wrapper with LARGEFILE flag set*/
         if (flags & O_CREAT) {
-            ret = UNIFYCR_REAL(open)(path, flags | O_LARGEFILE, mode);
+            ret = UNIFYCR_WRAP(open)(path, flags | O_LARGEFILE, mode);
         } else {
-            ret = UNIFYCR_REAL(open)(path, flags | O_LARGEFILE);
+            ret = UNIFYCR_WRAP(open)(path, flags | O_LARGEFILE);
         }
     } else {
         MAP_OR_FAIL(open64);


### PR DESCRIPTION
### Description
All open64 calls are getting intercepted by our wrapper, but they are
all then just being forwarded on to the system as UNIFYCR_WRAP(open64)
is never called.

### How Has This Been Tested?
New tests being added to our test suite are what caught this bug. Those tests are now passing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.