### PR TITLE
add fid field to file descriptor structure, add free fd stack

### DIFF
--- a/client/src/unifycr-dirops.c
+++ b/client/src/unifycr-dirops.c
@@ -15,55 +15,80 @@
 
 #include "unifycr-sysio.h"
 
-/*
- * TODO: the number of open directories clearly won't exceed the number of file
- * descriptors. however, the current UNIFYCR_MAX_FILEDESCS value of 256 will
- * quickly run out. if this value is fixed to be reasonably larger, then we
- * would need a way to dynamically allocate the dirstreams instead of the
- * following fixed size array.
- */
-static unifycr_dirstream_t _dirstreams[UNIFYCR_MAX_FILEDESCS];
-
-/*
- * TODO: currently, we just take the same indexed slot to our fid.
- */
-#if 0
-static pthread_spinlock_t _dirstream_lock;
-static unifycr_dirstream_t *_dirstream_freelist;
-
-static unifycr_dirstream_t *unifycr_dirstream_alloc(void)
-{
-}
-
-static void unifycr_dirstream_free(unifycr_dirstream_t *dirp)
-{
-}
-#endif
-
+/* given a file id corresponding to a directory,
+ * allocate and initialize a directory stream */
 static inline unifycr_dirstream_t *unifycr_dirstream_alloc(int fid)
 {
-    unifycr_dirstream_t *dirp = &_dirstreams[fid];
+    /* allocate a file descriptor for this stream */
+    int fd = unifycr_stack_pop(unifycr_fd_stack);
+    if (fd < 0) {
+        /* exhausted our file descriptors */
+        errno = EMFILE;
+        return NULL;
+    }
 
+    /* allocate a directory stream id */
+    int dirid = unifycr_stack_pop(unifycr_dirstream_stack);
+    if (dirid < 0) {
+        /* exhausted our directory streams,
+         * return our file descriptor and set errno */
+        unifycr_stack_push(unifycr_fd_stack, fd);
+        errno = EMFILE;
+        return NULL;
+    }
+
+    /* get file descriptor for this fd */
+    unifycr_fd_t *filedesc = unifycr_get_filedesc_from_fd(fd);
+    filedesc->fid   = fid;
+    filedesc->pos   = 0;
+    filedesc->read  = 0;
+    filedesc->write = 0;
+
+    /* get pointer to file stream structure */
+    unifycr_dirstream_t *dirp = &(unifycr_dirstreams[dirid]);
+
+    /* initialize fields in structure */
     memset((void *) dirp, 0, sizeof(*dirp));
+
+    /* record index into unifycr_dirstreams */
+    dirp->dirid = dirid;
+
+    /* record local file id corresponding to directory */
+    dirp->fid = fid;
+
+    /* record file descriptor we're using for this stream */
+    dirp->fd = fd;
+
+    /* position directory pointer to first item */
+    dirp->pos = 0;
 
     return dirp;
 }
 
-static inline void unifycr_dirstream_free(unifycr_dirstream_t *dirp)
+/* release resources allocated in unifycr_dirstream_alloc */
+static inline int unifycr_dirstream_free(unifycr_dirstream_t *dirp)
 {
-    return;
+    /* reinit file descriptor to indicate that it's no longer in use,
+     * not really necessary, but should help find bugs */
+    unifycr_fd_init(dirp->fd);
+
+    /* return file descriptor to the free stack */
+    unifycr_stack_push(unifycr_fd_stack, dirp->fd);
+
+    /* reinit dir stream to indicate that it's no longer in use,
+     * not really necessary, but should help find bugs */
+    unifycr_dirstream_init(dirp->dirid);
+
+    /* return our index to directory stream stack */
+    unifycr_stack_push(unifycr_dirstream_stack, dirp->dirid);
+
+    return UNIFYCR_SUCCESS;
 }
 
 DIR *UNIFYCR_WRAP(opendir)(const char *name)
 {
-    int ret = 0;
-    int gfid = -1;
-    int fid = -1;
-    struct stat *sb = NULL;
-    unifycr_dirstream_t *_dirp = NULL;
-    unifycr_file_attr_t gfattr = { 0, };
-    unifycr_filemeta_t *meta = NULL;
-
+    /* call real opendir and return early if this is
+     * not one of our paths */
     if (!unifycr_intercept_path(name)) {
         MAP_OR_FAIL(opendir);
         return UNIFYCR_REAL(opendir)(name);
@@ -74,20 +99,23 @@ DIR *UNIFYCR_WRAP(opendir)(const char *name)
      * if valid, populate the local file meta cache accordingly.
      */
 
-    fid = unifycr_get_fid_from_path(name);
-    gfid = unifycr_generate_gfid(name);
-    ret = unifycr_get_global_file_meta(fid, gfid, &gfattr);
+    int fid  = unifycr_get_fid_from_path(name);
+    int gfid = unifycr_generate_gfid(name);
+
+    unifycr_file_attr_t gfattr = { 0, };
+    int ret = unifycr_get_global_file_meta(fid, gfid, &gfattr);
     if (ret != UNIFYCR_SUCCESS) {
         errno = ENOENT;
         return NULL;
     }
 
-    sb = &gfattr.file_attr;
+    struct stat *sb = &gfattr.file_attr;
     if (!S_ISDIR(sb->st_mode)) {
         errno = ENOTDIR;
         return NULL;
     }
 
+    unifycr_filemeta_t *meta = NULL;
     if (fid >= 0) {
         meta = unifycr_get_meta_from_fid(fid);
 
@@ -115,78 +143,124 @@ DIR *UNIFYCR_WRAP(opendir)(const char *name)
         }
 
         meta = unifycr_get_meta_from_fid(fid);
-        meta->is_dir = 1;
-        meta->size = sb->st_size;
-        meta->chunks = sb->st_blocks;
+        meta->is_dir   = 1;
+        meta->size     = sb->st_size;
+        meta->chunks   = sb->st_blocks;
         meta->log_size = 0;
     }
 
-    _dirp = unifycr_dirstream_alloc(fid);
+    unifycr_dirstream_t *dirp = unifycr_dirstream_alloc(fid);
 
-    return (DIR *) _dirp;
+    return (DIR *) dirp;
 }
 
 DIR *UNIFYCR_WRAP(fdopendir)(int fd)
 {
-    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-    errno = ENOSYS;
-
-    return NULL;
+    if (unifycr_intercept_fd(&fd)) {
+        fprintf(stderr, "Function not yet supported @ %s:%d\n",
+            __FILE__, __LINE__);
+        errno = ENOSYS;
+        return NULL;
+    } else {
+        MAP_OR_FAIL(fdopendir);
+        DIR *ret = UNIFYCR_REAL(fdopendir)(fd);
+        return ret;
+    }
 }
 
 int UNIFYCR_WRAP(closedir)(DIR *dirp)
 {
-    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-    errno = ENOSYS;
-
-    return -1;
+    if (unifycr_intercept_dirstream(dirp)) {
+        unifycr_dirstream_t *d = (unifycr_dirstream_t *) dirp;
+        unifycr_dirstream_free(d);
+        return 0;
+    } else {
+        MAP_OR_FAIL(closedir);
+        int ret = UNIFYCR_REAL(closedir)(dirp);
+        return ret;
+    }
 }
 
 struct dirent *UNIFYCR_WRAP(readdir)(DIR *dirp)
 {
-    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-    errno = ENOSYS;
-
-    return NULL;
+    if (unifycr_intercept_dirstream(dirp)) {
+        fprintf(stderr, "Function not yet supported @ %s:%d\n",
+            __FILE__, __LINE__);
+        errno = ENOSYS;
+        return NULL;
+    } else {
+        MAP_OR_FAIL(readdir);
+        struct dirent *d = UNIFYCR_REAL(readdir)(dirp);
+        return d;
+    }
 }
 
 void UNIFYCR_WRAP(rewinddir)(DIR *dirp)
 {
-    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
+    if (unifycr_intercept_dirstream(dirp)) {
+        unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
 
-    /* TODO: update the pos in the file descriptor (fd) via lseek */
+        /* TODO: update the pos in the file descriptor (fd) via lseek */
 
-    _dirp->filepos = 0;
+        _dirp->pos = 0;
+    } else {
+        MAP_OR_FAIL(rewinddir);
+        UNIFYCR_REAL(rewinddir)(dirp);
+        return;
+    }
 }
 
 int UNIFYCR_WRAP(dirfd)(DIR *dirp)
 {
-    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
-
-    return _dirp->fid + unifycr_fd_limit;
+    if (unifycr_intercept_dirstream(dirp)) {
+        unifycr_dirstream_t *d = (unifycr_dirstream_t *) dirp;
+        int fd = d->fd;
+        return fd;
+    } else {
+        MAP_OR_FAIL(dirfd);
+        int fd = UNIFYCR_REAL(dirfd)(dirp);
+        return fd;
+    }
 }
 
 long UNIFYCR_WRAP(telldir)(DIR *dirp)
 {
-    unifycr_dirstream_t *_dirp = (unifycr_dirstream_t *) dirp;
-
-    return _dirp->filepos;
+    if (unifycr_intercept_dirstream(dirp)) {
+        unifycr_dirstream_t *d = (unifycr_dirstream_t *) dirp;
+        return d->pos;
+    } else {
+        MAP_OR_FAIL(telldir);
+        long ret = UNIFYCR_REAL(telldir)(dirp);
+        return ret;
+    }
 }
 
-int UNIFYCR_WRAP(scandir)(const char *dirp, struct dirent **namelist,
+int UNIFYCR_WRAP(scandir)(const char *path, struct dirent **namelist,
                           int (*filter)(const struct dirent *),
                           int (*compar)(const struct dirent **,
                                         const struct dirent **))
 {
-    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-    errno = ENOSYS;
-
-    return -1;
+    if (unifycr_intercept_path(path)) {
+        fprintf(stderr, "Function not yet supported @ %s:%d\n",
+            __FILE__, __LINE__);
+        errno = ENOSYS;
+        return -1;
+    } else {
+        MAP_OR_FAIL(scandir);
+        long ret = UNIFYCR_REAL(scandir)(path, namelist, filter, compar);
+        return ret;
+    }
 }
 
 void UNIFYCR_WRAP(seekdir)(DIR *dirp, long loc)
 {
-    fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-    errno = ENOSYS;
+    if (unifycr_intercept_dirstream(dirp)) {
+        fprintf(stderr, "Function not yet supported @ %s:%d\n",
+            __FILE__, __LINE__);
+        errno = ENOSYS;
+    } else {
+        MAP_OR_FAIL(seekdir);
+        UNIFYCR_REAL(seekdir)(dirp, loc);
+        return;
+    }
 }
-

--- a/client/src/unifycr-dirops.h
+++ b/client/src/unifycr-dirops.h
@@ -20,14 +20,6 @@
 #include <dirent.h>
 #include <pthread.h>
 
-struct _unifycr_dirstream {
-    int fid;
-    unifycr_fd_t fd;
-    off_t filepos;
-};
-
-typedef struct _unifycr_dirstream unifycr_dirstream_t;
-
 /*
  * FIXME: is this portable to use the linux dirent structure?
  */


### PR DESCRIPTION
This adds a fid field to the file descriptor structure to track the underlying local file id that an open file descriptor is associated with.  It also adds a stack to track free fd values, a free fd value is popped from the stack on open() and pushed back on close().

It similarly adds a stack to track free FILE* streams, allowing a process to fopen() the same file more than once.

It accomplishes the following:
- enables a process to have more than one active file descriptor open to the same underlying file
- adds state to a file descriptor to know when it's active or not (e.g., fixes double close bug)
- enables a process to have more than one active FILE* stream open to the same underlying file
- enables a process to have more than one active DIR* stream open to the same underlying directory
- https://github.com/LLNL/UnifyCR/issues/206

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
