### PR TITLE
config: drop UNIFYCR_META_DB_PATH macro

### DIFF
--- a/common/src/unifycr_configurator.h
+++ b/common/src/unifycr_configurator.h
@@ -77,7 +77,7 @@
     UNIFYCR_CFG(logfs, index_buf_size, INT, UNIFYCR_INDEX_BUF_SIZE, "log file system index buffer size", NULL) \
     UNIFYCR_CFG(logfs, attr_buf_size, INT, UNIFYCR_FATTR_BUF_SIZE, "log file system file attributes buffer size", NULL) \
     UNIFYCR_CFG(meta, db_name, STRING, META_DEFAULT_DB_NAME, "metadata database name", NULL) \
-    UNIFYCR_CFG(meta, db_path, STRING, META_DEFAULT_DB_PATH, "metadata database path", NULL) \
+    UNIFYCR_CFG(meta, db_path, STRING, /tmp, "metadata database path", NULL) \
     UNIFYCR_CFG(meta, server_ratio, INT, META_DEFAULT_SERVER_RATIO, "metadata server ratio", NULL) \
     UNIFYCR_CFG(meta, range_size, INT, META_DEFAULT_RANGE_SZ, "metadata range size", NULL) \
     UNIFYCR_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server runstate file") \

--- a/common/src/unifycr_const.h
+++ b/common/src/unifycr_const.h
@@ -114,7 +114,6 @@
 // #define SERVICE_MEM_POOL_SIZE 2147483648
 
 /* ****************** Metadata/MDHIM Default Values ******************** */
-#define META_DEFAULT_DB_PATH (/tmp)
 #define META_DEFAULT_DB_NAME unifycr_db
 #define META_DEFAULT_SERVER_RATIO 1
 #define META_DEFAULT_RANGE_SZ MIB


### PR DESCRIPTION
config: drop UNIFYCR_META_DB_PATH macro, define path directly in configurator instead

The checkpatch script does like paths as bare macros.  It requires parens or quotes around them.  However, adding those characters interferes with our configurator macros.  So the solution opted for here is to drop the macro that defines the path and hardcode that path in the configurator file directly.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
