### PR TITLE
fix: missing declare for wrapper prototype in static build

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -183,9 +183,11 @@ do { \
 
 /* we don't need a variable to record the address of the real function,
  * just declare the existence of __real_open so the compiler knows the
- * prototype of this function (linker will provide it) */
+ * prototype of this function (linker will provide it), also need to
+ * declare prototype for __wrap_open */
 #define UNIFYCR_DECL(name,ret,args) \
       extern ret __real_ ## name args;  \
+      ret __wrap_ ## name args;
 
 /* we define our wrapper function as __wrap_open instead of open */
 #define UNIFYCR_WRAP(name) __wrap_ ## name


### PR DESCRIPTION
The compiler did not have the wrapper function prototype in the static build.  As a result, if a wrapper had to call another wrapper, we'd end up with a warning like the following:

```
../../../client/src/unifycr-sysio.c:201:13: warning: implicit declaration of function ‘__wrap_unlink’ [-Wimplicit-function-declaration]
             int ret = UNIFYCR_WRAP(unlink)(newpath);
             ^
```

This is a one line fix that adds that.  Looks like the line might have been dropped along the way, given the continuation character on the live above the fix.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
