### PR TITLE
Change the domain socket file name to include uid.

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2281,8 +2281,8 @@ static int unifycr_init_socket(int proc_id, int l_num_procs_per_node,
         (l_num_procs_per_node == 1) &&
         (l_num_del_per_node == 1)) {
         // use zero-index domain socket path
-        snprintf(tmp_path, sizeof(tmp_path), "%s0",
-                 SOCKET_PATH);
+        snprintf(tmp_path, sizeof(tmp_path), "%s.%d",
+                 SOCKET_PATH, getuid());
 
 #ifdef HAVE_PMIX_H
         // lookup domain socket path in PMIx

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -152,9 +152,12 @@ int invert_sock_ids[MAX_NUM_CLIENTS];
 
 extern pthread_t data_thrd;
 extern int glb_rank, glb_size;
-extern int local_rank_idx;
 extern int *local_rank_lst;
 extern int local_rank_cnt;
 extern long max_recs_per_slice;
+
+#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
+extern int local_rank_idx;
+#endif
 
 #endif

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -49,7 +49,6 @@
 
 int *local_rank_lst;
 int local_rank_cnt;
-int local_rank_idx;
 int glb_rank, glb_size;
 
 arraylist_t *app_config_list;
@@ -60,6 +59,10 @@ int invert_sock_ids[MAX_NUM_CLIENTS]; /*records app_id for each sock_id*/
 int log_print_level = 5;
 
 unifycr_cfg_t server_cfg;
+
+#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
+extern int local_rank_idx;
+#endif
 
 /*
  * Perform steps to create a daemon process:
@@ -155,9 +158,10 @@ int main(int argc, char *argv[])
     if (rc < 0)
         exit(1);
 
+#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
     local_rank_idx = find_rank_idx(glb_rank, local_rank_lst,
                                    local_rank_cnt);
-
+#endif
     snprintf(dbg_fname, sizeof(dbg_fname), "%s/%s.%d",
             server_cfg.log_dir, server_cfg.log_file, glb_rank);
     rc = dbg_open(dbg_fname);
@@ -179,7 +183,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    rc = sock_init_server(local_rank_idx);
+    rc = sock_init_server();
     if (rc != 0) {
         LOG(LOG_ERR, "%s",
             unifycr_error_enum_description(UNIFYCR_ERROR_SOCKET));
@@ -423,6 +427,7 @@ static int CountTasksPerNode(int rank, int numTasks)
     return 0;
 }
 
+#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
 static int find_rank_idx(int my_rank,
                          int *local_rank_lst, int local_rank_cnt)
 {
@@ -435,6 +440,7 @@ static int find_rank_idx(int my_rank,
     return -1;
 
 }
+#endif
 
 static int compare_int(const void *a, const void *b)
 {

--- a/server/src/unifycr_init.h
+++ b/server/src/unifycr_init.h
@@ -49,7 +49,11 @@ typedef struct {
 static int CountTasksPerNode(int rank, int numTasks);
 static int compare_name_rank_pair(const void *a, const void *b);
 static int compare_int(const void *a, const void *b);
+
+#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
 static int find_rank_idx(int my_rank,
                          int *local_rank_lst, int local_rank_cnt);
+#endif
+
 static int unifycr_exit();
 #endif

--- a/server/src/unifycr_service_manager.c
+++ b/server/src/unifycr_service_manager.c
@@ -1030,8 +1030,8 @@ int sm_init_socket()
     serv_addr.sun_family = AF_UNIX;
 
     /*which delegator I belong to*/
-    snprintf(tmp_path, sizeof(tmp_path), "%s%d",
-             SOCKET_PATH, local_rank_idx);
+    snprintf(tmp_path, sizeof(tmp_path), "%s.%d",
+             SOCKET_PATH, getuid());
 
     strcpy(serv_addr.sun_path, tmp_path);
     len = sizeof(serv_addr);

--- a/server/src/unifycr_sock.c
+++ b/server/src/unifycr_sock.c
@@ -64,14 +64,13 @@ int cur_sock_id = -1;
 * initialize the listening socket on this delegator
 * @return success/error code
 */
-int sock_init_server(int local_rank_idx)
+int sock_init_server(void)
 {
     int rc;
     char sock_path[UNIFYCR_MAX_FILENAME];
 
-    server_rank_idx = local_rank_idx;
-    snprintf(sock_path, sizeof(sock_path), "%s%d",
-             SOCKET_PATH, server_rank_idx);
+    snprintf(sock_path, sizeof(sock_path), "%s.%d",
+             SOCKET_PATH, getuid());
 
     server_sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
 

--- a/server/src/unifycr_sock.h
+++ b/server/src/unifycr_sock.h
@@ -33,7 +33,7 @@
 #include <poll.h>
 #include "unifycr_const.h"
 
-int sock_init_server(int local_rank_idx);
+int sock_init_server(void);
 int sock_add(int fd);
 void sock_reset();
 int sock_wait_cli_cmd();


### PR DESCRIPTION
If the UnifyCR server does not shut down correctly, the domain socket is
left in /tmp. This can cause issues on shared resources.
Attaching the user id to the file should fix collisions with sockets
left behind by other users.
