### PR TITLE
call unmount for every MPI rank in the job

### DIFF
--- a/examples/src/app-btio.c
+++ b/examples/src/app-btio.c
@@ -247,8 +247,8 @@ int main(int argc, char* argv[])
 
     if (direction != 0) {/*only write without reading*/
         close(fd);
+        unifycr_unmount();
         if (rank == 0) {
-            unifycr_unmount();
             printf("Aggregated Write BW is %lf, Min Write BW is %lf\n",
                    aggwrbw, min_wr_bw);
             fflush(stdout);
@@ -291,9 +291,7 @@ int main(int argc, char* argv[])
         close(fd);
         MPI_Barrier(MPI_COMM_WORLD);
 
-        if (rank == 0) {
-            unifycr_unmount();
-        }
+        unifycr_unmount();
 
         free(aiocb_list);
         free(cb_list);

--- a/examples/src/app-hdf5-create.c
+++ b/examples/src/app-hdf5-create.c
@@ -204,8 +204,9 @@ int main(int argc, char **argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount && rank == 0)
+    if (!standard && unmount) {
         unifycr_unmount();
+    }
 
     return 0;
 }

--- a/examples/src/app-hdf5-writeread.c
+++ b/examples/src/app-hdf5-writeread.c
@@ -217,8 +217,9 @@ int main(int argc, char **argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount && rank == 0)
+    if (!standard && unmount) {
         unifycr_unmount();
+    }
 
     return 0;
 }

--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -389,7 +389,7 @@ int main(int argc, char* argv[])
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount && rank == 0) {
+    if (!standard && unmount) {
         unifycr_unmount();
     }
 

--- a/examples/src/app-tileio.c
+++ b/examples/src/app-tileio.c
@@ -215,9 +215,7 @@ int main(int argc, char* argv[])
     writetime = writetime / 1000000;
 
     if (direction == 1) {
-        if (rank == 0) {
-            unifycr_unmount();
-        }
+        unifycr_unmount();
         close(fd);
     }
 
@@ -282,9 +280,7 @@ int main(int argc, char* argv[])
         MPI_Barrier(MPI_COMM_WORLD);
         close(fd);
 
-        if (rank == 0) {
-            unifycr_unmount();
-        }
+        unifycr_unmount();
 
         double rd_bw = (double)tot_sz / ranknum / 1048576 / readtime;
         double max_rd_time;

--- a/examples/src/sysio-cp.c
+++ b/examples/src/sysio-cp.c
@@ -281,7 +281,7 @@ int main(int argc, char** argv)
 donothing:
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (unmount && rank == 0) {
+    if (unmount) {
         unifycr_unmount();
     }
 

--- a/examples/src/sysio-dir.c
+++ b/examples/src/sysio-dir.c
@@ -338,7 +338,7 @@ int main(int argc, char** argv)
     MPI_Barrier(MPI_COMM_WORLD);
 
 out_unmount:
-    if (!standard && unmount && rank == 0) {
+    if (!standard && unmount) {
         unifycr_unmount();
     }
 out:

--- a/examples/src/sysio-read.c
+++ b/examples/src/sysio-read.c
@@ -416,7 +416,7 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount && rank == 0) {
+    if (!standard && unmount) {
         unifycr_unmount();
     }
 

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -200,7 +200,7 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (unmount && rank == 0) {
+    if (unmount) {
         unifycr_unmount();
     }
 

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -345,7 +345,7 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount && rank == 0) {
+    if (!standard && unmount) {
         unifycr_unmount();
     }
 

--- a/examples/src/sysio-writeread.c
+++ b/examples/src/sysio-writeread.c
@@ -276,9 +276,7 @@ int main(int argc, char* argv[])
 
 #ifndef NO_UNIFYCR
     if (use_unifycr) {
-        if (rank == 0) {
-            unifycr_unmount();
-        }
+        unifycr_unmount();
     }
 #endif
 

--- a/examples/src/sysio-writeread2.c
+++ b/examples/src/sysio-writeread2.c
@@ -406,6 +406,8 @@ int main(int argc, char *argv[])
     /* verify data integrity in file */
     checkdata(name, filesize, times);
 
+    unifycr_unmount();
+
     MPI_Finalize();
 
     return 0;


### PR DESCRIPTION
After adding the unmount RPC function it now
expects unmount to be called from every rank,
not just rank 0. This commit updates the example
programs. 