### PR TITLE
properly register and use mread rpc

### DIFF
--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -1813,23 +1813,25 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
         //unifycr_ReadRequest_end_as_root(&builder);
 
         /* allocate our buffer to be sent */
-        size_t size;
+        size_t size = 0;
         void* buffer = flatcc_builder_finalize_buffer(&builder, &size);
         assert(buffer);
-
-        flatcc_builder_clear(&builder);
+        LOGDBG("mread: n_reqs:%zu, flatcc buffer (%p) sz:%zu",
+               read_req_set.count, buffer, size);
 
         /* invoke read rpc here */
         unifycr_client_mread_rpc_invoke(&unifycr_rpc_context, app_id,
                                         local_rank_idx, ptr_meta_entry->gfid,
                                         read_req_set.count, size, buffer);
 
+        flatcc_builder_clear(&builder);
         free(buffer);
     } else {
         /* got a single read request */
         int gfid = ptr_meta_entry->gfid;
         size_t offset = read_req_set.read_reqs[0].offset;
         size_t length = read_req_set.read_reqs[0].length;
+        LOGDBG("read: offset:%zu, len:%zu", offset, length);
         unifycr_client_read_rpc_invoke(&unifycr_rpc_context, app_id,
                                        local_rank_idx, gfid, offset, length);
     }

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2207,6 +2207,12 @@ static int unifycr_client_rpc_init(
                        unifycr_read_out_t,
                        NULL);
 
+    (*unifycr_rpc_context)->unifycr_mread_rpc_id =
+        MARGO_REGISTER((*unifycr_rpc_context)->mid, "unifycr_mread_rpc",
+                       unifycr_mread_in_t,
+                       unifycr_mread_out_t,
+                       NULL);
+
     (*unifycr_rpc_context)->unifycr_mount_rpc_id   =
         MARGO_REGISTER((*unifycr_rpc_context)->mid, "unifycr_mount_rpc",
                        unifycr_mount_in_t,
@@ -2236,12 +2242,6 @@ static int unifycr_client_rpc_init(
         MARGO_REGISTER((*unifycr_rpc_context)->mid, "unifycr_filesize_rpc",
                        unifycr_filesize_in_t,
                        unifycr_filesize_out_t,
-                       NULL);
-
-    (*unifycr_rpc_context)->unifycr_read_rpc_id =
-        MARGO_REGISTER((*unifycr_rpc_context)->mid, "unifycr_read_rpc",
-                       unifycr_read_in_t,
-                       unifycr_read_out_t,
                        NULL);
 
     /* resolve server address */

--- a/client/src/unifycr_client.c
+++ b/client/src/unifycr_client.c
@@ -340,7 +340,7 @@ int32_t unifycr_client_mread_rpc_invoke(unifycr_client_rpc_context_t**
     /* fill in input struct */
     hret = margo_create((*unifycr_rpc_context)->mid,
                         (*unifycr_rpc_context)->svr_addr,
-                        (*unifycr_rpc_context)->unifycr_read_rpc_id,
+                        (*unifycr_rpc_context)->unifycr_mread_rpc_id,
                         &handle);
     assert(hret == HG_SUCCESS);
     hret = margo_bulk_create((*unifycr_rpc_context)->mid, 1, &buffer, &size,

--- a/client/src/unifycr_client.h
+++ b/client/src/unifycr_client.h
@@ -20,6 +20,7 @@ typedef struct ClientRpcContext {
     hg_addr_t svr_addr;
     hg_id_t unifycr_filesize_rpc_id;
     hg_id_t unifycr_read_rpc_id;
+    hg_id_t unifycr_mread_rpc_id;
     hg_id_t unifycr_mount_rpc_id;
     hg_id_t unifycr_unmount_rpc_id;
     hg_id_t unifycr_metaget_rpc_id;

--- a/server/src/unifycr_metadata.c
+++ b/server/src/unifycr_metadata.c
@@ -439,7 +439,7 @@ int meta_process_fsync(int app_id, int client_side_id, int gfid)
  * @param client_id: client-side process id
  * @param thrd_id: the thread created for processing
  *  its client's read requests.
- * @param dbg_rank: the client process's rank in its
+ * @param cli_rank: the client process's rank in its
  *  own application, used for debug purpose
  * @param gfid: global file id
  * @param offset: start offset for segment
@@ -449,7 +449,7 @@ int meta_process_fsync(int app_id, int client_side_id, int gfid)
  *  requested segments
  * @return success/error code
  */
-int meta_read_get(int app_id, int client_id, int thrd_id, int dbg_rank,
+int meta_read_get(int app_id, int client_id, int thrd_id, int cli_rank,
                   int gfid, size_t offset, size_t length,
                   msg_meta_t* del_req_set)
 {
@@ -520,7 +520,7 @@ int meta_read_get(int app_id, int client_id, int thrd_id, int dbg_rank,
             /* src_offset is the logical offset of the shared file */
             msg->src_offset = (size_t) key->offset;
 
-            msg->src_dbg_rank = dbg_rank;
+            msg->src_dbg_rank = cli_rank;
             msg->src_delegator_rank = glb_rank;
             msg->src_fid = (int) key->fid;
             msg->src_thrd = thrd_id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The implementation of multiple read requests (e.g., lio_listio) was accidentally
using the read rpc, rather than the mread rpc, even though the correct rpc
input structure was being used. This commit fixes the sysio_writeread failure for
lio_listio that I was seeing on Summitdev.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
