### PR TITLE
fix domain socket naming

### DIFF
--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -230,8 +230,4 @@ extern int *local_rank_lst;
 extern int local_rank_cnt;
 extern size_t max_recs_per_slice;
 
-#if defined(UNIFYCR_MULTIPLE_DELEGATORS)
-extern int local_rank_idx;
-#endif
-
 #endif

--- a/server/src/unifycr_sock.c
+++ b/server/src/unifycr_sock.c
@@ -65,13 +65,13 @@ int cur_sock_id = 1;
 * initialize the listening socket on this delegator
 * @return success/error code
 */
-int sock_init_server(void)
+int sock_init_server(int srvr_id)
 {
     int rc;
     char sock_path[UNIFYCR_MAX_FILENAME];
 
-    snprintf(sock_path, sizeof(sock_path), "%s.%d",
-             SOCKET_PATH, getuid());
+    snprintf(sock_path, sizeof(sock_path), "%s.%d.%d",
+             SOCKET_PATH, getuid(), srvr_id);
 
     server_sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
 

--- a/server/src/unifycr_sock.h
+++ b/server/src/unifycr_sock.h
@@ -37,7 +37,7 @@ extern int server_sockfd;
 extern int client_sockfd;
 extern struct pollfd poll_set[MAX_NUM_CLIENTS];
 
-int sock_init_server(void);
+int sock_init_server(int srvr_id);
 int sock_add(int fd);
 void sock_reset();
 int sock_wait_cli_cmd();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

m2 was missing half of the domain socket getuid() fix, resolved


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
