### PR TITLE
Verify correct file size in sysio-write example

### DIFF
--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -190,7 +190,7 @@ static void report_result(void)
                     "I/O request size:        %llu B\n"
                     "Aggregate I/O bandwidth: %lf MB/s\n"
                     "Min. I/O bandwidth:      %lf MB/s\n"
-                    "Total I/O time:          %lf sec.\n\n",
+                    "Total I/O time:          %lf sec.\n",
                     total_ranks,
                     type ? "read" : "write",
                     1.0 * blocksize * nblocks / (1 << 20),
@@ -316,25 +316,25 @@ int main(int argc, char* argv[])
     }
 
     if (type == -1) {
-        test_print_once(rank, "type should be 'write' or 'read'\n");
+        test_print_once(rank, "type should be 'write' or 'read'");
         exit(-1);
     }
 
     if (blocksize < chunksize || blocksize % chunksize > 0) {
         test_print_once(rank, "blocksize should be larger than "
-                        "and divisible by chunksize.\n");
+                        "and divisible by chunksize.");
         exit(-1);
     }
 
     if (chunksize % (1 << 10) > 0) {
         test_print_once(rank, "chunksize and blocksize should be divisible "
-                        "by 1024.\n");
+                        "by 1024.");
         exit(-1);
     }
 
     if (static_linked(program) && standard) {
         test_print_once(rank, "--standard, -s option only works when "
-                        "dynamically linked.\n");
+                        "dynamically linked.");
         exit(-1);
     }
 

--- a/examples/src/sysio-cp.c
+++ b/examples/src/sysio-cp.c
@@ -259,20 +259,20 @@ int main(int argc, char** argv)
 
     ret = stat(srcpath, &sb);
     if (ret < 0) {
-        test_print(rank, "stat failed on \"%s\"\n", srcpath);
+        test_print(rank, "stat failed on \"%s\"", srcpath);
         goto out;
     }
 
     ret = resolve_dstpath(argv[optind]);
     if (ret) {
-        test_print(rank, "cannot resolve the destination path \"%s\" (%s)\n",
+        test_print(rank, "cannot resolve the destination path \"%s\" (%s)",
                    dstpath, strerror(ret));
         goto out;
     }
 
     ret = do_copy();
     if (ret) {
-        test_print(rank, "copy failed (%d: %s)\n", ret, strerror(ret));
+        test_print(rank, "copy failed (%d: %s)", ret, strerror(ret));
     }
 
     free(dstpath);

--- a/examples/src/sysio-dir.c
+++ b/examples/src/sysio-dir.c
@@ -280,7 +280,7 @@ int main(int argc, char** argv)
 
     if (static_linked(program) && standard) {
         test_print_once(rank, "--standard, -s option only works when "
-                        "dynamically linked.\n");
+                        "dynamically linked.");
         exit(-1);
     }
 
@@ -301,7 +301,7 @@ int main(int argc, char** argv)
     MPI_Barrier(MPI_COMM_WORLD);
 
     if (singletest) {
-        test_print_once(rank, "only testing %s ..\n",
+        test_print_once(rank, "only testing %s ..",
                         singletest_names[singletest]);
         ret = test_funcs[singletest]();
         if (ret < 0) {

--- a/examples/src/sysio-read.c
+++ b/examples/src/sysio-read.c
@@ -95,7 +95,7 @@ static int do_read(void)
 
                 ret = lipsum_check(buf, chunksize, offset, &epos);
                 if (ret < 0) {
-                    test_print(rank, "lipsum check failed at offset %llu.\n",
+                    test_print(rank, "lipsum check failed at offset %llu.",
                                (unsigned long long) epos);
                     return -1;
                 }
@@ -154,7 +154,7 @@ static int do_listread(void)
             ret = lipsum_check((const char*) current->aio_buf, chunksize,
                                current->aio_offset, &epos);
             if (ret < 0) {
-                test_print(rank, "lipsum check failed at offset %llu.\n",
+                test_print(rank, "lipsum check failed at offset %llu.",
                            (unsigned long long) epos);
                 return -1;
             }
@@ -194,7 +194,7 @@ static void report_result(void)
                     "I/O request size:         %llu B\n"
                     "Aggregate read bandwidth: %lf MB/s\n"
                     "Min. read bandwidth:      %lf MB/s\n"
-                    "Total Read time:          %lf sec.\n\n",
+                    "Total Read time:          %lf sec.\n",
                     total_ranks,
                     1.0 * blocksize * nblocks / (1 << 20),
                     1.0 * total_ranks * blocksize * nblocks / (1 << 20),
@@ -331,31 +331,31 @@ int main(int argc, char** argv)
     }
 
     if (pattern < 0) {
-        test_print_once(rank, "pattern should be 'n1' or 'nn'\n");
+        test_print_once(rank, "pattern should be 'n1' or 'nn'");
         exit(-1);
     }
 
     if (blocksize < chunksize || blocksize % chunksize > 0) {
         test_print_once(rank, "blocksize should be larger than "
-                        "and divisible by chunksize.\n");
+                        "and divisible by chunksize.");
         exit(-1);
     }
 
     if (chunksize % (1 << 10) > 0) {
         test_print_once(rank, "chunksize and blocksize should be divisible "
-                        "by 1024.\n");
+                        "by 1024.");
         exit(-1);
     }
 
     if (static_linked(program) && standard) {
         test_print_once(rank, "--standard, -s option only works when "
-                        "dynamically linked.\n");
+                        "dynamically linked.");
         exit(-1);
     }
 
     if (use_listio && use_pread) {
         test_print_once(rank,
-                        "--listio and --pread should be set exclusively\n");
+                        "--listio and --pread should be set exclusively");
         exit(-1);
     }
 

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
 
     ret = stat(filename, &sb);
     if (ret < 0) {
-        test_print(rank, "stat failed on \"%s\"\n", filename);
+        test_print(rank, "stat failed on \"%s\"", filename);
     } else {
         dump_stat(rank, &sb);
     }

--- a/examples/src/testlib.h
+++ b/examples/src/testlib.h
@@ -43,7 +43,11 @@ void test_print(int rank, const char* fmt, ...)
 
     if (errno) {
         fprintf(stdout, " (errno=%d, %s)\n", errno, strerror(errno));
+    } else {
+        fprintf(stdout, "\n");
     }
+
+    fflush(stdout);
 }
 
 static inline
@@ -60,7 +64,11 @@ void test_print_once(int rank, const char* fmt, ...)
 
         if (errno) {
             fprintf(stdout, " (errno=%d, %s)\n", errno, strerror(errno));
+        } else {
+            fprintf(stdout, "\n");
         }
+
+        fflush(stdout);
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds a check to verify that the correct file size was created in the sysio-write example.  It should help catch bugs if the internal file size computation goes bad.

We can add similar tests to our travis suite after some write tests are available.

It also changes test_print() to always print a newline and call fflush, along with changing calls to this function to drop newlines.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
