### PR TITLE
initial LSF-CSM job integration scripts and readme

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -281,7 +281,6 @@ AC_SUBST(LDFLAGS)
 AC_SUBST(__CP_LOG_PATH)
 AC_SUBST(CP_WRAPPERS)
 AC_SUBST(DISABLE_LDPRELOAD)
-AC_OUTPUT(client/unifycr-config)
 
 AC_CONFIG_FILES([Makefile
                  common/Makefile
@@ -300,8 +299,14 @@ AC_CONFIG_FILES([Makefile
                  t/Makefile
                  t/lib/Makefile
                  util/Makefile
+                 util/scripts/Makefile
+                 util/scripts/lsfcsm/Makefile
                  util/unifycr/Makefile
                  util/unifycr/src/Makefile])
+
+AC_CONFIG_FILES([client/unifycr-config], [chmod +x client/unifycr-config])
+AC_CONFIG_FILES([util/scripts/lsfcsm/unifycr_lsfcsm_prolog], [chmod +x util/scripts/lsfcsm/unifycr_lsfcsm_prolog])
+AC_CONFIG_FILES([util/scripts/lsfcsm/unifycr_lsfcsm_epilog], [chmod +x util/scripts/lsfcsm/unifycr_lsfcsm_epilog])
 
 UNIFYCR_VERSION=${PACKAGE_VERSION}
 AC_SUBST(UNIFYCR_VERSION)

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = unifycr
+SUBDIRS = scripts unifycr

--- a/util/scripts/Makefile.am
+++ b/util/scripts/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = lsfcsm

--- a/util/scripts/lsfcsm/Makefile.am
+++ b/util/scripts/lsfcsm/Makefile.am
@@ -1,0 +1,3 @@
+sbin_SCRIPTS = unifycr_lsfcsm_prolog unifycr_lsfcsm_epilog
+
+CLEANFILES = $(sbin_SCRIPTS)

--- a/util/scripts/lsfcsm/README.md
+++ b/util/scripts/lsfcsm/README.md
@@ -1,0 +1,52 @@
+### Integration with IBM Platform LSF with Cluster System Manager (CSM)
+
+To enable job-level integration of UnifyCR, where the UnifyCR daemon
+is automatically launched on each node during job startup and
+terminate once the job completes, additions must be made
+to the CSM prologue and epilogue Python scripts. Typically,
+these CSM scripts are found somewhere within the `/opt/ibm/csm`
+directory and named `privileged_prolog` and `privileged_epilog`.
+Consult with your LSF system administrator for more precise location
+information, and to make the changes described below.
+
+We provide helper scripts that launch and terminate a UnifyCR daemon
+(i.e., `unifycrd`) on a node. The scripts are:
+* launch: `<INSTALL_PREFIX>/sbin/unifycr_lsfcsm_prolog`
+* terminate: `<INSTALL_PREFIX>/sbin/unifycr_lsfcsm_epilog`
+
+Integration of the helper scripts requires editing the CSM prologue and
+epilogue scripts to support a new "unifycr" job allocation flag.
+Users may specify the allocation flag as an option to the `bsub`
+command:
+```shell
+[prompt]$ bsub -alloc_flags unifycr <other options> jobscript.lsf
+```
+Alternatively, the job script may contain the flag as a `#BSUB`
+directive:
+```shell
+#! /bin/bash -l
+#BSUB -alloc_flags UNIFYCR
+```
+
+Supporting the new flag is as simple as adding a new `elif` block to
+the flag parsing loop, as shown below for an excerpt from
+`privileged_prolog`. Note that the CSM scripts use uppercase strings
+for flag comparison.
+
+```python
+flags = args.user_flags.split(" ")
+regex = re.compile ("(\D+)(\d*)$")
+for feature in flags:
+    fparse = regex.match (feature.upper())
+    if hasattr(fparse, 'group'):
+        if fparse.group(0) == "HUGEPAGES":
+            os.chmod("/dev/hugepages", 1777)
+        elif fparse.group(0) == "UNIFYCR":
+            cmd = ['%s/unifycr_lsfcsm_prolog' % JOB_SCRIPT_DIR]
+            runcmd (cmd)
+```
+
+The provided helper scripts should be installed as root to the
+`JOB_SCRIPT_DIR` used by the CSM scripts (e.g., `/opt/ibm/csm/prologs`).
+
+

--- a/util/scripts/lsfcsm/unifycr_lsfcsm_epilog.in
+++ b/util/scripts/lsfcsm/unifycr_lsfcsm_epilog.in
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+bindir=@unifycr_bin_path@
+unifycrd=$bindir/unifycrd
+
+if [[ -x $(type -p pkill) ]]; then
+    pkill unifycrd
+elif [[ -x $(type -p pidof) ]]; then
+    pid=$(pidof -s $unifycrd)
+    [[ -n $pid ]] && kill $pid
+fi
+

--- a/util/scripts/lsfcsm/unifycr_lsfcsm_prolog.in
+++ b/util/scripts/lsfcsm/unifycr_lsfcsm_prolog.in
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+bindir=@unifycr_bin_path@
+unifycrd=$bindir/unifycrd
+
+if [[ -f /etc/rc.d/init.d/functions ]]; then
+    source /etc/rc.d/init.d/functions
+    daemon --user=$CSM_USER_NAME $unifycrd
+elif [[ -x $(type -p runuser) ]]; then
+    runuser -s /bin/bash $CSM_USER_NAME -c $unifycrd
+elif [[ -x $(type -p su) ]]; then
+    su -s /bin/bash $CSM_USER_NAME -c $unifycrd
+else
+    # WHAT KIND OF SYSTEM IS THIS?
+    echo "ERROR: $0 - unable to run unifycrd as user $CSM_USER_NAME"
+    exit 1
+fi
+


### PR DESCRIPTION
### Description
Initial support for job-level integration with LSF/CSM using "unifycr" allocation
flag. Created two helper scripts that launch/terminate `unifycrd` on the local node. 
These are for use in CSM `privileged_prolog` and `privileged_epilog`, which 
execute at job startup and completion, respectively. Also created a `README.md`
describing the necessary integration steps.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)
