### PR TITLE
Rework init / finalize flow in client

### DIFF
--- a/client/src/gotcha_map_unifycr_list.h
+++ b/client/src/gotcha_map_unifycr_list.h
@@ -41,6 +41,7 @@ UNIFYCR_DEF(flock, int, (int fd, int operation));
 UNIFYCR_DEF(mmap, void*, (void* addr, size_t length, int prot, int flags,
                           int fd, off_t offset));
 UNIFYCR_DEF(msync, int, (void* addr, size_t length, int flags));
+UNIFYCR_DEF(munmap, int, (void* addr, size_t length));
 UNIFYCR_DEF(mmap64, void*, (void* addr, size_t length, int prot, int flags,
                             int fd, off_t offset));
 UNIFYCR_DEF(__fxstat, int, (int vers, int fd, struct stat* buf));
@@ -137,6 +138,7 @@ struct gotcha_binding_t wrap_unifycr_list[] = {
     { "flock", UNIFYCR_WRAP(flock), &UNIFYCR_REAL(flock) },
     { "mmap", UNIFYCR_WRAP(mmap), &UNIFYCR_REAL(mmap) },
     { "msync", UNIFYCR_WRAP(msync), &UNIFYCR_REAL(msync) },
+    { "munmap", UNIFYCR_WRAP(munmap), &UNIFYCR_REAL(munmap) },
     { "mmap64", UNIFYCR_WRAP(mmap64), &UNIFYCR_REAL(mmap64) },
     { "__fxstat", UNIFYCR_WRAP(__fxstat), &UNIFYCR_REAL(__fxstat) },
     { "close", UNIFYCR_WRAP(close), &UNIFYCR_REAL(close) },

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -104,6 +104,7 @@ static inline off_t unifycr_compute_spill_offset(
 
     /* identify physical chunk id */
     int physical_id = chunk_meta->id;
+
     /* compute start of chunk in spill over device */
     off_t start = 0;
     if (physical_id < unifycr_max_chunks) {
@@ -115,6 +116,7 @@ static inline off_t unifycr_compute_spill_offset(
          * grabbing this chunk */
         start = ((long)(physical_id - unifycr_max_chunks) << unifycr_chunk_bits);
     }
+
     off_t buf = start + logical_offset;
     return buf;
 }
@@ -124,6 +126,7 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t* meta, int chunk_id)
 {
     /* get pointer to chunk meta data */
     unifycr_chunkmeta_t* chunk_meta = &(meta->chunk_meta[chunk_id]);
+
     /* allocate a chunk and record its location */
     if (unifycr_use_memfs) {
         /* allocate a new chunk from memory */
@@ -138,8 +141,8 @@ static int unifycr_chunk_alloc(int fid, unifycr_filemeta_t* meta, int chunk_id)
             chunk_meta->id = id;
         } else if (unifycr_use_spillover) {
             /* shm segment out of space, grab a block from spill-over device */
-
             DEBUG("getting blocks from spill-over device\n");
+
             /* TODO: missing lock calls? */
             /* add unifycr_max_chunks to identify chunk location */
             unifycr_stack_lock();
@@ -512,7 +515,6 @@ int unifycr_fid_store_fixed_extend(int fid, unifycr_filemeta_t* meta,
 {
     /* determine whether we need to allocate more chunks */
     off_t maxsize = meta->chunks << unifycr_chunk_bits;
-//      printf("rank %d,meta->chunks is %d, length is %ld, maxsize is %ld\n", dbgrank, meta->chunks, length, maxsize);
     if (length > maxsize) {
         /* compute number of additional bytes we need */
         off_t additional = length - maxsize;
@@ -521,6 +523,7 @@ int unifycr_fid_store_fixed_extend(int fid, unifycr_filemeta_t* meta,
             if (meta->chunks == unifycr_max_chunks + unifycr_spillover_max_chunks) {
                 return UNIFYCR_ERROR_NOSPC;
             }
+
             /* allocate a new chunk */
             int rc = unifycr_chunk_alloc(fid, meta, meta->chunks);
             if (rc != UNIFYCR_SUCCESS) {

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -332,9 +332,7 @@ read_req_set_t read_req_set;
 read_req_set_t tmp_read_req_set;
 index_set_t tmp_index_set;
 
-extern int dbgrank;
 extern unifycr_index_buf_t unifycr_indices;
-extern void* unifycr_superblock;
 extern unsigned long unifycr_max_index_entries;
 extern long unifycr_spillover_max_chunks;
 
@@ -344,18 +342,13 @@ extern int local_rank_idx;
 extern int local_del_cnt;
 extern int client_sockfd;
 extern struct pollfd cmd_fd;
-extern long shm_req_size;
-extern long shm_recv_size;
-extern char* shm_recvbuf;
-extern char* shm_reqbuf;
+extern void* shm_req_buf;
+extern void* shm_recv_buf;
 extern char cmd_buf[CMD_BUF_SIZE];
-extern char ack_msg[3];
 extern unifycr_fattr_buf_t unifycr_fattrs;
 
-extern int glb_superblock_size;
 extern int dbg_rank;
 extern int app_id;
-extern int glb_size;
 extern long unifycr_key_slice_range;
 
 /* -------------------------------

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -92,7 +92,7 @@ int local_rank_cnt;
 int local_rank_idx;
 
 int local_del_cnt = 1;
-int client_sockfd;
+int client_sockfd = -1;
 struct pollfd cmd_fd;
 
 /* shared memory buffer to transfer read requests
@@ -2833,7 +2833,15 @@ int unifycr_unmount(void)
     unifycr_shm_free(shm_req_name,  shm_req_size,  &shm_req_buf);
     unifycr_shm_free(shm_recv_name, shm_recv_size, &shm_recv_buf);
 
-    /* TODO: close socket */
+    /* close socket to server */
+    if (client_sockfd >= 0) {
+        errno = 0;
+        int close_rc = close(client_sockfd);
+        if (close_rc != 0) {
+            LOGERR("Failed to close socket to server rc=%d (%s)",
+                errno, strerror(errno));
+        }
+    }
 
     /* invoke unmount rpc to tell server we're disconnecting */
     printf("calling unmount\n");

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2910,19 +2910,3 @@ int unifycr_unmount(void)
 
     return ret;
 }
-
-/*
- * get information about the chunk data region for external async libraries
- * to register during their init
- */
-size_t unifycr_get_data_region(void** ptr)
-{
-    *ptr = unifycr_chunks;
-    return unifycr_chunk_mem;
-}
-
-/* get a list of chunks for a given file (useful for RDMA, etc.) */
-chunk_list_t* unifycr_get_chunk_list(char* path)
-{
-    return NULL;
-}

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2605,6 +2605,9 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
     bool b;
     char* cfgval;
 
+    /* print log messages to stderr */
+    unifycr_log_open(NULL);
+
     /* record our rank for debugging messages,
      * record the value we should use for an app_id */
     dbg_rank = rank;
@@ -2863,6 +2866,9 @@ int unifycr_unmount(void)
     if (tmp_rc) {
         ret = UNIFYCR_FAILURE;
     }
+
+    /* shut down our logging */
+    unifycr_log_close();
 
     return ret;
 }

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -82,9 +82,6 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
 int unifycr_unmount(void);
 int compare_fattr(const void* a, const void* b);
 
-/* mount memfs at some prefix location */
-int unifycrfs_mount(const char prefix[], size_t size, int rank);
-
 /* get information about the chunk data region
  * for external async libraries to register during their init */
 size_t unifycr_get_data_region(void** ptr);

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -82,15 +82,4 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
 int unifycr_unmount(void);
 int compare_fattr(const void* a, const void* b);
 
-/* get information about the chunk data region
- * for external async libraries to register during their init */
-size_t unifycr_get_data_region(void** ptr);
-
-/* get a list of chunks for a given file (useful for RDMA, etc.) */
-chunk_list_t* unifycr_get_chunk_list(char* path);
-
-/* debug function to print list of chunks constituting a file
- * and to test above function*/
-void unifycr_print_chunk_list(char* path);
-
 #endif /* UNIFYCR_H */

--- a/common/src/unifycr_log.h
+++ b/common/src/unifycr_log.h
@@ -59,6 +59,7 @@ extern char unifycr_log_timestamp[256];
 #else
 #error gettid syscal is not defined
 #endif
+
 #define LOG(level, ...) \
     if (level <= unifycr_log_level) { \
         unifycr_log_time = time(NULL); \

--- a/common/src/unifycr_shm.c
+++ b/common/src/unifycr_shm.c
@@ -107,7 +107,7 @@ int unifycr_shm_free(const char* name, size_t size, void** paddr)
     void* addr = *paddr;
 
     /* if we have a pointer, try to munmap and unlink it */
-    if (addr == NULL) {
+    if (addr != NULL) {
         /* unmap shared memory from memory space */
         errno = 0;
         int rc = munmap(addr, size);

--- a/common/src/unifycr_shm.c
+++ b/common/src/unifycr_shm.c
@@ -115,7 +115,8 @@ int unifycr_shm_free(const char* name, size_t size, void** paddr)
             /* failed to open shared memory */
             LOGERR("Failed to unmap shared memory %s errno=%d (%s)",
                    name, errno, strerror(errno));
-            return UNIFYCR_FAILURE;
+
+            /* not fatal, so keep going */
         }
 
         /* release our reference to the shared memory region */
@@ -125,7 +126,8 @@ int unifycr_shm_free(const char* name, size_t size, void** paddr)
             /* failed to open shared memory */
             LOGERR("Failed to unlink shared memory %s errno=%d (%s)",
                    name, errno, strerror(errno));
-            return UNIFYCR_FAILURE;
+
+            /* not fatal, so keep going */
         }
     }
 


### PR DESCRIPTION
Simplify init/finalize code.
 - merge unifycrfs_mount into unifycr_mount
 - drop unused functions to expose data region and chunks to external tools (left over from CRUISE)
 - ensure code works when unifycr_use_memfs is disabled
 - detach (unmap and unlink) from shared memory segments
 - close socket to server
 - fix mmap/msync/munmap to call real functions until wrappers fully supported
 - style edits

Depends on Finalize PR being merged first.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.