### PR TITLE
Fix srand seed issue

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -7,6 +7,8 @@ TESTS = \
 	0001-setup.t \
 	0100-sysio-gotcha.t \
 	0200-stdio-gotcha.t \
+	0500-sysio-static.t \
+	0600-stdio-static.t \
 	9005-unifycr-unmount.t \
 	9010-stop-unifycrd.t \
 	9020-mountpoint-empty.t
@@ -15,6 +17,8 @@ check_SCRIPTS = \
 	0001-setup.t \
 	0100-sysio-gotcha.t \
 	0200-stdio-gotcha.t \
+	0500-sysio-static.t \
+	0600-stdio-static.t \
 	9005-unifycr-unmount.t \
 	9010-stop-unifycrd.t \
 	9020-mountpoint-empty.t
@@ -33,6 +37,8 @@ clean-local:
 libexec_PROGRAMS = \
 	sys/sysio-gotcha.t \
 	std/stdio-gotcha.t \
+	sys/sysio-static.t \
+	std/stdio-static.t \
 	unifycr_unmount.t
 
 test_ldadd = \
@@ -70,16 +76,16 @@ sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_ldadd)
 sys_sysio_gotcha_t_LDFLAGS = $(AM_LDFLAGS)
 
-#sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
-#                             sys/sysio_suite.c \
-#                             sys/creat-close.c \
-#                             sys/creat64.c \
-#                             sys/mkdir-rmdir.c \
-#                             sys/open.c \
-#                             sys/open64.c
-#sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
-#sys_sysio_static_t_LDADD = $(test_static_ldadd)
-#sys_sysio_static_t_LDFLAGS = $(test_static_ldflags)
+sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
+                             sys/sysio_suite.c \
+                             sys/creat-close.c \
+                             sys/creat64.c \
+                             sys/mkdir-rmdir.c \
+                             sys/open.c \
+                             sys/open64.c
+sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
+sys_sysio_static_t_LDADD = $(test_static_ldadd)
+sys_sysio_static_t_LDFLAGS = $(test_static_ldflags)
 
 std_stdio_gotcha_t_SOURCES = std/stdio_suite.h \
                              std/stdio_suite.c \
@@ -88,12 +94,12 @@ std_stdio_gotcha_t_CPPFLAGS = $(test_cppflags)
 std_stdio_gotcha_t_LDADD = $(test_ldadd)
 std_stdio_gotcha_t_LDFLAGS = $(AM_LDFLAGS)
 
-#std_stdio_static_t_SOURCES = std/stdio_suite.h \
-#                             std/stdio_suite.c \
-#                             std/fopen-fclose.c
-#std_stdio_static_t_CPPFLAGS = $(test_cppflags)
-#std_stdio_static_t_LDADD = $(test_static_ldadd)
-#std_stdio_static_t_LDFLAGS = $(test_static_ldflags)
+std_stdio_static_t_SOURCES = std/stdio_suite.h \
+                             std/stdio_suite.c \
+                             std/fopen-fclose.c
+std_stdio_static_t_CPPFLAGS = $(test_cppflags)
+std_stdio_static_t_LDADD = $(test_static_ldadd)
+std_stdio_static_t_LDFLAGS = $(test_static_ldflags)
 
 unifycr_unmount_t_SOURCES = unifycr_unmount.c
 unifycr_unmount_t_CPPFLAGS = $(test_cppflags)

--- a/t/lib/testutil.c
+++ b/t/lib/testutil.c
@@ -14,20 +14,31 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
+#include <sys/time.h>
 #include "testutil.h"
 
-static int seed;
+static unsigned long seed;
 
 /*
  * Seed the pseudo random number generator if it hasn't already been
  * seeded. Call this before calling rand() if you want a unique
  * pseudo random sequence.
+ *
+ * Test suites currently each run off their own main function so that they can
+ * be run individually if need be. If they run too fast, seeding srand() with
+ * time(NULL) can happen more than once in a second, causing the pseudo random
+ * sequence to repeat which causes each suite to create the same random files.
+ * Using gettimeofday() allows us to increase the granularty to microseconds.
  */
 static void test_util_srand(void)
 {
     if (seed == 0) {
-        seed = time(NULL);
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
+
+        /* Convert seconds since Epoch to microseconds and add the microseconds
+         * in order to prevent the seed from rolling over and repeating. */
+        seed = (tv.tv_sec * 1000000) + tv.tv_usec;
         srand(seed);
     }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Each test suite currently runs off its own main function so that they can be run individually if need be. If they run too fast, seeding srand() with time(NULL) can happen more than once in a second, causing the pseudo random sequence to repeat which causes each test suite to create the same random files. 

This PR
* Increases the granularity of the seed to microseconds since Epoch by using gettimeofday().
* Re-enables the static tests that discovered the issue and were disabled in #247.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Cloned the broken m2 branch when this issue showed up and pushed it to my fork. Then had Travis CI build my forked branch to replicate the problem. Tested locally and on the forked branch before creating this PR.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.