### PR TITLE
Get sysio-writeread example working again

### DIFF
--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -108,7 +108,7 @@ int unifycr_fd_read(int fd, off_t pos, void *buf, size_t count,
  * allocates new bytes and updates file size as necessary,
  * fills any gaps with zeros */
 int unifycr_fd_write(int fd, off_t pos, const void *buf, size_t count);
-int unifycr_fd_logreadlist(read_req_t *read_req, int count);
+int unifycr_fd_logreadlist(read_req_t *read_req, size_t count);
 int compare_read_req(const void *a, const void *b);
 int compare_index_entry(const void *a, const void *b);
 

--- a/common/src/err_enumerator.h
+++ b/common/src/err_enumerator.h
@@ -92,7 +92,7 @@
     ENUMITEM(SOCKET, "Error creating/open socket.")                     \
     ENUMITEM(SOCKET_FD_EXCEED, "Exceeded max number of connections.")   \
     ENUMITEM(SOCK_CMD, "Unknown exception on the remote peer.")         \
-    ENUMITEM(SOCK_DISCONNECT, "Remote peer disconnected.")              \
+    ENUMITEM(SOCK_DISCONNECT, "Socket disconnected.")                   \
     ENUMITEM(SOCK_LISTEN, "Exception on listening socket.")             \
     ENUMITEM(SOCK_OTHER, "Unknown socket error.")                       \
     ENUMITEM(THRDINIT, "Thread initialization failure.")                \

--- a/common/src/unifycr_client_context.c
+++ b/common/src/unifycr_client_context.c
@@ -15,114 +15,18 @@
 #include "unifycr_const.h"
 #include "unifycr_client_context.h"
 
-#include "string.h"
-int unifycr_pack_client_context(unifycr_client_context_t ctx, char *buffer,
-                                off_t *offset)
+#include <string.h>
+
+int unifycr_pack_client_context(unifycr_client_context_t *ctx,
+                                char *buffer)
 {
-    int rc = UNIFYCR_SUCCESS;
-
-    memcpy(buffer + sizeof(int), &ctx.app_id, sizeof(int));
-    *offset += sizeof(ctx.app_id);
-
-    memcpy(buffer + 2 * sizeof(int),
-           &ctx.local_rank_index, sizeof(int));
-    *offset += sizeof(ctx.local_rank_index);
-
-    memcpy(buffer + 3 * sizeof(int),
-           &ctx.dbg_rank, sizeof(int)); /*add debug info*/
-    *offset += sizeof(ctx.dbg_rank);
-
-    memcpy(buffer + 4 * sizeof(int), &ctx.num_procs_per_node, sizeof(int));
-    *offset += sizeof(ctx.num_procs_per_node);
-
-    memcpy(buffer + 5 * sizeof(int), &ctx.req_buf_sz, sizeof(int));
-    *offset += sizeof(ctx.req_buf_sz);
-
-    memcpy(buffer + 6 * sizeof(int), &ctx.recv_buf_sz, sizeof(int));
-    *offset += sizeof(ctx.recv_buf_sz);
-
-    memcpy(buffer + 7 * sizeof(int), &ctx.superblock_sz, sizeof(long));
-    *offset += sizeof(ctx.superblock_sz);
-
-    memcpy(buffer + 7 * sizeof(int) + sizeof(long),
-           &ctx.meta_offset, sizeof(long));
-    *offset += sizeof(ctx.meta_offset);
-
-    memcpy(buffer + 7 * sizeof(int) + 2 * sizeof(long),
-           &ctx.meta_size, sizeof(long));
-    *offset += sizeof(ctx.meta_size);
-
-    memcpy(buffer + 7 * sizeof(int) + 3 * sizeof(long),
-           &ctx.fmeta_offset, sizeof(long));
-    *offset += sizeof(ctx.fmeta_offset);
-
-    memcpy(buffer + 7 * sizeof(int) + 4 * sizeof(long),
-           &ctx.fmeta_size, sizeof(long));
-    *offset += sizeof(ctx.fmeta_size);
-
-    memcpy(buffer + 7 * sizeof(int) + 5 * sizeof(long),
-           &ctx.data_offset, sizeof(long));
-    *offset += sizeof(ctx.data_offset);
-
-    memcpy(buffer + 7 * sizeof(int) + 6 * sizeof(long),
-           &ctx.data_size, sizeof(long));
-    *offset += sizeof(ctx.data_size);
-
-    memcpy(buffer + 7 * sizeof(int) + 7 * sizeof(long),
-           ctx.external_spill_dir, UNIFYCR_MAX_FILENAME);
-    *offset += UNIFYCR_MAX_FILENAME;
-
-    return rc;
+    memcpy(buffer, ctx, sizeof(unifycr_client_context_t));
+    return UNIFYCR_SUCCESS;
 }
 
-int unifycr_unpack_client_context(char *buffer, off_t *offset,
+int unifycr_unpack_client_context(char *buffer,
                                   unifycr_client_context_t *ctx)
 {
-    int rc = UNIFYCR_SUCCESS;
-
-    ctx->app_id = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->app_id);
-
-    ctx->local_rank_index = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->local_rank_index);
-
-    ctx->dbg_rank = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->dbg_rank);
-
-    ctx->num_procs_per_node = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->num_procs_per_node);
-
-    ctx->req_buf_sz = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->req_buf_sz);
-
-    ctx->recv_buf_sz = *(int *)(buffer + *offset);
-    *offset += sizeof(ctx->recv_buf_sz);
-
-    ctx->superblock_sz = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->superblock_sz);
-
-    ctx->meta_offset = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->meta_offset);
-
-    ctx->meta_size = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->meta_size);
-
-    ctx->fmeta_offset = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->fmeta_offset);
-
-    ctx->fmeta_size = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->fmeta_size);
-
-    ctx->data_offset = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->data_offset);
-
-    ctx->data_size = *(long *)(buffer + *offset);
-    *offset += sizeof(ctx->data_size);
-
-    // TODO: determain if a pointer to the string will
-    // be fine, since it will be copied
-    strcpy(ctx->external_spill_dir, buffer + *offset);
-    offset += UNIFYCR_MAX_FILENAME;
-
-    return rc;
+    memcpy(ctx, buffer, sizeof(unifycr_client_context_t));
+    return UNIFYCR_SUCCESS;
 }

--- a/common/src/unifycr_client_context.h
+++ b/common/src/unifycr_client_context.h
@@ -15,31 +15,35 @@
 #ifndef UNIFYCR_CLIENT_CONTEXT_H
 #define UNIFYCR_CLIENT_CONTEXT_H
 
+#include <stddef.h>
+#include <sys/types.h>
+
+#include "unifycr_const.h"
+
 /*
  * Structure that contains the client side context information.
  */
-struct unifycr_client_context_s {
-    int app_id;
-    int local_rank_index;
-    int dbg_rank;
-    int num_procs_per_node;
-    int req_buf_sz; // should probably be a size_t
-    int recv_buf_sz; // should probably be a size_t
-    long superblock_sz; // should probably be a size_t
-    long meta_offset; // off_t?
-    long meta_size; // size_t?
-    long fmeta_offset; // off_t?
-    long fmeta_size; // size_t?
-    long data_offset; // off_t
-    long data_size; // size_t;
-    char external_spill_dir[UNIFYCR_MAX_FILENAME];
-} typedef unifycr_client_context_t;
+typedef struct unifycr_client_context_s {
+    int    app_id;
+    int    local_rank_index;
+    int    dbg_rank;
+    int    num_procs_per_node;
+    size_t req_buf_sz;
+    size_t recv_buf_sz;
+    size_t superblock_sz;
+    size_t meta_offset;
+    size_t meta_size;
+    size_t fmeta_offset;
+    size_t fmeta_size;
+    size_t data_offset;
+    size_t data_size;
+    char   external_spill_dir[UNIFYCR_MAX_FILENAME];
+} unifycr_client_context_t;
 
+int unifycr_pack_client_context(unifycr_client_context_t *ctx,
+                                char *buffer);
 
-int unifycr_pack_client_context(unifycr_client_context_t ctx, char *buffer,
-                                off_t *offset);
-
-int unifycr_unpack_client_context(char *buffer, off_t *offset,
+int unifycr_unpack_client_context(char *buffer,
                                   unifycr_client_context_t *ctx);
 
 #endif // UNIFYCR_CLIENT_CONTEXT_H

--- a/common/src/unifycr_const.h
+++ b/common/src/unifycr_const.h
@@ -53,23 +53,23 @@
 #define UNIFYCR_MAX_FILENAME KIB
 
 // Metadata
-#define MAX_META_PER_SEND (512*KIB)
+#define MAX_META_PER_SEND 256
 #define MAX_FILE_CNT_PER_NODE KIB
 
 // Request Manager
-#define RECV_BUF_CNT 1
-#define RECV_BUF_LEN (MIB + 128*KIB)
-#define REQ_BUF_LEN (128*MIB + 4*KIB + 128*KIB)
+#define RECV_BUF_CNT 4
+#define RECV_BUF_LEN (8 * MIB)
+#define REQ_BUF_LEN (128 * KIB)
 #define SHM_WAIT_INTERVAL 10
 
 // Service Manager
 #define MIN_SLEEP_INTERVAL 10
 #define SLEEP_INTERVAL 100 /* unit: us */
 #define SLEEP_SLICE_PER_UNIT 10
-#define READ_BLOCK_SIZE MIB
-#define SEND_BLOCK_SIZE (MIB + 128*KIB)
+#define READ_BLOCK_SIZE (64 * MIB)
+#define SEND_BLOCK_SIZE (4 * MIB)
 #define READ_BUF_SZ GIB
-#define LARGE_BURSTY_DATA (500 * MIB)
+#define LARGE_BURSTY_DATA (512 * MIB)
 #define MAX_BURSTY_INTERVAL 10000 /* unit: us */
 
 // Request and Service Managers, Command Handler
@@ -90,12 +90,12 @@
 #define UNIFYCR_CHUNK_MEM (256 * MIB)
 #define UNIFYCR_SPILLOVER_SIZE (KIB * MIB)
 #define UNIFYCR_SUPERBLOCK_KEY 4321
-#define UNIFYCR_SHMEM_REQ_SIZE (MIB*128 + 128*KIB)
-#define UNIFYCR_SHMEM_RECV_SIZE (MIB + 128*KIB)
-#define UNIFYCR_INDEX_BUF_SIZE  (20 * MIB)
-#define UNIFYCR_FATTR_BUF_SIZE MIB
+#define UNIFYCR_SHMEM_REQ_SIZE (128 * KIB)
+#define UNIFYCR_SHMEM_RECV_SIZE (64 * MIB)
+#define UNIFYCR_INDEX_BUF_SIZE (4 * MIB)
+#define UNIFYCR_FATTR_BUF_SIZE (16 * MIB)
 #define UNIFYCR_MAX_SPLIT_CNT MIB
-#define UNIFYCR_MAX_READ_CNT MIB
+#define UNIFYCR_MAX_READ_CNT KIB
 
 // Following are not currently used:
 // #define ACK_MSG_SZ 8

--- a/common/src/unifycr_meta.h
+++ b/common/src/unifycr_meta.h
@@ -36,15 +36,28 @@ typedef enum {
 typedef struct {
     int fid;
     int gfid;
-    char filename[UNIFYCR_MAX_FILENAME];
     struct stat file_attr;
+    char filename[UNIFYCR_MAX_FILENAME];
 } unifycr_file_attr_t;
 
 typedef struct {
-    off_t file_pos;
-    off_t mem_pos;
+    size_t file_pos;
+    size_t mem_pos;
     size_t length;
     int fid;
 } unifycr_index_t;
+
+/* file metadata format in the shared memory */
+typedef struct {
+    int src_fid;
+    size_t offset;
+    size_t length;
+} shm_meta_t;
+
+/* header for contents of recv/req shmem buffers */
+typedef struct {
+    size_t sz;
+    size_t cnt;
+} shm_hdr_t;
 
 #endif /* UNIFYCR_META_H */

--- a/configure.ac
+++ b/configure.ac
@@ -51,9 +51,18 @@ AC_CHECK_HEADERS([inttypes.h wchar.h wctype.h])
 AC_CHECK_HEADER([openssl/md5.h], [], [AC_MSG_FAILURE([
         *** openssl/md5.h missing, openssl-devel package required])])
 
+# PMIx support build option
+AC_ARG_ENABLE([pmix],
+              AC_HELP_STRING([--enable-pmix],
+                             [Enable PMIx build options.]))
+
+if test "x$enable_pmix" = "xyes"; then
 AC_CHECK_HEADERS([pmix.h],
                  [AM_CONDITIONAL([USE_PMIX], [true])],
                  [AM_CONDITIONAL([USE_PMIX], [false])])
+else
+AM_CONDITIONAL([USE_PMIX], [false])
+fi
 
 
 # Checks for library functions.

--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -30,7 +30,9 @@ libmdhim_a_SOURCES = Mlog2/mlog2.c \
 libmdhim_a_LDFLAGS = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
-              -I$(top_srcdir)/meta/src/uthash
+              -I$(top_srcdir)/meta/src/uthash \
+              -I$(top_srcdir)/common/src \
+              -I$(top_srcdir)/server/src
 
 AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS) $(MPI_CFLAGS)
 AM_CFLAGS += -Wall

--- a/meta/src/ds_leveldb.c
+++ b/meta/src/ds_leveldb.c
@@ -828,7 +828,7 @@ int mdhim_leveldb_commit(void *dbh) {
 
 
 /**
- * mdhim_levedb_batch_next
+ * mdhim_leveldb_batch_next
  * get next (tot_records) starting from key (inclusive)
  *
  * @param dbh         in   pointer to the leveldb db handle
@@ -840,8 +840,9 @@ int mdhim_leveldb_commit(void *dbh) {
  * @return MDHIM_SUCCESS on success or MDHIM_DB_ERROR on failure
  * @return
  */
-int mdhim_levedb_batch_next(void *dbh, char **key, int *key_len, char **data, int32_t *data_len, \
-		int tot_records, int *num_records) {
+int mdhim_leveldb_batch_next(void *dbh, char **key, int *key_len,
+                             char **data, int32_t *data_len,
+                             int tot_records, int *num_records) {
 
 	gettimeofday(&dbngetstart, NULL);
 	struct mdhim_leveldb_t *mdhim_db = (struct mdhim_leveldb_t *) dbh;
@@ -916,454 +917,421 @@ error:
 }
 
 /**
- * levedb_batch_ranges
+ * leveldb_batch_ranges
  * get a list of key-value pairs that fall in the range of a list of
  * items identified (start_key, end_key)
  *
  * @param dbh         in   pointer to the leveldb db handle
- * @param key         in   a list of start_keys and end_keys.
- * odd indexed is start_key, even indexed key is end_key
- * @param key_len 	  in   a list of key_length for start_keys and end_keys
- * @param out_key	  in   a list keys to be returned corresponding to the start_keys/end_keys
- * @param out_key_len in   a list of key lengths to be returned
- * @param out_val     in   a list of values to be returned
- * @param out_val_len in   a list of value lens to be returned
- * @param tot_records in   number of start_keys and end_keys
+ * @param key         in   a list of start_key and end_key pairs
+ * @param key_len     in   a list of key_length for start_keys and end_keys
+ * @param out_keys     in   pointer to a list keys to be returned
+ * @param out_keys_len in   pointer to a list of key_lengths to be returned
+ * @param out_val     in   pointer to a list of values to be returned
+ * @param out_val_len in   pointer to a list of value lens to be returned
+ * @param num_ranges  in   number of start/end key ranges
  * @param out_records_cnt in number of copied key-value pairs
- * @param out_records_cap in number of allocated key-value pairs
  * @return MDHIM_SUCCESS on success or MDHIM_DB_ERROR on failure
  * @return
  */
-int levedb_batch_ranges(void *dbh, char **key, int *key_len,\
-		char ***out_key, int **out_key_len,\
-			char ***out_val, int **out_val_len,\
-				int tot_records, int *out_records_cnt) {
+int leveldb_batch_ranges(void *dbh, char **key, int32_t *key_len,
+                         char ***out_keys, int32_t **out_keys_len,
+                         char ***out_vals, int32_t **out_vals_len,
+                         int num_ranges, int *out_records_cnt) {
 
-	int i;
-	struct mdhim_leveldb_t *mdhim_db = (struct mdhim_leveldb_t *) dbh;
+    int i, start_ndx, end_ndx;
+    struct mdhim_leveldb_t *mdhim_db = (struct mdhim_leveldb_t *) dbh;
 
-	int tmp_records_cnt = 0; /*the temporary number of out records*/
-	int tmp_out_cap = tot_records/2; /* the temporary out capacity*/
+    int tmp_records_cnt = 0; /*the temporary number of out records*/
+    int tmp_out_cap = num_ranges; /* the temporary out capacity*/
 
-	leveldb_iterator_t *iter;
-	leveldb_readoptions_t *options;
-	options = mdhim_db->read_options;
+    leveldb_iterator_t *iter;
+    leveldb_readoptions_t *options;
+    options = mdhim_db->read_options;
 
-	iter = leveldb_create_iterator(mdhim_db->db, options);
+    iter = leveldb_create_iterator(mdhim_db->db, options);
 
-	*out_val = (char **)malloc(tot_records/2 * sizeof(char *));
-	*out_val_len = (int *)malloc(tot_records/2 * sizeof(int));
-	*out_key = (char **)malloc(tot_records/2 * sizeof(char *));
-	*out_key_len = (int *)malloc(tot_records/2 * sizeof(int));
+    *out_keys = (char **) calloc(num_ranges, sizeof(char *));
+    *out_keys_len = (int32_t *) calloc(num_ranges, sizeof(int32_t));
 
-	/*ToDo: return different error types if leveldb_process_range fails*/
+    *out_vals = (char **) calloc(num_ranges, sizeof(char *));
+    *out_vals_len = (int32_t *) calloc(num_ranges, sizeof(int32_t));
 
-	for (i = 0; i < tot_records/2; i++) {
-/*		printf("%dth offset is %ld, fid is %d, %d offset is %ld, len:%ld\n", 2 * i, \
-				UNIFYCR_OFFSET(key[2 * i]), UNIFYCR_FID(key[2 * i]), 2 * i + 1, \
-					UNIFYCR_OFFSET(key[ 2 * i + 1]), key_len[2 * i]); */
-		leveldb_process_range(iter, key[2 * i], key[2 * i + 1], \
-				key_len[2 * i], out_key, out_key_len, \
-					out_val, out_val_len, &tmp_records_cnt, \
-						&tmp_out_cap);
+    /*ToDo: return different error types if leveldb_process_range fails*/
 
-	}
+    for (i = 0; i < num_ranges; i++) {
+        start_ndx = 2 * i;
+        end_ndx = start_ndx + 1;
+        /* printf("range %d: fid is %d, start_offset=%zu end_offset=%zu\n",
+         *        i, UNIFYCR_KEY_FID(key[start_ndx]),
+         *        UNIFYCR_KEY_OFF(key[start_ndx]),
+         *        UNIFYCR_KEY_OFF(key[end_ndx]));
+         */
+        leveldb_process_range(iter, key[start_ndx], key[end_ndx],
+                              key_len[start_ndx],
+                              out_keys, out_keys_len,
+                              out_vals, out_vals_len,
+                              &tmp_records_cnt, &tmp_out_cap);
+    }
 
-	*out_records_cnt = tmp_records_cnt;
+    *out_records_cnt = tmp_records_cnt;
 
-/*	printf("out_records_cnt is %d\n", *out_records_cnt);
-	for (i = 0; i < *out_records_cnt; i++) {
-		printf("%dth out offset is %ld, fid is %ld, addr is %ld\n", \
-				i, UNIFYCR_OFFSET((*out_key)[i]), UNIFYCR_FID((*out_key)[i]), \
-					UNIFYCR_ADDR((*out_val)[i]));
-		fflush(stdout);
-	}
-*/
+    /* printf("out_records_cnt is %d\n", *out_records_cnt);
+     * for (i = 0; i < *out_records_cnt; i++) {
+     *     printf("out %d: fid is %d, offset=%zu addr=%zu\n",
+     *            i, UNIFYCR_KEY_FID((*out_keys)[i]),
+     *            UNIFYCR_KEY_OFF((*out_keys)[i]),
+     *            UNIFYCR_VAL_ADDR((*out_vals)[i]));
+     * }
+     * fflush(stdout);
+     */
 
-	leveldb_iter_destroy(iter);
-	return 0;
+    leveldb_iter_destroy(iter);
+    return 0;
 }
 
 /*
  * for comments inside:
- * start: start_key
- * end: end_key
- * pre_start: the start of the key-value pair right before start_key
- * pre_end: the end of the key-value pair right before start_key
- * pre_end = pre_start + range of the key-value pair (length) - 1
- * start_f: the start of the key-value pair right after start_key
- * start_e: the end of the key-value pair right after start_key
- * start_e = start_f + range of the key-value pair (length) - 1
+ * start: start_key offset
+ * end: end_key offset
+ * prev_s: start offset of the K-V pair that precedes start
+ * prev_e: end offset of the K-V pair that precedes start
+ *          (prev_e = prev_s + value length - 1)
+ * next_s: start offset of the K-V pair that follows start
+ * next_e: end offset of the K-V pair that follows start
+ *         (next_e = next_s + value length - 1)
  * */
-int leveldb_process_range(leveldb_iterator_t *iter,\
-		char *start_key, char *end_key, \
-			int key_len, char ***out_key, int **out_key_len, \
-				char ***out_val, int **out_val_len, int *tmp_records_cnt, \
-					int *tmp_out_cap) {
+int leveldb_process_range(leveldb_iterator_t *iter,
+                          char *start_key, char *end_key, int32_t key_len,
+                          char ***out_keys, int32_t **out_keys_len,
+                          char ***out_vals, int32_t **out_vals_len,
+                          int *tmp_records_cnt, int *tmp_out_cap) {
 
-	const char *ret_key, *ret_val;
-	long tmp_key_len, tmp_val_len;
-	const char *save_next_ret_key;
+    const char *ret_key, *ret_val;
+    size_t tmp_key_len, tmp_val_len;
+    const char *next_ret_key;
 
-	leveldb_iter_seek(iter, (char *)start_key, key_len);
+    int prev_flag = 0;
 
-	int diff_fid_flag = 0, data_end_flag = 0;
-	if (!leveldb_iter_valid(iter)) {
-		leveldb_iter_seek_to_last(iter);
-		if (!leveldb_iter_valid(iter))
-			return 0;
+    leveldb_iter_seek(iter, (char *)start_key, (size_t)key_len);
+    if (!leveldb_iter_valid(iter)) {
+        // check last K-V
+        leveldb_iter_seek_to_last(iter);
+        if (!leveldb_iter_valid(iter))
+            return 0;
 
-		ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-		if (!ret_key)
-			return MDHIM_DB_ERROR;
+        ret_key = leveldb_iter_key(iter, &tmp_key_len);
+        if (!ret_key)
+            return MDHIM_DB_ERROR;
+        else if (UNIFYCR_KEY_FID(ret_key) != UNIFYCR_KEY_FID(start_key))
+            return 0;
 
-		ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
-		if (!ret_val)
-			return MDHIM_DB_ERROR;
+        // last key matched fid, but not offset
+        prev_flag = 1;
+    } else {
+        ret_key = leveldb_iter_key(iter, &tmp_key_len);
+        if (!ret_key)
+            return MDHIM_DB_ERROR;
 
-		if (UNIFYCR_FID(ret_key) != UNIFYCR_FID(start_key))
-			return 0;
+        if (UNIFYCR_KEY_FID(start_key) != UNIFYCR_KEY_FID(ret_key)) {
+            // mismatch on fid, check previous K-V
+            leveldb_iter_prev(iter);
+            if (!leveldb_iter_valid(iter)) {
+                return 0;
+            }
 
-		data_end_flag = 1;
-	} else {
-		ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-		if (!ret_key)
-			return MDHIM_DB_ERROR;
+            ret_key = leveldb_iter_key(iter, &tmp_key_len);
+            if (!ret_key)
+                return MDHIM_DB_ERROR;
+            else if (UNIFYCR_KEY_FID(start_key) != UNIFYCR_KEY_FID(ret_key))
+                return 0;
 
-		ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
-		if (!ret_val)
-			return MDHIM_DB_ERROR;
+            prev_flag = 1;
+        }
+    }
 
-	}
+    ret_val = leveldb_iter_value(iter, &tmp_val_len);
+    if (!ret_val)
+        return MDHIM_DB_ERROR;
 
-	if (UNIFYCR_FID(start_key) != UNIFYCR_FID(ret_key)) {
-			leveldb_iter_prev(iter);
-			if (!leveldb_iter_valid(iter)) {
-				return 0;
-			}
+    unsigned long start_off = UNIFYCR_KEY_OFF(start_key);
+    unsigned long end_off = UNIFYCR_KEY_OFF(end_key);
 
-			ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-			if (!ret_key)
-				return MDHIM_DB_ERROR;
+    if (prev_flag) {
+        // ret_key is previous K-V with matching fid
+        unsigned long prev_st = UNIFYCR_KEY_OFF(ret_key);
+        unsigned long prev_end = prev_st + UNIFYCR_VAL_LEN(ret_val) - 1;
+        if (start_off > prev_end) {
+            /*	prev_s......prev_e;  ......  start..end  */
+            return 0;
+        }
 
-			ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
-			if (!ret_val)
-				return MDHIM_DB_ERROR;
+        unsigned long tmp_end;
+        if (end_off > prev_end) {
+            /*  prev_s......prev_e; next_s......next_e
+                     start...............end 	 */
+            tmp_end = prev_end;
+        } else {
+            /*  prev_s......prev_e; next_s......next_e
+                   start..end 	 */
+            tmp_end = end_off;
+        }
 
-			if (UNIFYCR_FID(start_key) != UNIFYCR_FID(ret_key))
-				return 0;
+        assert((UNIFYCR_KEY_SZ == tmp_key_len) &&
+               (UNIFYCR_VAL_SZ == tmp_val_len));
+        char *ret_out_key = calloc(1, UNIFYCR_KEY_SZ);
+        char *ret_out_val = calloc(1, UNIFYCR_VAL_SZ);
 
-			diff_fid_flag = 1;
-	}
+        memcpy(ret_out_key, ret_key, UNIFYCR_KEY_SZ);
+        UNIFYCR_KEY_OFF(ret_out_key) = start_off;
 
-	if (data_end_flag || diff_fid_flag) {
-		if (UNIFYCR_OFFSET(start_key) > UNIFYCR_OFFSET(ret_key)\
-				+ UNIFYCR_LEN(ret_val) - 1) {
-			/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-			 		 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 	 start  end 	 */
-			return 0;
-		} else {
+        memcpy(ret_out_val, ret_val, UNIFYCR_VAL_SZ);
+        UNIFYCR_VAL_ADDR(ret_out_val) = UNIFYCR_VAL_ADDR(ret_val)
+                                        + (start_off - prev_st);
+        UNIFYCR_VAL_LEN(ret_out_val) = tmp_end - start_off + 1;
 
-			long tmp_end;
-			if (UNIFYCR_OFFSET(end_key) >\
-					UNIFYCR_OFFSET(ret_key) + UNIFYCR_LEN(ret_val) - 1) {
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
+        add_kv(out_keys, out_keys_len,
+               out_vals, out_vals_len,
+               tmp_records_cnt, tmp_out_cap,
+               ret_out_key, ret_out_val,
+               tmp_key_len, tmp_val_len);
 
+        return 0;
 
-				 	 	 	 	 	 	 	 	 	 	 	 	start 	 	 	 	 	end 	 */
-				tmp_end = UNIFYCR_OFFSET(ret_key)\
-						+ UNIFYCR_LEN(ret_val) - 1;
-			} else {
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
+    } else if (UNIFYCR_KEY_OFF(ret_key) == start_off) {
+        // exact match on start offset
+        return handle_next_half(iter, start_key, end_key,
+                                out_keys, out_keys_len,
+                                out_vals, out_vals_len,
+                                tmp_records_cnt, tmp_out_cap);
+    }
 
+    leveldb_iter_prev(iter);
+    if (!leveldb_iter_valid(iter)) {
+        // already the first K-V, handle the rest of range
+        leveldb_iter_seek_to_first(iter);
+        return handle_next_half(iter, start_key, end_key,
+                                out_keys, out_keys_len,
+                                out_vals, out_vals_len,
+                                tmp_records_cnt, tmp_out_cap);
+    }
 
-				 	 	 	 	 	 	 	 	 	 	 	 	start end 	 */
-				tmp_end = UNIFYCR_OFFSET(end_key);
-			}
+    next_ret_key = ret_key;
+    ret_key = leveldb_iter_key(iter, &tmp_key_len);
+    if (!ret_key)
+        return MDHIM_DB_ERROR;
+    else if (UNIFYCR_KEY_FID(ret_key) != UNIFYCR_KEY_FID(start_key)) {
+        leveldb_iter_next(iter);
+        return handle_next_half(iter, start_key, end_key,
+                                out_keys, out_keys_len,
+                                out_vals, out_vals_len,
+                                tmp_records_cnt, tmp_out_cap);
+    }
 
-			char *ret_out_key = malloc(tmp_key_len);
-			char *ret_out_val = malloc(tmp_val_len);
-			memcpy(ret_out_key, ret_key, tmp_key_len);
-			memcpy(ret_out_val, ret_val, tmp_val_len);
+    ret_val = leveldb_iter_value(iter, &tmp_val_len);
+    if (!ret_val)
+        return MDHIM_DB_ERROR;
 
-			UNIFYCR_ADDR(ret_out_val) = UNIFYCR_ADDR(ret_val)\
-					+ UNIFYCR_OFFSET(start_key) - UNIFYCR_OFFSET(ret_key);
-			UNIFYCR_LEN(ret_out_val) = tmp_end - UNIFYCR_OFFSET(start_key) + 1;
-			UNIFYCR_OFFSET(ret_out_key) = UNIFYCR_OFFSET(start_key);
+    unsigned long prev_st = UNIFYCR_KEY_OFF(ret_key);
+    unsigned long prev_end = prev_st + UNIFYCR_VAL_LEN(ret_val) - 1;
 
-			add_kv(out_key, out_key_len, out_val,\
-				out_val_len, tmp_records_cnt, tmp_out_cap, \
-					ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
+    if (start_off <= prev_end) {
+        int found_end = 0;
+        unsigned long tmp_end = prev_end;
+        if (end_off <= prev_end) {
+            /*	 prev_s......prev_e; next_s......next_e
+             *     start....end
+             */
+            found_end = 1;
+            tmp_end = end_off;
+        }
+        /* else prev_end < end_off
+         *       prev_s......prev_e; next_s......next_e
+         *            start..................end
+         */
 
-			return 0;
-		}
+        assert((UNIFYCR_KEY_SZ == tmp_key_len) &&
+               (UNIFYCR_VAL_SZ == tmp_val_len));
+        char *ret_out_key = (char *) calloc(1, UNIFYCR_KEY_SZ);
+        char *ret_out_val = (char *) calloc(1, UNIFYCR_VAL_SZ);
 
-	} else {
-		if (UNIFYCR_OFFSET(ret_key) == UNIFYCR_OFFSET(start_key)) {
-			return	handle_next_half(iter,\
-					start_key, end_key, \
-						 out_key, out_key_len, \
-							out_val, out_val_len, tmp_records_cnt, \
-								tmp_out_cap);
-		}
+        memcpy(ret_out_key, ret_key, UNIFYCR_KEY_SZ);
+        UNIFYCR_KEY_OFF(ret_out_key) = start_off;
 
-		leveldb_iter_prev(iter);
-		if (!leveldb_iter_valid(iter)) {
-			/*already the first, handle the next*/
-			//start_next_half
-			leveldb_iter_seek_to_first(iter);
-			return handle_next_half(iter,\
-					start_key, end_key, \
-						out_key, out_key_len, \
-							out_val, out_val_len, tmp_records_cnt, \
-								tmp_out_cap);
-		} else {
-			save_next_ret_key = ret_key;
-			ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-			if (!ret_key)
-				return MDHIM_DB_ERROR;
+        memcpy(ret_out_val, ret_val, UNIFYCR_VAL_SZ);
+        UNIFYCR_VAL_LEN(ret_out_val) = tmp_end - start_off + 1;
+        UNIFYCR_VAL_ADDR(ret_out_val) = UNIFYCR_VAL_ADDR(ret_val) +
+                                        (start_off - prev_st);
 
-			ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
-			if (!ret_val)
-				return MDHIM_DB_ERROR;
+        add_kv(out_keys, out_keys_len,
+               out_vals, out_vals_len,
+               tmp_records_cnt, tmp_out_cap,
+               ret_out_key, ret_out_val,
+               tmp_key_len, tmp_val_len);
 
-			if (UNIFYCR_FID(ret_key) != UNIFYCR_FID(start_key)) {
-				leveldb_iter_next(iter);
-				return handle_next_half(iter,\
-						start_key, end_key, \
-							out_key, out_key_len, \
-								out_val, out_val_len, tmp_records_cnt, \
-									tmp_out_cap);
+        if (found_end) {
+            return 0;
+        }
 
-			}
+        // start at next to find rest of range
+        UNIFYCR_KEY_OFF(start_key) = UNIFYCR_KEY_OFF(next_ret_key);
+        leveldb_iter_next(iter);
+    } else {
+        /* start between prev and next, one of two cases:
+         * (1) prev_s......prev_e;           next_s......next_e
+         *                          start............end
+         *
+         * (2) prev_s......prev_e;           next_s......next_e
+         *                          start..........................end
+         */
+        // look for start of range in next
+        leveldb_iter_next(iter);
+    }
 
-			if (UNIFYCR_OFFSET(start_key) <=\
-					UNIFYCR_OFFSET(ret_key) + UNIFYCR_LEN(ret_val) - 1) {
+    return handle_next_half(iter, start_key, end_key,
+                            out_keys, out_keys_len,
+                            out_vals, out_vals_len,
+                            tmp_records_cnt, tmp_out_cap);
 
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-				 	 	 	 	 start 		 end
-				 	 	 	 	  	 	 	 	 	 	 	 	 	 		 */
-
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-				 	 	 	 	 start 							 end
-				 	 	 	 	  	 	 	 	 	 	 	 	 	 		 */
-
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-				 	 	 	 	 start 							 							end
-				 	  	 	 	 	 	 	 	 	 	 		 */
-				int to_ret = 0;
-				long tmp_end;
-				if (UNIFYCR_OFFSET(end_key) <=\
-						UNIFYCR_OFFSET(ret_key) + UNIFYCR_LEN(ret_val) - 1) {
-					to_ret = 1;
-					tmp_end = UNIFYCR_OFFSET(end_key);
-				} else {
-					tmp_end = UNIFYCR_OFFSET(ret_key)\
-							+ UNIFYCR_LEN(ret_val) - 1;
-				}
-
-				char *ret_out_key = malloc(tmp_key_len);
-				char *ret_out_val = malloc(tmp_val_len);
-				memcpy(ret_out_key, ret_key, tmp_key_len);
-				memcpy(ret_out_val, ret_val, tmp_val_len);
-
-				UNIFYCR_LEN(ret_out_val) = tmp_end - UNIFYCR_OFFSET(start_key) + 1;
-				UNIFYCR_ADDR(ret_out_val) = UNIFYCR_ADDR(ret_val) + \
-						UNIFYCR_OFFSET(start_key) - UNIFYCR_OFFSET(ret_key);
-				UNIFYCR_OFFSET(ret_out_key) = UNIFYCR_OFFSET(start_key);
-
-				add_kv(out_key, out_key_len, out_val,\
-					out_val_len, tmp_records_cnt, tmp_out_cap, \
-						ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
-
-				if (to_ret == 1) {
-					return 0;
-				}
-
-				/*start next half*/
-				UNIFYCR_OFFSET(start_key) = UNIFYCR_OFFSET(save_next_ret_key);
-				leveldb_iter_next(iter);
-				return handle_next_half(iter,\
-						start_key, end_key, \
-							 out_key, out_key_len, \
-								out_val, out_val_len, tmp_records_cnt, \
-									tmp_out_cap);
-
-
-			} else {
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-				 	 	 	 	 					start			end
-				 	 	 	 	  	 	 	 	 	 	 	 	 	 		 */
-
-				/*	pre_start,...........,pre_end; (start_f)..............(start_e)
-													start								end
-				 	 	 	 	  	 	 	 	 	 	 	 	 	 		 */
-				// directly handle the next
-				leveldb_iter_next(iter);
-				return handle_next_half(iter,\
-						start_key, end_key, \
-							out_key, out_key_len, \
-								out_val, out_val_len, tmp_records_cnt, \
-									tmp_out_cap);
-			}
-		}
-
-	}
-
-	return 0;
+    return 0;
 }
 
-int handle_next_half(leveldb_iterator_t *iter,\
-		char *start_key, char *end_key, \
-			char ***out_key, int **out_key_len, \
-				char ***out_val, int **out_val_len, int *tmp_records_cnt, \
-					int *tmp_out_cap) {
-	const char *ret_key, *ret_val;
+int handle_next_half(leveldb_iterator_t *iter,
+                     char *start_key, char *end_key,
+                     char ***out_keys, int32_t **out_keys_len,
+                     char ***out_vals, int32_t **out_vals_len,
+                     int *tmp_records_cnt, int *tmp_out_cap) {
+    const char *ret_key, *ret_val;
+    size_t tmp_key_len, tmp_val_len;
 
-	long tmp_key_len, tmp_val_len;
-	ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-	ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
+    ret_key = leveldb_iter_key(iter, &tmp_key_len);
+    if (!ret_key)
+        return MDHIM_DB_ERROR;
 
-	if (UNIFYCR_OFFSET(ret_key)\
-			> UNIFYCR_OFFSET(end_key)) {
-		/*	(start)........end....(start_f)...(end_f),........
-					 			 */
-		return 0;
-	} else {
-		if (UNIFYCR_OFFSET(end_key) <=\
-				UNIFYCR_OFFSET(ret_key) + UNIFYCR_LEN(ret_val) - 1) {
-			/* search between start and end*/
-			/*	(start).........end............
-						start_f  		(end_f)	 */
+    ret_val = leveldb_iter_value(iter, &tmp_val_len);
+    if (!ret_val)
+        return MDHIM_DB_ERROR;
 
-			char *ret_out_key = malloc(tmp_key_len);
-			char *ret_out_val = malloc(tmp_val_len);
-			memcpy(ret_out_key, ret_key, tmp_key_len);
-			memcpy(ret_out_val, ret_val, tmp_val_len);
+    assert((UNIFYCR_KEY_SZ == tmp_key_len) &&
+           (UNIFYCR_VAL_SZ == tmp_val_len));
 
-			UNIFYCR_LEN(ret_out_val) = UNIFYCR_OFFSET(end_key)\
-				- UNIFYCR_OFFSET(ret_key) +1;
-			UNIFYCR_ADDR(ret_out_val) = UNIFYCR_ADDR(ret_val)\
-					+ UNIFYCR_OFFSET(ret_key) - UNIFYCR_OFFSET(start_key);
+    unsigned long curr_off = UNIFYCR_KEY_OFF(ret_key);
+    unsigned long curr_end = curr_off + UNIFYCR_VAL_LEN(ret_val) - 1;
 
-			add_kv(out_key, out_key_len, out_val,\
-				out_val_len, tmp_records_cnt, tmp_out_cap, \
-					ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
+    unsigned long end_off = UNIFYCR_KEY_OFF(end_key);
 
-			return 0;
+    if (curr_off > end_off) {
+        // start..end precedes current K-V offset
+        return 0;
+    }
 
-		} else {
-			/*	(start).......................end......
-						start_f 	end_f		 			 */
+    char *ret_out_key;
+    char *ret_out_val;
 
-			int flag = 0;
+    ret_out_key = (char *) calloc(1, UNIFYCR_KEY_SZ);
+    ret_out_val = (char *) calloc(1, UNIFYCR_VAL_SZ);
+    memcpy(ret_out_key, ret_key, UNIFYCR_KEY_SZ);
+    memcpy(ret_out_val, ret_val, UNIFYCR_VAL_SZ);
 
-			char *ret_out_key = malloc(tmp_key_len);
-			char *ret_out_val = malloc(tmp_val_len);
-		/*	printf("here, ret_key offset is %ld, addr is %ld, len is %ld\n",\
-					UNIFYCR_OFFSET(ret_key), UNIFYCR_ADDR(ret_val),\
-						UNIFYCR_LEN(ret_val));
-			fflush(stdout); */
-			memcpy(ret_out_key, ret_key, tmp_key_len);
-			memcpy(ret_out_val, ret_val, tmp_val_len);
-			add_kv(out_key, out_key_len, out_val,\
-				out_val_len, tmp_records_cnt, tmp_out_cap, \
-					ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
-			while (1) {
+    if (end_off <= curr_end) {
+        // found end in current K-V, add slice
+        /*  curr_s.........curr_e
+           [start]....end          */
 
-				leveldb_iter_next(iter);
+        UNIFYCR_VAL_LEN(ret_out_val) = end_off - curr_off + 1;
 
-				if (!leveldb_iter_valid(iter)) {
-					/*	(start).............(end_f),........
-								start_f 			end of file  (cur_start_f) */
-					break; /*end_key is beyond the size of database*/
-				}
+        add_kv(out_keys, out_keys_len,
+               out_vals, out_vals_len,
+               tmp_records_cnt, tmp_out_cap,
+               ret_out_key, ret_out_val,
+               tmp_key_len, tmp_val_len);
+        return 0;
+    }
 
-				ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
-				if (!ret_key)
-					return MDHIM_DB_ERROR;
+    // range fully covers current K-V, add it
+    add_kv(out_keys, out_keys_len,
+           out_vals, out_vals_len,
+           tmp_records_cnt, tmp_out_cap,
+           ret_out_key, ret_out_val,
+           tmp_key_len, tmp_val_len);
 
-				ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
-				if (!ret_val)
-					return MDHIM_DB_ERROR;
+    // add subsequent K-Vs until end found (or fid mismatch)
+    int found_end = 0;
+    while (1) {
+        leveldb_iter_next(iter);
+        if (!leveldb_iter_valid(iter)) {
+            // end is past last K-V
+            break;
+        }
 
-				if (UNIFYCR_FID(ret_key) != UNIFYCR_FID(start_key)) {
-					break;
-				}
+        ret_key = leveldb_iter_key(iter, (size_t *)&tmp_key_len);
+        if (!ret_key)
+            return MDHIM_DB_ERROR;
+        else if (UNIFYCR_KEY_FID(ret_key) != UNIFYCR_KEY_FID(start_key)) {
+            // fid mismatch
+            break;
+        }
 
-				if (UNIFYCR_OFFSET(ret_key) > UNIFYCR_OFFSET(end_key)) {
-					/*	(start).............(end_f),........
-								start_f 			end  current_start_f */
-					break;
-				}
+        ret_val = leveldb_iter_value(iter, (size_t *)&tmp_val_len);
+        if (!ret_val)
+            return MDHIM_DB_ERROR;
 
-				if (UNIFYCR_OFFSET(ret_key) + UNIFYCR_LEN(ret_val) - 1 >=\
-						UNIFYCR_OFFSET(end_key)) {
-					/*	(start)............................end_f),........
-								start_f 			end*/
-					flag = 1;
-					break;
-				}
-				/*	(start).............(end_f),........
-							start_f 			end*/
-				char *ret_out_key = malloc(tmp_key_len);
-				char *ret_out_val = malloc(tmp_val_len);
-			/*	printf("here, ret_key offset is %ld, addr is %ld, len is %ld\n",\
-						UNIFYCR_OFFSET(ret_key), UNIFYCR_ADDR(ret_val), \
-							UNIFYCR_LEN(ret_val));
-				fflush(stdout); */
-				memcpy(ret_out_key, ret_key, tmp_key_len);
-				memcpy(ret_out_val, ret_val, tmp_val_len);
-				add_kv(out_key, out_key_len, out_val,\
-					out_val_len, tmp_records_cnt, tmp_out_cap, \
-						ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
-			}
+        curr_off = UNIFYCR_KEY_OFF(ret_key);
+        curr_end = curr_off + UNIFYCR_VAL_LEN(ret_val) - 1;
 
-			if (flag == 1) {
-				/*	(start)............................end_f),........
-							start_f 			end*/
+        if (curr_off > end_off) {
+            // current K-V starts after end
+            break;
+        }
 
-				char *ret_out_key = malloc(tmp_key_len);
-				char *ret_out_val = malloc(tmp_val_len);
+        assert((UNIFYCR_KEY_SZ == tmp_key_len) &&
+               (UNIFYCR_VAL_SZ == tmp_val_len));
+        ret_out_key = (char *) calloc(1, UNIFYCR_KEY_SZ);
+        ret_out_val = (char *) calloc(1, UNIFYCR_VAL_SZ);
+        memcpy(ret_out_key, ret_key, UNIFYCR_KEY_SZ);
+        memcpy(ret_out_val, ret_val, UNIFYCR_VAL_SZ);
 
-			/*	printf("finally, ret_key offset is %ld, addr is %ld, len is %ld\n",\
-						UNIFYCR_OFFSET(ret_key), UNIFYCR_ADDR(ret_val), \
-						UNIFYCR_LEN(ret_val)); */
-				memcpy(ret_out_key, ret_key, tmp_key_len);
-				memcpy(ret_out_val, ret_val, tmp_val_len);
+        if (curr_end >= end_off) {
+            // found end in current K-V, add slice
+            found_end = 1;
+            UNIFYCR_VAL_LEN(ret_out_val) = end_off - curr_off + 1;
+        }
+        // else, range fully covers current K-V, add it
+        add_kv(out_keys, out_keys_len,
+               out_vals, out_vals_len,
+               tmp_records_cnt, tmp_out_cap,
+               ret_out_key, ret_out_val,
+               tmp_key_len, tmp_val_len);
 
-				UNIFYCR_LEN(ret_out_val) = UNIFYCR_OFFSET(end_key)\
-						- UNIFYCR_OFFSET(ret_key) + 1;
-				UNIFYCR_ADDR(ret_out_val) = UNIFYCR_ADDR(ret_val);
-				add_kv(out_key, out_key_len, out_val,\
-					out_val_len, tmp_records_cnt, tmp_out_cap, \
-						ret_out_key, ret_out_val, tmp_key_len, tmp_val_len);
-
-			}
-			return 0;
-
-		}
-	}
-
+        if (found_end)
+            break;
+    }
+    return 0;
 }
 
-int add_kv(char ***out_key, int **out_key_len, char ***out_val,\
-		int **out_val_len, int *tmp_records_cnt, int *tmp_out_cap, \
-			char *ret_key, char *ret_val, int key_len, int val_len) {
+int add_kv(char ***out_keys, int32_t **out_keys_len,
+           char ***out_vals, int32_t **out_vals_len,
+           int *tmp_records_cnt, int *tmp_out_cap,
+           char *ret_key, char *ret_val,
+           size_t key_len, size_t val_len) {
+    int curr_cnt = *tmp_records_cnt;
+    if (curr_cnt == *tmp_out_cap) {
+        int new_cap = curr_cnt * 2;
+        *out_keys = (char **) realloc(*out_keys,
+                                      new_cap * sizeof(char *));
+        *out_vals = (char **) realloc(*out_vals,
+                                      new_cap * sizeof(char *));
+        *out_keys_len = (int32_t *) realloc(*out_keys_len,
+                                            new_cap * sizeof(int32_t));
+        *out_vals_len = (int32_t *) realloc(*out_vals_len,
+                                            new_cap * sizeof(int32_t));
+        *tmp_out_cap = new_cap;
+    }
 
-	if (*tmp_records_cnt == *tmp_out_cap) {
-		*out_key = (char **)realloc(*out_key, 2 * (*tmp_out_cap) * sizeof(char *));
-		*out_val = (char **)realloc(*out_val, 2 * (*tmp_out_cap) * sizeof(char *));
-		*out_key_len = (int *)realloc(*out_key_len, 2 * (*tmp_out_cap) * sizeof(int));
-		*out_val_len = (int *)realloc(*out_val_len, 2 * (*tmp_out_cap) * sizeof(int));
-		*tmp_out_cap *= 2;
-	}
+    (*out_keys)[curr_cnt] = ret_key;
+    (*out_vals)[curr_cnt] = ret_val;
+    (*out_keys_len)[curr_cnt] = (int32_t)key_len;
+    (*out_vals_len)[curr_cnt] = (int32_t)val_len;
 
-	(*out_key)[*tmp_records_cnt] = ret_key;
-	(*out_val)[*tmp_records_cnt] = ret_val;
-	(*out_key_len)[*tmp_records_cnt] = key_len;
-	(*out_val_len)[*tmp_records_cnt] = val_len;
-
-	*tmp_records_cnt = *tmp_records_cnt + 1;
-	return 0;
+    *tmp_records_cnt = curr_cnt + 1;
+    return 0;
 }

--- a/meta/src/ds_leveldb.h
+++ b/meta/src/ds_leveldb.h
@@ -34,10 +34,10 @@
  *
  */
 
-#ifndef      __LEVELDB_H
-#define      __LEVELDB_H
+#ifndef __LEVELDB_H
+#define __LEVELDB_H
 
-#ifndef      LEVELDB_SUPPORT
+#ifndef LEVELDB_SUPPORT
 #include <rocksdb/c.h>
 #else
 #include <leveldb/c.h>
@@ -47,14 +47,11 @@
 #include "partitioner.h"
 #include "data_store.h"
 
-#define UNIFYCR_FID(key) *(long *)key
-#define UNIFYCR_OFFSET(key) *((long *)key + 1)
-#define UNIFYCR_ADDR(val) *((long *)val + 2)
-#define UNIFYCR_LEN(val) *((long *)val + 1)
+#include "unifycr_metadata.h"
 
 /* Function pointer for comparator in C */
 typedef int (*mdhim_store_cmp_fn_t)(void* arg, const char* a, size_t alen,
-				    const char* b, size_t blen);
+                                    const char* b, size_t blen);
 
 struct mdhim_leveldb_t {
 	leveldb_t *db;
@@ -67,36 +64,44 @@ struct mdhim_leveldb_t {
 	leveldb_readoptions_t *read_options;
 	mdhim_store_cmp_fn_t compare;
 };
-int mdhim_leveldb_open(void **dbh, void **dbs, char *path, int flags, int key_type, struct mdhim_options_t	*opts);
-int mdhim_leveldb_put(void *dbh, void *key, int key_len, void *data, int32_t data_len);
-int mdhim_leveldb_get(void *dbh, void *key, int key_len, void **data, int32_t *data_len);
+
+int mdhim_leveldb_open(void **dbh, void **dbs, char *path,
+                       int flags, int key_type,
+                       struct mdhim_options_t	*opts);
+int mdhim_leveldb_put(void *dbh, void *key, int key_len,
+                      void *data, int32_t data_len);
+int mdhim_leveldb_get(void *dbh, void *key, int key_len,
+                      void **data, int32_t *data_len);
 int mdhim_leveldb_get_next(void *dbh, void **key, int *key_len, 
-			   void **data, int32_t *data_len);
+                           void **data, int32_t *data_len);
 int mdhim_leveldb_get_prev(void *dbh, void **key, int *key_len, 
-			   void **data, int32_t *data_len);
+                           void **data, int32_t *data_len);
 int mdhim_leveldb_close(void *dbh, void *dbs);
 int mdhim_leveldb_del(void *dbh, void *key, int key_len);
 int mdhim_leveldb_commit(void *dbh);
 int mdhim_leveldb_batch_put(void *dbh, void **key, int32_t *key_lens, 
-			    void **data, int32_t *data_lens, int num_records);
-int mdhim_levedb_batch_next(void *dbh, char **key,\
-		int *key_len, char **data, int32_t *data_len, \
-			int tot_records, int *num_records);
-int levedb_batch_ranges(void *dbh, char **key, int *key_len,\
-		char ***out_key, int **out_key_len,\
-			char ***out_val, int **out_val_len,\
-				int tot_records, int *out_records_cnt);
-int leveldb_process_range(leveldb_iterator_t *iter,\
-		char *start_key, char *end_key, \
-			int key_len, char ***out_key, int **out_key_len, \
-				char ***out_val, int **out_val_len, int *tmp_records_cnt, \
-					int *tmp_out_cap);
-int handle_next_half(leveldb_iterator_t *iter,\
-		char *start_key, char *end_key, \
-			char ***out_key, int **out_key_len, \
-				char ***out_val, int **out_val_len, int *tmp_records_cnt, \
-					int *tmp_out_cap);
-int add_kv(char ***out_key, int **out_key_len, char ***out_val,\
-		int **out_val_len, int *tmp_records_cnt, int *tmp_out_cap, \
-			char *ret_key, char *ret_val, int key_len, int val_len);
+                            void **data, int32_t *data_lens, int num_records);
+int mdhim_leveldb_batch_next(void *dbh, char **key,
+                             int *key_len, char **data, int32_t *data_len,
+                             int tot_records, int *num_records);
+int leveldb_batch_ranges(void *dbh, char **key, int32_t *key_len,
+                         char ***out_key, int32_t **out_key_len,
+                         char ***out_val, int32_t **out_val_len,
+                         int num_ranges, int *out_records_cnt);
+int leveldb_process_range(leveldb_iterator_t *iter,
+                          char *start_key, char *end_key, int32_t key_len,
+                          char ***out_key, int32_t **out_key_len,
+                          char ***out_val, int32_t **out_val_len,
+                          int *tmp_records_cnt, int *tmp_out_cap);
+int handle_next_half(leveldb_iterator_t *iter,
+                     char *start_key, char *end_key,
+                     char ***out_key, int **out_key_len,
+                     char ***out_val, int **out_val_len,
+                     int *tmp_records_cnt, int *tmp_out_cap);
+int add_kv(char ***out_key, int32_t **out_key_len,
+           char ***out_val, int32_t **out_val_len,
+           int *tmp_records_cnt, int *tmp_out_cap,
+           char *ret_key, char *ret_val,
+           size_t key_len, size_t val_len);
+
 #endif

--- a/meta/src/range_server.c
+++ b/meta/src/range_server.c
@@ -44,17 +44,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include "mdhim.h"
-#include "range_server.h"
-#include "partitioner.h"
-#include "mdhim_options.h"
-#include "ds_leveldb.h"
-#include "uthash.h"
 
-#define UNIFYCR_FID(key) *(long *)key
-#define UNIFYCR_OFFSET(key) *((long *)key + 1)
-#define UNIFYCR_ADDR(val) *((long *)val + 2)
-#define UNIFYCR_LEN(val) *((long *)val + 1)
+#include "ds_leveldb.h"
+#include "mdhim.h"
+#include "mdhim_options.h"
+#include "partitioner.h"
+#include "range_server.h"
+#include "unifycr_metadata.h"
+#include "uthash.h"
 
 int recv_counter = 0;
 
@@ -87,32 +84,13 @@ struct timeval statstart, statend;
 double starttime=0;
 
 int putflag = 1;
+
 int unifycr_compare(const char* a, const char* b) {
-	int ret;
-
-	long offset, old_offset;
-	long fid, old_fid;
-
-	fid = *((unsigned long *)a);
-	old_fid = *((unsigned long *)b);
-
-	offset = *((unsigned long *)a+1);
-	old_offset = *((unsigned long *)b+1);
-
-	ret = fid - old_fid;
-
-	if (ret != 0)
-			return ret;
-	else {
-		if (offset - old_offset > 0)
-				return 1;
-		else if(offset - old_offset < 0)
-				return -1;
-		else
-				return 0;
-	}
-
-	return ret;
+	int rc;
+	unifycr_key_t *keya = (unifycr_key_t *)a;
+	unifycr_key_t *keyb = (unifycr_key_t *)b;
+	rc = unifycr_key_compare(keya, keyb);
+	return rc;
 }
 
 void add_timing(struct timeval start, struct timeval end, int num, 
@@ -769,8 +747,8 @@ int range_server_commit(struct mdhim_t *md, struct mdhim_basem_t *im, int source
 int range_server_bget(struct mdhim_t *md, struct mdhim_bgetm_t *bgm, int source) {
 	putflag = 0;
 	int ret;
-	void **values;
-	int32_t *value_lens;
+	void **values = NULL;
+	int32_t *value_lens = NULL;
 	int i;
 	struct mdhim_bgetrm_t *bgrm;
 	int error = 0;
@@ -780,9 +758,8 @@ int range_server_bget(struct mdhim_t *md, struct mdhim_bgetm_t *bgm, int source)
 
 	gettimeofday(&start, NULL);
 	if (bgm->op != MDHIM_RANGE_BGET) {
-		values = malloc(sizeof(void *) * bgm->num_keys);
-		value_lens = malloc(sizeof(int32_t) * bgm->num_keys);
-		memset(value_lens, 0, sizeof(int32_t) * bgm->num_keys);
+		values = (void **) calloc(bgm->num_keys, sizeof(void *));
+		value_lens = (int32_t *) calloc(bgm->num_keys, sizeof(int32_t));
 	}
 	//Get the index referenced the message
 	index = find_index(md, (struct mdhim_basem_t *) bgm);
@@ -794,20 +771,15 @@ int range_server_bget(struct mdhim_t *md, struct mdhim_bgetm_t *bgm, int source)
 	}
 
 	if (bgm->op == MDHIM_RANGE_BGET) {
-		values = malloc(sizeof(void *) * bgm->num_keys/2);
-		value_lens = malloc(sizeof(int32_t) * bgm->num_keys/2);
-		memset(value_lens, 0, sizeof(int) * bgm->num_keys/2);
-
-		void **ret_keys = malloc(bgm->num_keys * sizeof(char *)/2);
-		int32_t *ret_key_lens = malloc(bgm->num_keys * sizeof(int32_t));
-		memset(ret_key_lens, 0, sizeof(int) * bgm->num_keys/2);
-
+		void **ret_keys;
+		int32_t *ret_key_lens;
+		int num_ranges = bgm->num_keys / 2;
 		int out_record_cnt = 0;
-		levedb_batch_ranges(index->mdhim_store->db_handle,
+		leveldb_batch_ranges(index->mdhim_store->db_handle,
                                     (char **)bgm->keys, bgm->key_lens,
                                     (char ***)&ret_keys, &ret_key_lens,
                                     (char ***)&values, &value_lens,
-                                    bgm->num_keys, &out_record_cnt);
+                                    num_ranges, &out_record_cnt);
 
 		if (source != md->mdhim_rank) {
 			for (i = 0; i < bgm->num_keys; i++) {
@@ -1141,11 +1113,11 @@ int range_server_bget_op(struct mdhim_t *md, struct mdhim_bgetm_t *bgm, int sour
 		*get_key_len = bgm->key_lens[0];
 		key_lens[0] = *get_key_len;
 
-		error = mdhim_levedb_batch_next(index->mdhim_store->db_handle,
-						(char **)keys, key_lens,
-						(char **)values, value_lens,
-						bgm->num_keys * bgm->num_recs,
-						&num_records);
+		error = mdhim_leveldb_batch_next(index->mdhim_store->db_handle,
+                                                 (char **)keys, key_lens,
+                                                 (char **)values, value_lens,
+                                                 bgm->num_keys * bgm->num_recs,
+                                                 &num_records);
 
 	}
 

--- a/meta/src/range_server.h
+++ b/meta/src/range_server.h
@@ -92,10 +92,6 @@ int range_server_init_comm(struct mdhim_t *md);
 int range_server_stop(struct mdhim_t *md);
 int range_server_add_oreq(struct mdhim_t *md, MPI_Request *req, void *msg); //Add an outstanding request
 int range_server_clean_oreqs(struct mdhim_t *md); //Clean outstanding reqs
-int levedb_batch_ranges(void *dbh, char **key, int *key_len,\
-		char ***out_key, int **out_key_len,\
-			char ***out_val, int **out_val_len,\
-				int tot_records, int *out_records_cnt);
 int unifycr_compare(const char *a, const char *b);
 
 #endif

--- a/server/src/arraylist.c
+++ b/server/src/arraylist.c
@@ -34,59 +34,66 @@
 
 arraylist_t *arraylist_create()
 {
-    arraylist_t *arr = (arraylist_t *)malloc(sizeof(arraylist_t));
-    if (!arr) {
+    arraylist_t *arr = (arraylist_t *) malloc(sizeof(arraylist_t));
+    if (NULL == arr) {
         return NULL;
     }
 
     arr->cap = DEF_ARR_CAP;
     arr->size = 0;
-    arr->elems = (void **)malloc(arr->cap * sizeof(void *));
+    arr->elems = (void **) calloc(arr->cap, sizeof(void*));
 
-    if (!arr->elems) {
+    if (NULL == arr->elems) {
+        free(arr);
         return NULL;
     }
-
-    int i;
-    for (i = 0; i < arr->cap; i++) {
-        arr->elems[i] = NULL;
-    }
-
     return arr;
 }
 
 int arraylist_capacity(arraylist_t *arr)
 {
+    if (NULL == arr) {
+        return -1;
+    }
     return arr->cap;
 }
 
 int arraylist_size(arraylist_t *arr)
 {
+    if (NULL == arr) {
+        return -1;
+    }
     return arr->size;
 }
 
 void *arraylist_get(arraylist_t *arr, int pos)
 {
-    if (pos >= arr->size) {
+    if ((NULL == arr) || (pos >= arr->size)) {
         return NULL;
     }
     return arr->elems[pos];
-};
+}
 
 int arraylist_insert(arraylist_t *arr, int pos, void *elem)
 {
+    if (NULL == arr) {
+        return -1;
+    }
+
     if (pos >= arr->cap) {
-        arr->elems = (void **)realloc(arr->elems,
-                                      2 * pos * sizeof(void *));
-        if (!arr->elems) {
+        int newcap = 2 * pos;
+        void** newlist = (void **) realloc(arr->elems,
+                                           newcap * sizeof(void*));
+        if (NULL == newlist) {
             return -1;
         }
+        arr->elems = newlist;
 
-        long i;
-        for (i = arr->cap; i < 2 * pos; i++) {
+        int i;
+        for (i = arr->cap; i < newcap; i++) {
             arr->elems[i] = NULL;
         }
-        arr->cap = 2 * pos;
+        arr->cap = newcap;
     }
 
     if (arr->elems[pos] != NULL) {
@@ -98,53 +105,64 @@ int arraylist_insert(arraylist_t *arr, int pos, void *elem)
         arr->size = pos + 1;
 
     return 0;
-
 }
 
 
 int arraylist_add(arraylist_t *arr, void *elem)
 {
+    if (NULL == arr) {
+        return -1;
+    }
+
     if (arr->size == arr->cap) {
-        arr->elems = (void **)realloc(arr->elems, 2 * arr->cap * sizeof(void *));
-        if (!arr->elems) {
+        int newcap = 2 * arr->cap;
+        void** newlist = (void **) realloc(arr->elems,
+                                           newcap * sizeof(void*));
+        if (NULL == newlist) {
             return -1;
         }
+        arr->elems = newlist;
+        arr->cap = newcap;
 
-        long i;
-        for (i = arr->cap; i < 2 * arr->cap; i++) {
+        int i;
+        for (i = arr->size; i < newcap; i++) {
             arr->elems[i] = NULL;
         }
-        arr->cap = arr->cap * 2;
     }
 
     if (arr->elems[arr->size] != NULL) {
         free(arr->elems[arr->size]);
     }
     arr->elems[arr->size] = elem;
-    arr->size = arr->size + 1;
-    return 0;
+    arr->size += 1;
 
+    return 0;
 }
 
 int arraylist_reset(arraylist_t *arr)
 {
-    if (!arr) {
+    if (NULL == arr) {
         return -1;
     }
 
     arr->size = 0;
+
     return 0;
 }
 
 int arraylist_free(arraylist_t *arr)
 {
-    long i;
+    if (NULL == arr) {
+        return -1;
+    }
+
+    int i;
     for (i = 0; i < arr->cap; i++) {
         if (arr->elems[i] != NULL) {
             free(arr->elems[i]);
         }
     }
-
     free(arr);
+
     return 0;
 }

--- a/server/src/arraylist.h
+++ b/server/src/arraylist.h
@@ -33,8 +33,8 @@
 #define DEF_ARR_CAP 1024
 
 typedef struct {
-    long cap;
-    long size;
+    int cap;
+    int size;
     void **elems;
 } arraylist_t;
 

--- a/server/src/log.h
+++ b/server/src/log.h
@@ -36,7 +36,6 @@
 #include <sys/time.h>
 
 extern FILE *dbg_stream;
-extern char dbg_line[1024];
 extern int glb_rank;
 
 typedef enum {
@@ -56,27 +55,32 @@ struct timeval logstart, logend;
 double mlogtm;
 
 extern int log_print_level;
+
 #if defined(__NR_gettid)
     #define gettid() syscall(__NR_gettid)
 #elif defined(SYS_gettid)
     #define gettid() syscall(SYS_gettid)
 #else
-    #error gettid syscal is not defined
+    #error gettid system call is not defined
 #endif
-#define LOG(level, ...) \
-                if(level <= log_print_level) { \
-                    gettimeofday(&logstart, NULL); \
-                    ltime = time(NULL); \
-                    ttime = localtime(&ltime); \
-                    strftime(timestamp, sizeof(timestamp), \
-                            "%Y-%m-%dT%H:%M:%S", ttime); \
-                    fprintf(dbg_stream,"logtime:%lf rank [%d] [%s] [%ld] [%s:%d] [%s] ", \
-                                mlogtm/1000000, glb_rank, timestamp, gettid(), \
-                                        __FILE__, __LINE__, __FUNCTION__); \
-                    fprintf(dbg_stream, __VA_ARGS__); \
-                    fprintf(dbg_stream, "\n"); \
-                    fflush(dbg_stream); \
-                    gettimeofday(&logend, NULL); \
-                    mlogtm += 1000000*(logend.tv_sec-logstart.tv_sec)+logend.tv_usec-logstart.tv_usec; \
-                        }
+
+#define LOG(level, ...)                                                 \
+    if (level <= log_print_level) {                                     \
+        gettimeofday(&logstart, NULL);                                  \
+        ltime = time(NULL);                                             \
+        ttime = localtime(&ltime);                                      \
+        strftime(timestamp, sizeof(timestamp),                          \
+                 "%Y-%m-%dT%H:%M:%S", ttime);                           \
+        fprintf(dbg_stream,                                             \
+                "logtime:%lf rank [%d] [%s] [%ld] [%s:%d] [%s] ",       \
+                mlogtm/1000000, glb_rank, timestamp, gettid(),          \
+                __FILE__, __LINE__, __func__);                          \
+        fprintf(dbg_stream, __VA_ARGS__);                               \
+        fprintf(dbg_stream, "\n");                                      \
+        fflush(dbg_stream);                                             \
+        gettimeofday(&logend, NULL);                                    \
+        mlogtm += 1000000*(logend.tv_sec - logstart.tv_sec) +           \
+            logend.tv_usec - logstart.tv_usec;                          \
+    }
+
 #endif /* LOG_H */

--- a/server/src/unifycr_debug.c
+++ b/server/src/unifycr_debug.c
@@ -32,7 +32,6 @@
 #include "unifycr_const.h"
 
 FILE *dbg_stream = NULL;
-char dbg_line[GEN_STR_LEN] = {0};
 
 int dbg_open(char *fname)
 {
@@ -40,21 +39,18 @@ int dbg_open(char *fname)
     if (dbg_stream == NULL) {
         dbg_stream = stderr;
         return (int)UNIFYCR_ERROR_DBG;
-    } else {
-        return ULFS_SUCCESS;
     }
-
+    return UNIFYCR_SUCCESS;
 }
 
 int dbg_close()
 {
     if (dbg_stream == NULL) {
         return (int)UNIFYCR_ERROR_DBG;
-    } else {
-        if (fclose(dbg_stream) == 0) {
-            return ULFS_SUCCESS;
+    } else if (dbg_stream != stderr) {
+        if (fclose(dbg_stream) != 0) {
+            return (int)UNIFYCR_ERROR_DBG;
         }
-        return (int)UNIFYCR_ERROR_DBG;
-
     }
+    return UNIFYCR_SUCCESS;
 }

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -48,41 +48,40 @@ typedef enum {
 typedef struct {
     int dest_app_id;
     int dest_client_id; /*note: the id is the app-side rank on the remote node*/
-    long dest_offset;
+    off_t dest_offset;
     int dest_delegator_rank;
-    long length;
+    size_t length;
     int src_delegator_rank;
     int src_cli_id;
     int src_app_id;
     int src_fid;
-    long src_offset;
+    off_t src_offset;
     int src_thrd;
     int src_dbg_rank;
     int arrival_time;
 } send_msg_t;
 
 typedef struct {
-    long src_fid;
-    long src_offset;
-    long length;
-} recv_msg_t;
-
+    int src_fid;
+    size_t src_offset;
+    size_t length;
+} data_msg_t;
 
 typedef struct {
-    int num;
+    size_t num;
     send_msg_t msg_meta[MAX_META_PER_SEND];
 } msg_meta_t;
 
 typedef struct {
-    long superblock_sz;
-    long meta_offset;
-    long meta_size;
-    long fmeta_offset;
-    long fmeta_size;
-    long data_offset;
-    long data_size;
-    int req_buf_sz;
-    int recv_buf_sz;
+    size_t superblock_sz;
+    size_t meta_offset;
+    size_t meta_size;
+    size_t fmeta_offset;
+    size_t fmeta_size;
+    size_t data_offset;
+    size_t data_size;
+    size_t req_buf_sz;
+    size_t recv_buf_sz;
     int num_procs_per_node;
     int client_ranks[MAX_NUM_CLIENTS];
     int thrd_idxs[MAX_NUM_CLIENTS];
@@ -141,8 +140,8 @@ typedef struct {
 typedef int fattr_key_t;
 
 typedef struct {
-    char fname[UNIFYCR_MAX_FILENAME];
     struct stat file_attr;
+    char fname[UNIFYCR_MAX_FILENAME];
 } fattr_val_t;
 
 extern arraylist_t *app_config_list;
@@ -154,10 +153,6 @@ extern pthread_t data_thrd;
 extern int glb_rank, glb_size;
 extern int *local_rank_lst;
 extern int local_rank_cnt;
-extern long max_recs_per_slice;
-
-#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
-extern int local_rank_idx;
-#endif
+extern size_t max_recs_per_slice;
 
 #endif

--- a/server/src/unifycr_metadata.h
+++ b/server/src/unifycr_metadata.h
@@ -30,6 +30,7 @@
 #ifndef UNIFYCR_METADATA_H
 #define UNIFYCR_METADATA_H
 
+#include <assert.h>
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -49,30 +50,41 @@ typedef struct {
     unsigned long offset;
 } unifycr_key_t;
 
-typedef struct {
-    unsigned long delegator_id;
-    unsigned long len;
-    unsigned long addr;
-    unsigned long app_rank_id; /*include both app and rank id*/
-} unifycr_val_t;
+#define UNIFYCR_KEY_SZ (sizeof(unifycr_key_t))
+
+#define UNIFYCR_KEY_FID(keyp) (((unifycr_key_t *)keyp)->fid)
+#define UNIFYCR_KEY_OFF(keyp) (((unifycr_key_t *)keyp)->offset)
+
+int unifycr_key_compare(unifycr_key_t *a, unifycr_key_t *b);
 
 typedef struct {
-    int fid;
-    long offset;
-    long length;
-} cli_req_t;
+    unsigned long addr;
+    unsigned long len;
+    int delegator_id;
+    int app_id;
+    int rank;
+} unifycr_val_t;
+
+#define UNIFYCR_VAL_SZ (sizeof(unifycr_val_t))
+
+#define UNIFYCR_VAL_ADDR(valp) (((unifycr_val_t *)valp)->addr)
+#define UNIFYCR_VAL_LEN(valp) (((unifycr_val_t *)valp)->len)
 
 extern arraylist_t *ulfs_keys;
 extern arraylist_t *ulfs_vals;
 extern arraylist_t *ulfs_metas;
+
+void debug_log_key_val(const char* ctx,
+                       unifycr_key_t *key,
+                       unifycr_val_t *val);
 
 int meta_sanitize();
 int meta_init_store(unifycr_cfg_t *cfg);
 void print_bget_indices(int app_id, int cli_id,
                         send_msg_t *index_set, int tot_num);
 int meta_process_fsync(int sock_id);
-int meta_batch_get(int app_id, int client_id,
-                   int thrd_id, int dbg_rank, char *shm_reqbuf, int num,
+int meta_batch_get(int app_id, int client_id, int thrd_id, int dbg_rank,
+                   shm_meta_t *meta_reqs, size_t req_cnt,
                    msg_meta_t *del_req_set);
 int meta_init_indices();
 int meta_free_indices();

--- a/server/src/unifycr_request_manager.h
+++ b/server/src/unifycr_request_manager.h
@@ -29,36 +29,57 @@
 
 #ifndef UNIFYCR_REQUEST_MANAGER_H
 #define UNIFYCR_REQUEST_MANAGER_H
+
 #include "unifycr_const.h"
 #include "unifycr_global.h"
+#include "unifycr_meta.h"
 #include "arraylist.h"
 
-typedef struct {
-    int src_fid;
-    long offset;
-    long length;
-} shm_meta_t; /*metadata format in the shared memory*/
-
 void *rm_delegate_request_thread(void *arg);
-int rm_read_remote_data(int sock_id, int num);
-int rm_send_remote_requests(thrd_ctrl_t *thrd_ctrl,
-                            int thrd_tag, long *tot_sz);
-int rm_pack_send_requests(char *req_msg_buf,
-                          send_msg_t *send_metas, int req_num,
-                          long *tot_sz);
 
-int compare_delegators(const void *a, const void *b);
-int rm_pack_send_msg(int rank, char *send_msg_buf,
-                     send_msg_t *send_metas, int meta_num,
-                     long *tot_sz);
+int rm_read_remote_data(int sock_id,
+                        size_t req_cnt);
+
+int rm_send_remote_requests(thrd_ctrl_t *thrd_ctrl,
+                            int thrd_tag,
+                            size_t *tot_sz);
+
+int rm_pack_send_requests(char *req_msg_buf,
+                          send_msg_t *send_metas,
+                          size_t req_cnt,
+                          size_t *tot_sz);
+
+int compare_delegators(const void *a,
+                       const void *b);
+
+int rm_pack_send_msg(int rank,
+                     char *send_msg_buf,
+                     send_msg_t *send_metas,
+                     size_t meta_cnt,
+                     size_t *tot_sz);
+
 int rm_receive_remote_message(int app_id,
-                              int sock_id, long tot_sz);
+                              int sock_id,
+                              size_t tot_sz);
+
 void print_recv_msg(int app_id,
-                    int cli_id, int dbg_rank, int thrd_id, shm_meta_t *msg);
-int rm_process_received_msg(int app_id, int sock_id,
-                            char *recv_msg_buf, long *ptr_tot_sz);
-void print_remote_del_reqs(int app_id, int cli_id,
-                           int dbg_rank, del_req_stat_t *del_req_stat);
+                    int cli_id,
+                    int dbg_rank,
+                    int thrd_id,
+                    shm_meta_t *msg);
+
+int rm_process_received_msg(int app_id,
+                            int sock_id,
+                            char *recv_msg_buf,
+                            size_t *ptr_tot_sz);
+
+void print_remote_del_reqs(int app_id,
+                           int cli_id,
+                           int dbg_rank,
+                           del_req_stat_t *del_req_stat);
+
 void print_send_msgs(send_msg_t *send_metas,
-                     long msg_cnt, int dbg_rank);
+                     size_t msg_cnt,
+                     int dbg_rank);
+
 #endif

--- a/server/src/unifycr_service_manager.h
+++ b/server/src/unifycr_service_manager.h
@@ -29,15 +29,14 @@
 
 #ifndef UNIFYCR_SERVICE_MANAGER_H
 #define UNIFYCR_SERVICE_MANAGER_H
+
 #include <mpi.h>
 #include "unifycr_global.h"
 #include "arraylist.h"
 #include <aio.h>
 
 typedef struct {
-    long src_fid;
-    long src_offset;
-    long length;
+    data_msg_t msg;
     char *addr;
 } ack_meta_t;
 
@@ -49,9 +48,9 @@ typedef struct {
 } ack_stat_t;
 
 typedef struct {
-    int start_idx;
-    int end_idx;
-    int size;
+    size_t start_idx;
+    size_t end_idx;
+    size_t size;
     int app_id;
     int cli_id;
     int arrival_time;
@@ -59,80 +58,98 @@ typedef struct {
 
 typedef struct {
     read_task_t *read_tasks;
-    int num;
-    int cap;
+    size_t num;
+    size_t cap;
 } task_set_t;
 
 typedef struct {
     send_msg_t *msg;
-    int num;
-    int cap;
+    size_t num;
+    size_t cap;
 } service_msgs_t;
 
 typedef struct {
     struct aiocb read_cb;
-    int index;
-    int start_pos;
-    int end_pos;
+    size_t index;
+    size_t start_pos;
+    size_t end_pos;
     char *mem_pos;
 } pended_read_t;
 
 typedef struct {
     arraylist_t *ack_list;
+    int start_cursor;
     int rank_id;
     int thrd_id;
     int src_cli_rank;
-    long src_sz;
-    int start_cursor;
+    size_t src_sz;
 } rank_ack_meta_t;
 
 typedef struct {
     rank_ack_meta_t *ack_metas;
-    int num;
+    size_t num;
 } rank_ack_task_t;
 
-int insert_ack_meta(rank_ack_task_t *rank_ack_task,
-                    ack_meta_t *ptr_ack, int pos, int rank_id, int thrd_id,
-                    int src_cli_rank);
+// comparison helper functions
 int compare_rank_thrd(int src_rank, int src_thrd,
                       int cmp_rank, int cmp_thrd);
-void *sm_service_reads(void *ctx);
-int sm_decode_msg(char *recv_msg_buf);
-int sm_classfy_reads(service_msgs_t *service_msgs);
-int sm_ack_reads(service_msgs_t *service_msgs);
+int compare_ack_stat(const void *a, const void *b);
+int compare_read_task(const void *a, const void *b);
 int compare_send_msg(const void *a, const void *b);
-int sm_wait_until_digested(task_set_t *read_task_set,
-                           service_msgs_t *service_msgs,
-                           rank_ack_task_t *read_ack_task);
-int sm_ack_remote_delegator(rank_ack_meta_t *ptr_ack_meta);
-int batch_ins_to_ack_lst(rank_ack_task_t *rank_ack_task,
-                         read_task_t *read_task,
-                         service_msgs_t *service_msgs,
-                         char  *mem_addr, int start_offset, int end_offset);
+
+// service manager methods
+int sm_exit(void);
+
+int sm_init_socket(void);
+
+void *sm_service_reads(void *ctx);
+
+int sm_decode_msg(char *recv_msgs);
+
 int sm_read_send_pipe(task_set_t *read_task_set,
                       service_msgs_t *service_msgs,
                       rank_ack_task_t *rank_ack_task);
-int sm_init_socket();
-int ins_to_ack_lst(rank_ack_task_t *rank_ack_task,
-                   char *mem_addr, service_msgs_t *service_msgs,
-                   int index, long src_offset, long len);
-int find_ack_meta(rank_ack_task_t *rank_ack_task,
-                  int src_rank, int src_thrd);
+
 int sm_cluster_reads(task_set_t *read_task_set,
                      service_msgs_t *service_msgs);
+
+int sm_classfy_reads(service_msgs_t *service_msgs);
+
+int sm_ack_reads(service_msgs_t *service_msgs);
+
+int sm_ack_remote_delegator(rank_ack_meta_t *ptr_ack_meta);
+
+int sm_wait_until_digested(task_set_t *read_task_set,
+                           service_msgs_t *service_msgs,
+                           rank_ack_task_t *read_ack_task);
+
+// helper methods
 void reset_read_tasks(task_set_t *read_task_set,
-                      service_msgs_t *service_msgs, int index);
-int compare_read_task(const void *a, const void *b);
-int sm_exit();
-void print_task_set(task_set_t *read_task_set,
-                    service_msgs_t *service_msgs);
-void print_service_msgs(service_msgs_t *service_msgs);
-void reset_read_tasks(task_set_t *read_task_set,
-                      service_msgs_t *service_msgs, int index);
-void print_task_set(task_set_t *read_task_set,
-                    service_msgs_t *service_msgs);
+                      service_msgs_t *service_msgs, size_t index);
+
+size_t find_ack_meta(rank_ack_task_t *rank_ack_task,
+                     int src_rank, int src_thrd);
+
+int insert_ack_meta(rank_ack_task_t *rank_ack_task,
+                    ack_meta_t *ptr_ack, size_t pos,
+                    int rank_id, int thrd_id, int src_cli_rank);
+
+int ins_to_ack_lst(rank_ack_task_t *rank_ack_task,
+                   char *mem_addr, service_msgs_t *service_msgs,
+                   size_t index, size_t src_offset, size_t len);
+
+int batch_ins_to_ack_lst(rank_ack_task_t *rank_ack_task,
+                         read_task_t *read_task,
+                         service_msgs_t *service_msgs,
+                         char *mem_addr,
+                         size_t start_offset, size_t end_offset);
+
+// debug print methods
+void print_ack_meta(rank_ack_task_t *rank_ack_tasks);
 void print_pended_reads(arraylist_t *pended_reads);
 void print_pended_sends(arraylist_t *pended_sends);
-void print_ack_meta(rank_ack_task_t *rank_ack_tasks);
-int compare_ack_stat(const void *a, const void *b);
+void print_service_msgs(service_msgs_t *service_msgs);
+void print_task_set(task_set_t *read_task_set,
+                    service_msgs_t *service_msgs);
+
 #endif

--- a/server/src/unifycr_sock.h
+++ b/server/src/unifycr_sock.h
@@ -33,7 +33,9 @@
 #include <poll.h>
 #include "unifycr_const.h"
 
-int sock_init_server(void);
+extern char server_sock_path[UNIFYCR_MAX_FILENAME];
+
+int sock_init_server(int del_id);
 int sock_add(int fd);
 void sock_reset();
 int sock_wait_cli_cmd();


### PR DESCRIPTION
### Description
This commit includes a wide range of fixes and code cleanup.
Highlights follow:
- fix incorrect EOF calculation caused by local metadata
  having incorrect total file size
- replace int/long with size_t where appropriate
- fix qsort comparison functions to work for unsigned types
- make sure clients and server use same data structs
  for shared memory exchanges
- make sure reqmgr and svcmgr use same data structs
  for MPI exchanges
- zero static buffers before reuse
- improve UNIFYCR key access macros in MDHIM code
- updated constants to reflect reasonable buffer sizes
- add PMIx configuration option for build even if available
- more comments to improve code understanding

### How Has This Been Tested?
This commit returns sysio-writeread example to working on Summitdev.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
