### PR TITLE
Fix checkpatch braces on conditional directives

### DIFF
--- a/scripts/linux_kernel_checkpatch/checkpatch.pl
+++ b/scripts/linux_kernel_checkpatch/checkpatch.pl
@@ -5210,6 +5210,13 @@ sub process {
 				# with additional single statement blocks inside of them.
 				$allowed = 0;
 			}
+
+			# Allow any conditional directives
+			if ($line =~ /^(.*#)/) {
+				#print "APW: ALLOWED: pre<$1>\n";
+				$allowed = 1;
+			}
+
 			# Check the post-context.
 			if (defined $chunks[1]) {
 				my ($cond, $block) = @{$chunks[1]};


### PR DESCRIPTION
### Description
Checkpatch is currently requiring braces around preprocessor conditional directives such as `#if 0` or `#if defined`. This adds an exception for those cases.

#261 and #264 should pass with this change.

### How Has This Been Tested?
Tested with multiple cases in local file. Hopefully got them all.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
