### PR TITLE
Finalize

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -799,12 +799,11 @@ int unifycr_get_global_file_meta(int fid, int gfid, unifycr_file_attr_t* gfattr)
         return -EINVAL;
     }
 
-    unifycr_file_attr_t* fmeta = NULL;
+    unifycr_file_attr_t fmeta;
     int ret = unifycr_client_metaget_rpc_invoke(
         &unifycr_rpc_context, &fmeta, fid, gfid);
     if (ret == UNIFYCR_SUCCESS) {
-        *gfattr = *fmeta;
-        free(fmeta);
+        *gfattr = fmeta;
     }
 
     return ret;
@@ -2307,9 +2306,6 @@ static int unifycr_finalize(void)
         unifycr_fd_stack = NULL;
     }
 
-    /* free resources allocated in client_rpc_init */
-    unifycr_client_rpc_finalize(&unifycr_rpc_context);
-
     /* clean up configuration */
     int tmp_rc = unifycr_config_fini(&client_cfg);
     if (tmp_rc) {
@@ -2333,6 +2329,9 @@ int unifycr_unmount(void)
     /* invoke unmount rpc */
     printf("calling unmount\n");
     int ret = unifycr_client_unmount_rpc_invoke(&unifycr_rpc_context);
+
+    /* free resources allocated in client_rpc_init */
+    unifycr_client_rpc_finalize(&unifycr_rpc_context);
 
     unifycr_finalize();
 

--- a/client/src/unifycr_client.c
+++ b/client/src/unifycr_client.c
@@ -58,6 +58,7 @@ uint32_t unifycr_client_mount_rpc_invoke(unifycr_client_rpc_context_t**
     unifycr_sync_to_del(&in);
     hret = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
+    free(in.external_spill_dir);
 
     /* decode response */
     hret = margo_get_output(handle, &out);

--- a/client/src/unifycr_client.c
+++ b/client/src/unifycr_client.c
@@ -26,13 +26,14 @@ static int set_global_file_meta(unifycr_metaset_in_t* in,
 }
 
 static int get_global_file_meta(int fid, int gfid, unifycr_metaget_out_t* out,
-                                unifycr_file_attr_t** file_meta)
+                                unifycr_file_attr_t* file_meta)
 {
-    *file_meta = (unifycr_file_attr_t*)calloc(1, sizeof(unifycr_file_attr_t));
-    (*file_meta)->fid = fid;
-    (*file_meta)->gfid = gfid;
-    strcpy((*file_meta)->filename, out->filename);
-    (*file_meta)->file_attr.st_size = out->st_size;
+    memset(file_meta, 0, sizeof(unifycr_file_attr_t));
+
+    file_meta->fid  = fid;
+    file_meta->gfid = gfid;
+    strcpy(file_meta->filename, out->filename);
+    file_meta->file_attr.st_size = out->st_size;
 
     return UNIFYCR_SUCCESS;
 }
@@ -147,7 +148,7 @@ uint32_t unifycr_client_metaset_rpc_invoke(unifycr_client_rpc_context_t**
 /* invokes the client metaget rpc function by calling get_global_file_meta */
 uint32_t unifycr_client_metaget_rpc_invoke(unifycr_client_rpc_context_t**
         unifycr_rpc_context,
-        unifycr_file_attr_t** file_meta, int fid, int gfid)
+        unifycr_file_attr_t* file_meta, int fid, int gfid)
 {
     hg_handle_t handle;
     unifycr_metaget_in_t in;

--- a/client/src/unifycr_client.h
+++ b/client/src/unifycr_client.h
@@ -47,7 +47,7 @@ uint32_t unifycr_client_metaset_rpc_invoke(unifycr_client_rpc_context_t**
 
 uint32_t unifycr_client_metaget_rpc_invoke(unifycr_client_rpc_context_t**
         unifycr_rpc_context,
-        unifycr_file_attr_t** file_meta, int fid, int gfid);
+        unifycr_file_attr_t* file_meta, int fid, int gfid);
 
 uint32_t unifycr_client_fsync_rpc_invoke(unifycr_client_rpc_context_t**
         unifycr_rpc_context,


### PR DESCRIPTION
Add finalize function to clean up resources allocated during unifycr_init().  Since init is called during mount(), finalize is called during unmount().

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
