### PR TITLE
add rpc handler to compute file size

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -483,6 +483,9 @@ int unifycr_fid_is_dir_empty(const char* path);
 /* return current size of given file id */
 off_t unifycr_fid_size(int fid);
 
+/* fill in limited amount of stat information for global file id */
+int unifycr_gfid_stat(int gfid, struct stat* buf);
+
 /* fill in limited amount of stat information */
 int unifycr_fid_stat(int fid, struct stat* buf);
 

--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -57,8 +57,10 @@ UNIFYCR_DECL(remove, int, (const char* path));
 UNIFYCR_DECL(rename, int, (const char* oldpath, const char* newpath));
 UNIFYCR_DECL(truncate, int, (const char* path, off_t length));
 UNIFYCR_DECL(stat, int, (const char* path, struct stat* buf));
-UNIFYCR_DECL(__lxstat, int, (int vers, const char* path, struct stat* buf));
+//UNIFYCR_DECL(fstat, int, (int fd, struct stat* buf));
 UNIFYCR_DECL(__xstat, int, (int vers, const char* path, struct stat* buf));
+UNIFYCR_DECL(__lxstat, int, (int vers, const char* path, struct stat* buf));
+UNIFYCR_DECL(__fxstat, int, (int vers, int fd, struct stat* buf));
 
 /* ---------------------------------------
  * POSIX wrappers: file descriptors

--- a/client/src/unifycr_client.h
+++ b/client/src/unifycr_client.h
@@ -18,6 +18,7 @@ typedef struct ClientRpcContext {
     hg_context_t* hg_context;
     hg_class_t* hg_class;
     hg_addr_t svr_addr;
+    hg_id_t unifycr_filesize_rpc_id;
     hg_id_t unifycr_read_rpc_id;
     hg_id_t unifycr_mount_rpc_id;
     hg_id_t unifycr_unmount_rpc_id;
@@ -45,17 +46,23 @@ int32_t unifycr_client_metaset_rpc_invoke(unifycr_client_rpc_context_t**
                                           unifycr_rpc_context,
                                           unifycr_file_attr_t* f_meta);
 
-int32_t unifycr_client_metaget_rpc_invoke(unifycr_client_rpc_context_t**
-                                          unifycr_rpc_context,
-                                          unifycr_file_attr_t* f_meta,
-                                          int32_t fid,
-                                          int32_t gfid);
+int32_t unifycr_client_metaget_rpc_invoke(
+    unifycr_client_rpc_context_t** unifycr_rpc_context,
+    int32_t gfid,
+    unifycr_file_attr_t* f_meta);
 
 int32_t unifycr_client_fsync_rpc_invoke(unifycr_client_rpc_context_t**
                                         unifycr_rpc_context,
                                         int32_t app_id,
                                         int32_t local_rank_idx,
                                         int32_t gfid);
+
+uint32_t unifycr_client_filesize_rpc_invoke(unifycr_client_rpc_context_t**
+                                            unifycr_rpc_context,
+                                            int32_t app_id,
+                                            int32_t local_rank_idx,
+                                            int32_t gfid,
+                                            hg_size_t* filesize);
 
 int32_t unifycr_client_read_rpc_invoke(unifycr_client_rpc_context_t**
                                        unifycr_rpc_context,

--- a/client/src/unifycr_clientcalls_rpc.h
+++ b/client/src/unifycr_clientcalls_rpc.h
@@ -79,6 +79,17 @@ MERCURY_GEN_PROC(unifycr_fsync_in_t,
                  ((int32_t)(gfid)))
 DECLARE_MARGO_RPC_HANDLER(unifycr_fsync_rpc)
 
+/* given an app_id, client_id, global file id,
+ * return filesize for given file */
+MERCURY_GEN_PROC(unifycr_filesize_out_t,
+                 ((int32_t)(ret))
+                 ((hg_size_t)(filesize)))
+MERCURY_GEN_PROC(unifycr_filesize_in_t,
+                 ((int32_t)(app_id))
+                 ((int32_t)(local_rank_idx))
+                 ((int32_t)(gfid)))
+DECLARE_MARGO_RPC_HANDLER(unifycr_filesize_rpc)
+
 /* given an app_id, client_id, global file id, an offset, and a length,
  * initiate read operation to lookup and return data,
  * client synchronizes with server again later when data is available

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -345,6 +345,19 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
+    if (rank == 0) {
+        errno = 0;
+        struct stat sbuf;
+        int stat_rc = stat(targetfile, &sbuf);
+        if (stat_rc == 0) {
+            test_print(rank, "stat(%s) says filesize = %llu",
+                targetfile, (unsigned long long)sbuf.st_size);
+        } else {
+            test_print(rank, "stat(%s) failed: errno=%d (%s)",
+                targetfile, errno, strerror(errno));
+        }
+    }
+
     if (!standard && unmount) {
         unifycr_unmount();
     }

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -189,6 +189,10 @@ static margo_instance_id setup_sm_target()
                    unifycr_fsync_in_t, unifycr_fsync_out_t,
                    unifycr_fsync_rpc);
 
+    MARGO_REGISTER(mid, "unifycr_filesize_rpc",
+                   unifycr_filesize_in_t, unifycr_filesize_out_t,
+                   unifycr_filesize_rpc);
+
     MARGO_REGISTER(mid, "unifycr_read_rpc",
                    unifycr_read_in_t, unifycr_read_out_t,
                    unifycr_read_rpc);

--- a/server/src/unifycr_request_manager.h
+++ b/server/src/unifycr_request_manager.h
@@ -44,6 +44,8 @@ int rm_cmd_mread(int app_id, int client_id, int gfid,
 int rm_cmd_read(int app_id, int client_id, int gfid,
                 size_t offset, size_t length);
 
+int rm_cmd_filesize(int app_id, int client_id, int gfid, size_t* outsize);
+
 /* function called by main thread to instruct
  * resource manager thread to exit,
  * returns UNIFYCR_SUCCESS on success */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds an rpc handler in the server to compute file size.  It accomplishes this by querying for all key/value pairs for a file using a starting offset of 0 and ending offset of "max file size" which is the max value of a signed long.  It then iterates over each returned key/value pair to find the maximum offset.  This is clearly inefficient, especially for files that have lots of key/value pairs.  However, it should return a correct answer until we get something better.

I don't fully understand the limits of bulk get in MDHIM, so this could be problematic, for example, if there a file has more key/value pairs than can be returned in a single bulk get call. 

Second, it provides a unifycr_gfid_stat() call that returns a stat structure given a global file id.  Up until now, we only had a unifycr_fid_stat() that requires a local file id, but that means a process that does not have a reference to a particular file in its local data structure could not query for the file's stat info.  This also rewrites the stat wrappers to call this new function that uses just the global file id.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
