### PR TITLE
Add unmount rpc

### DIFF
--- a/client/src/unifycr_client.c
+++ b/client/src/unifycr_client.c
@@ -70,6 +70,42 @@ uint32_t unifycr_client_mount_rpc_invoke(unifycr_client_rpc_context_t** unifycr_
     return out.ret;
 }
 
+/* function invokes the unmount rpc
+ * TODO: Need secondary function to do actual cleanup */
+uint32_t unifycr_client_unmount_rpc_invoke(unifycr_client_rpc_context_t**
+                                           unifycr_rpc_context)
+{
+    hg_handle_t handle;
+    unifycr_unmount_in_t in;
+    unifycr_unmount_out_t out;
+    hg_return_t hret;
+    int ret;
+
+    printf("invoking the unmount rpc function in client\n");
+
+    hret = margo_create((*unifycr_rpc_context)->mid,
+                            (*unifycr_rpc_context)->svr_addr,
+                            (*unifycr_rpc_context)->unifycr_unmount_rpc_id,
+                            &handle);
+    assert(hret == HG_SUCCESS);
+
+    /* fill in input struct */
+    in.app_id = app_id;
+    in.local_rank_idx = local_rank_idx;
+
+    hret = margo_forward(handle, &in);
+    assert(hret == HG_SUCCESS);
+
+    /* decode response */
+    hret = margo_get_output(handle, &out);
+    assert(hret == HG_SUCCESS);
+    ret = out.ret;
+
+    margo_free_output(handle, &out);
+    margo_destroy(handle);
+    return ret;
+}
+
 /* invokes the client metaset rpc function by calling set_global_file_meta */
 uint32_t unifycr_client_metaset_rpc_invoke(unifycr_client_rpc_context_t**
                                                 unifycr_rpc_context,

--- a/client/src/unifycr_client.h
+++ b/client/src/unifycr_client.h
@@ -21,6 +21,7 @@
     hg_addr_t svr_addr;
     hg_id_t unifycr_read_rpc_id;
     hg_id_t unifycr_mount_rpc_id;
+    hg_id_t unifycr_unmount_rpc_id;
     hg_id_t unifycr_metaget_rpc_id;
     hg_id_t unifycr_metaset_rpc_id;
     hg_id_t unifycr_fsync_rpc_id;
@@ -36,6 +37,9 @@ int unifycr_client_rpc_init(char* svr_addr_str,
 */
 
 uint32_t unifycr_client_mount_rpc_invoke(unifycr_client_rpc_context_t**
+                                                unifycr_rpc_context);
+
+uint32_t unifycr_client_unmount_rpc_invoke(unifycr_client_rpc_context_t**
                                                 unifycr_rpc_context);
 
 uint32_t unifycr_client_metaset_rpc_invoke(unifycr_client_rpc_context_t**

--- a/client/src/unifycr_clientcalls_rpc.h
+++ b/client/src/unifycr_clientcalls_rpc.h
@@ -46,7 +46,8 @@ DECLARE_MARGO_RPC_HANDLER(unifycr_mount_rpc)
 
 MERCURY_GEN_PROC(unifycr_unmount_out_t, ((int32_t)(ret)))
 MERCURY_GEN_PROC(unifycr_unmount_in_t,
-    ((hg_const_string_t)(external_spill_dir)))
+    ((uint32_t)(app_id))
+    ((uint32_t)(local_rank_idx)))
 DECLARE_MARGO_RPC_HANDLER(unifycr_unmount_rpc)
 
 /* given a global file id and a file name,

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -211,6 +211,10 @@ static margo_instance_id setup_sm_target()
                      unifycr_mount_in_t, unifycr_mount_out_t,
                      unifycr_mount_rpc);
 
+    MARGO_REGISTER(mid, "unifycr_unmount_rpc",
+                     unifycr_unmount_in_t, unifycr_unmount_out_t,
+                     unifycr_unmount_rpc);
+
     MARGO_REGISTER(mid, "unifycr_metaget_rpc",
                      unifycr_metaget_in_t, unifycr_metaget_out_t,
                      unifycr_metaget_rpc);
@@ -794,8 +798,7 @@ static int unifycr_exit()
     int i, j;
     for (i = 0; i < arraylist_size(thrd_list); i++) {
         /* wait for resource manager thread to exit */
-        thrd_ctrl_t *thrd_ctrl =
-            (thrd_ctrl_t *)arraylist_get(thrd_list, i);
+        thrd_ctrl_t* thrd_ctrl = (thrd_ctrl_t *)arraylist_get(thrd_list, i);
         rm_cmd_exit(thrd_ctrl);
     }
 
@@ -828,7 +831,7 @@ static int unifycr_exit()
             /* release receive buffer shared memory region */
             if (app->shm_recv_bufs[j] != NULL) {
                 unifycr_shm_free(app->recv_buf_name[j],
-                    app->recv_buf_sz, &(app->shm_recv_bufs[j]));
+                app->recv_buf_sz, &(app->shm_recv_bufs[j]));
             }
 
             /* release super block shared memory region */
@@ -854,7 +857,7 @@ static int unifycr_exit()
     /* shutdown the metadata service*/
     meta_sanitize();
 
-    /* TODO: notify the service threads to exit*/
+    /* TODO: notify the service threads to exit */
 
     /* destroy the sockets except for the ones
      * for acks*/

--- a/server/src/unifycr_server.h
+++ b/server/src/unifycr_server.h
@@ -25,6 +25,7 @@ typedef struct ServerRpcContext
     hg_id_t unifycr_read_rpc_id;
     hg_id_t unifycr_fsync_rpc_id;
     hg_id_t unifycr_mount_rpc_id;
+    hg_id_t unifycr_unmount_rpc_id;
     hg_id_t unifycr_metaget_rpc_id;
     hg_id_t unifycr_metaset_rpc_id;
     //hg_id_t write_rpc_id;

--- a/server/src/unifycr_sock.c
+++ b/server/src/unifycr_sock.c
@@ -267,6 +267,14 @@ int sock_get_id()
     return 0;
 }
 
+void sock_sanitize_cli(int client_id)
+{
+    /* close socket for this client id
+     * and set fd back to -1 */
+    close(poll_set[client_id].fd);
+    poll_set[client_id].fd = -1;
+}
+
 int sock_sanitize()
 {
     int i;

--- a/server/src/unifycr_sock.h
+++ b/server/src/unifycr_sock.h
@@ -47,6 +47,7 @@ int sock_get_id();
 int sock_get_error_id();
 int sock_ack_cli(int sock_id, int ret_sz);
 int sock_sanitize();
+void sock_sanitize_cli(int client_id);
 char *sock_get_ack_buf(int sock_id);
 int sock_remove(int idx);
 int sock_notify_cli(int sock_id, int cmd);


### PR DESCRIPTION
Adds unmount rpc that shuts down delegator thread, detaches from
request and read shared memory buffers, and closes the socket
that was opened during mount. This commit also adds a
sanitize_sock_cli function in order to only close the socket
that corresponds to that specific client id. The sock_sanitize
function closes all of the client sockets and the main socket,
which is not what we needed for a client disconnect call.

I will update the examples based on issue #226 in another PR. 