### PR TITLE
Add test dependencies for parallel build and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: c
 sudo: required
 
+env:
+  global:
+    - MAKEFLAGS="-j"
+
 before_install:
   # The default environment variable $CC is known to interfere with
   # MPI projects.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -126,6 +126,11 @@ sysio_suite in `t/Makefile.am`_ and `t/sys/sysio_suite.c`_:
     - Add this file to `t/Makefile.am`_ in the ``TESTS`` and ``check_SCRIPTS``
       variables and add the name of the file (but with a .t extension) this
       script runs to the ``libexec_PROGRAMS`` variable
+    - If your suite depends on another suite finishing first (i.e., if
+      *0001-setup.t* needs to complete first) then add the dependencies for
+      your *<####-suite-name>.log* file followed by any *.log* file(s) it
+      depends on. These are added to `t/Makefile.am`_ after the ``TESTS``
+      variable. This allows for the test to be run in parallel if need be
 
     You can then create the test suite file and any tests to be run in this
     suite.

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -13,6 +13,17 @@ TESTS = \
 	9010-stop-unifycrd.t \
 	9020-mountpoint-empty.t
 
+0100-sysio-gotcha.log: 0001-setup.log
+0200-stdio-gotcha.log: 0001-setup.log
+0500-sysio-static.log: 0001-setup.log
+0600-stdio-static.log: 0001-setup.log
+9005-unifycr-unmount.log: 0100-sysio-gotcha.log \
+	0200-stdio-gotcha.log \
+	0500-sysio-static.log \
+	0600-stdio-static.log
+9010-stop-unifycrd.log: 9005-unifycr-unmount.log
+9020-mountpoint-empty.log: 9010-stop-unifycrd.log
+
 check_SCRIPTS = \
 	0001-setup.t \
 	0100-sysio-gotcha.t \


### PR DESCRIPTION
### Description
Currently our test suite has to be run in serial as some tests depend on others finishing first, like setup and teardown. This adds the dependencies for each test suite so that certain tests still run first or last, but the suites in the middle can be run in parallel.

### Motivation and Context
This will make a bigger difference as our test suite grows as it will speed up the build by allowing tests to be run in parallel. Also, Spack defaults to building in parallel in order to speed up installation of large packages. Currently we have this disable since our Spack build breaks when doing `spack install --test={root, all} unifycr`. This will allow users to install UnifyCR faster with Spack.

### How Has This Been Tested?
Built and ran test manually and built on forked repo's Travis CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
