### PR TITLE
Add check for return value of unifycr_mount

### DIFF
--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -47,6 +47,9 @@
 #include <sys/types.h>   // off_t
 
 #include <limits.h>
+
+#include "unifycr_const.h"
+
 #ifndef HOST_NAME_MAX
 # define HOST_NAME_MAX 256
 #endif

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -14,7 +14,7 @@ noinst_HEADERS = testlib.h
 test_gotcha_ldadd = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm $(MPI_CLDFLAGS)
 test_static_ldadd = $(top_builddir)/client/src/libunifycr.la -lrt -lm
 test_static_ldflags = -static $(CP_WRAPPERS) $(AM_LDFLAGS) $(MPI_CLDFLAGS)
-test_cppflags = $(AM_CPPFLAGS) -I$(top_srcdir)/client/src $(MPI_CFLAGS)
+test_cppflags = $(AM_CPPFLAGS) -I$(top_srcdir)/client/src -I$(top_srcdir)/common/src $(MPI_CFLAGS)
 
 sysio_write_gotcha_SOURCES = sysio-write.c
 sysio_write_gotcha_CPPFLAGS = $(test_cppflags)

--- a/examples/src/sysio-writeread.c
+++ b/examples/src/sysio-writeread.c
@@ -79,6 +79,7 @@ int main(int argc, char *argv[])
     size_t blk_sz = 0, num_blk = 0, tran_sz = 0, num_reqs = 0;
     size_t index, i, j, offset = 0;
     ssize_t rc;
+    int ret;
     int pat = 0, c, num_rank, rank, fd, use_unifycr = 0;
 
     MPI_Init(&argc, &argv);
@@ -137,7 +138,10 @@ int main(int argc, char *argv[])
 
 #ifndef NO_UNIFYCR
     if (use_unifycr) {
-        unifycr_mount(mntpt, rank, num_rank, 0);
+        ret = unifycr_mount(mntpt, rank, num_rank, 0);
+        if (UNIFYCR_SUCCESS != ret) {
+            MPI_Abort(MPI_COMM_WORLD, ret);
+        }
         MPI_Barrier(MPI_COMM_WORLD);
     }
 #endif
@@ -238,7 +242,7 @@ int main(int argc, char *argv[])
 
     gettimeofday(&read_start, NULL);
 
-    int ret = lio_listio(LIO_WAIT, cb_list, num_reqs, NULL);
+    ret = lio_listio(LIO_WAIT, cb_list, num_reqs, NULL);
 
     if (ret < 0)
         perror("lio_listio failed");

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -41,6 +41,7 @@ test_ldadd = \
 test_cppflags = \
 	-I$(top_srcdir) \
 	-I$(top_srcdir)/client/src \
+	-I$(top_srcdir)/common/src \
 	-D_GNU_SOURCE \
 	$(AM_CPPFLAGS) \
         $(MPI_CFLAGS)


### PR DESCRIPTION
Make sure the test exits if it encounters an error mounting unifycr.