### PR TITLE
Add infrastructure for invoking rpcs on the server

### DIFF
--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -20,6 +20,8 @@ BASE_SRCS = \
   unifycr_runstate.c \
   unifycr_meta.h \
   unifycr_pmix.h \
+  unifycr_util.h \
+  unifycr_util.c \
   unifycr_log.h \
   unifycr_log.c \
   unifycr_shm.h \

--- a/common/src/unifycr_util.c
+++ b/common/src/unifycr_util.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2017, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include "unifycr_log.h"
+#include "unifycr_util.h"
+
+/* publishes server RPC address */
+void addr_publish_server(const char* addr)
+{
+    /* TODO: support other publish modes like PMIX */
+
+    /* write server address to /dev/shm/ for client on node to
+     * read from */
+    FILE* fp = fopen("/dev/shm/svr_id", "w+");
+    if (fp != NULL) {
+        fprintf(fp, "%s", addr);
+        fclose(fp);
+    } else {
+        LOGERR("Error writing server rpc addr to file `/dev/shm/svr_id'");
+    }
+}
+
+/* publishes client RPC address to a place where server can find it */
+void addr_publish_client(const char* addr,
+                                    int local_rank_idx,
+                                    int app_id)
+{
+    /* TODO: support other publish modes like PMIX */
+
+    /* write client address to /dev/shm/ for server to read from */
+    char fname[36];
+    sprintf(fname, "/dev/shm/client-%d.%d", app_id, local_rank_idx);
+    FILE* fp = fopen(fname, "w+");
+    if (fp != NULL) {
+        fprintf(fp, "%s", addr);
+        fclose(fp);
+    } else {
+        LOGERR("Error writing client rpc addr to file");
+    }
+}
+
+/* returns server rpc address in newly allocated string
+ * to be freed by caller, returns NULL if not found */
+char* addr_lookup_server(void)
+{
+    /* returns NULL if we can't find server address */
+    char* str = NULL;
+
+    /* TODO: support other lookup methods here like PMIX */
+
+    /* read server address string from well-known file name in ramdisk */
+    FILE* fp = fopen("/dev/shm/svr_id", "r");
+    if (fp != NULL) {
+        /* opened the file, now read the address string */
+        char addr_string[50];
+        int rc = fscanf(fp, "%s", addr_string);
+        if (rc == 1) {
+            /* read the server address, dup a copy of it */
+            str = strdup(addr_string);
+        }
+        fclose(fp);
+    }
+
+    /* print server address (debugging) */
+    if (str != NULL) {
+        LOGDBG("rpc address: %s", str);
+    }
+
+    return str;
+}
+
+/* returns client rpc address in newly allocated string
+ * to be freed by caller, returns NULL if not found */
+char* addr_lookup_client(int app_id, int client_id)
+{
+    /* returns NULL if we can't find client  address */
+    char* str = NULL;
+
+    /* TODO: support other lookup methods here like PMIX */
+
+    /* read client address string from well-known file name in ramdisk */
+    char fname[36];
+    sprintf(fname, "/dev/shm/client-%d.%d", app_id, client_id);
+    FILE* fp = fopen(fname, "r");
+    if (fp != NULL) {
+        /* opened the file, now read the address string */
+        char addr_string[50];
+        int rc = fscanf(fp, "%s", addr_string);
+        if (rc == 1) {
+            /* read the client address, dup a copy of it */
+            str = strdup(addr_string);
+        }
+        fclose(fp);
+    }
+
+    /* print client address (debugging) */
+    if (str != NULL) {
+        LOGDBG("rpc address: %s", str);
+    }
+
+    return str;
+}

--- a/common/src/unifycr_util.h
+++ b/common/src/unifycr_util.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#ifndef UNIFYCR_UTIL_H
+#define UNIFYCR_UTIL_H
+
+/* publish the address of the server */
+void addr_publish_server(const char* addr);
+
+/* publish the address of the client */
+void addr_publish_client(const char* addr, int local_rank_idx, int app_id);
+
+/* lookup address of server */
+char* addr_lookup_server(void);
+
+/* lookup address of client */
+char* addr_lookup_client(int app_id, int client_id);
+
+#endif // UNIFYCR_UTIL_H
+

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -32,6 +32,7 @@
 
 #include <pthread.h>
 #include <stdlib.h>
+#include <margo.h>
 #include "unifycr_configurator.h"
 #include "arraylist.h"
 
@@ -200,6 +201,9 @@ typedef struct {
     char *shm_superblocks[MAX_NUM_CLIENTS]; /* superblock data */
     char *shm_req_bufs[MAX_NUM_CLIENTS];    /* read request shm */
     char *shm_recv_bufs[MAX_NUM_CLIENTS];   /* read reply shm */
+
+    /* client address for rpc invocation */
+    hg_addr_t* client_addr[MAX_NUM_CLIENTS];
 
     /* file names */
     char super_buf_name[MAX_NUM_CLIENTS][UNIFYCR_MAX_FILENAME];

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -52,6 +52,9 @@
 
 #include "unifycr_clientcalls_rpc.h"
 #include "unifycr_server.h"
+#include "../../server/src/unifycr_servercalls_rpc.h"
+#include "../../server/src/unifycr_server.h"
+#include "../../common/src/unifycr_util.h"
 
 int* local_rank_lst;
 int local_rank_cnt;
@@ -64,24 +67,9 @@ arraylist_t* thrd_list;
 int invert_sock_ids[MAX_NUM_CLIENTS]; /*records app_id for each sock_id*/
 
 unifycr_cfg_t server_cfg;
+ServerRpcContext_t* unifycr_server_rpc_context;
 
 static const int IO_POOL_SIZE = 2;
-
-/* publishes server RPC address to a place where clients can find it */
-static void addr_publish_server_rpc(const char* addr)
-{
-    /* TODO: support other publish modes like PMIX */
-
-    /* write server address to /dev/shm/ for client on node to
-     * read from */
-    FILE* fp = fopen("/dev/shm/svr_id", "w+");
-    if (fp != NULL) {
-        fprintf(fp, "%s", addr);
-        fclose(fp);
-    } else {
-        LOGERR("Error writing server rpc addr to file `/dev/shm/svr_id'");
-    }
-}
 
 /* find_address - Resolves a name string to an address structure.
  *
@@ -121,7 +109,7 @@ static int find_address(
     printf("addr string:%s\n", addr_string);
 
     /* publish rpc address of server for local clients */
-    addr_publish_server_rpc(addr_self_string);
+    addr_publish_server(addr_self_string);
 
     return 0;
 }
@@ -135,73 +123,74 @@ static margo_instance_id setup_sm_target()
 {
     /* initialize margo */
     hg_return_t hret;
-    margo_instance_id mid;
     hg_addr_t addr_self;
     char addr_self_string[128];
     hg_size_t addr_self_string_sz = 128;
-    mid = margo_init(SMSVR_ADDR_STR, MARGO_SERVER_MODE,
-                     1, 1);
-    assert(mid);
+
+    /* create rpc server context to store information needed to call rpcs */
+    unifycr_server_rpc_context = malloc(sizeof(ServerRpcContext_t));
+    assert(unifycr_server_rpc_context);
+
+    unifycr_server_rpc_context->mid = margo_init(SMSVR_ADDR_STR,
+                                                 MARGO_SERVER_MODE, 1, 1);
+    assert(unifycr_server_rpc_context->mid);
 
     /* figure out what address this server is listening on */
-    hret = margo_addr_self(mid, &addr_self);
+    hret = margo_addr_self(unifycr_server_rpc_context->mid, &addr_self);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_addr_self()");
-        margo_finalize(mid);
+        margo_finalize(unifycr_server_rpc_context->mid);
         return NULL;
     }
-    hret = margo_addr_to_string(mid, addr_self_string,
-                                &addr_self_string_sz, addr_self);
+    hret = margo_addr_to_string(unifycr_server_rpc_context->mid,
+                                addr_self_string, &addr_self_string_sz,
+                                addr_self);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_addr_to_string()");
-        margo_addr_free(mid, addr_self);
-        margo_finalize(mid);
+        margo_addr_free(unifycr_server_rpc_context->mid, addr_self);
+        margo_finalize(unifycr_server_rpc_context->mid);
         return NULL;
     }
-    margo_addr_free(mid, addr_self);
+    margo_addr_free(unifycr_server_rpc_context->mid, addr_self);
 
-    printf("# accepting RPCs on address \"%s\"\n", addr_self_string);
+    printf("# accepting RPCs on server address \"%s\"\n", addr_self_string);
 
     /* publish rpc address of server for local clients */
-    addr_publish_server_rpc(addr_self_string);
+    addr_publish_server(addr_self_string);
 
-    //margo_instance_id mid = margo_init_pool(*progress_pool, handler_pool,
-    //                                    hg_context);
-    //assert(mid);
-
-    MARGO_REGISTER(mid, "unifycr_mount_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_mount_rpc",
                    unifycr_mount_in_t, unifycr_mount_out_t,
                    unifycr_mount_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_unmount_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_unmount_rpc",
                      unifycr_unmount_in_t, unifycr_unmount_out_t,
                      unifycr_unmount_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_metaget_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_metaget_rpc",
                    unifycr_metaget_in_t, unifycr_metaget_out_t,
                    unifycr_metaget_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_metaset_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_metaset_rpc",
                    unifycr_metaset_in_t, unifycr_metaset_out_t,
                    unifycr_metaset_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_fsync_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_fsync_rpc",
                    unifycr_fsync_in_t, unifycr_fsync_out_t,
                    unifycr_fsync_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_filesize_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_filesize_rpc",
                    unifycr_filesize_in_t, unifycr_filesize_out_t,
                    unifycr_filesize_rpc);
 
-    MARGO_REGISTER(mid, "unifycr_read_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_read_rpc",
                    unifycr_read_in_t, unifycr_read_out_t,
-                   unifycr_read_rpc);
+                   unifycr_read_rpc)
 
-    MARGO_REGISTER(mid, "unifycr_mread_rpc",
+    MARGO_REGISTER(unifycr_server_rpc_context->mid, "unifycr_mread_rpc",
                    unifycr_mread_in_t, unifycr_mread_out_t,
                    unifycr_mread_rpc);
 
-    return mid;
+    return unifycr_server_rpc_context->mid;
 }
 
 /* setup_verbs_target - Initializes the inter-server target.
@@ -559,6 +548,11 @@ int main(int argc, char* argv[])
     }
 
     margo_wait_for_finalize(mid);
+
+    if (unifycr_server_rpc_context != NULL) {
+        free(unifycr_server_rpc_context);
+    }
+
     MPI_Barrier(MPI_COMM_WORLD);
     MPI_Finalize();
 

--- a/server/src/unifycr_server.h
+++ b/server/src/unifycr_server.h
@@ -21,20 +21,8 @@ typedef struct ServerRpcContext {
     margo_instance_id mid;
     hg_context_t* hg_context;
     hg_class_t* hg_class ;
-    hg_id_t unifycr_read_rpc_id;
-    hg_id_t unifycr_fsync_rpc_id;
-    hg_id_t unifycr_mount_rpc_id;
-    hg_id_t unifycr_unmount_rpc_id;
-    hg_id_t unifycr_metaget_rpc_id;
-    hg_id_t unifycr_metaset_rpc_id;
-    //hg_id_t write_rpc_id;
-    //hg_id_t chkdir_rpc_id;
-    //hg_id_t addfile_rpc_id;
-    //hg_id_t open_rpc_id;
-    //hg_id_t close_rpc_id;
-    //hg_id_t getfilestat_rpc_id;
-    //hg_id_t getdircontents_rpc_id;
-    //hg_id_t readtransfer_rpc_id;
+    hg_addr_t client_addr;
+    /* TODO: rpc id's executed on client go here */
 } ServerRpcContext_t;
 
 static const char* SMSVR_ADDR_STR   = "na+sm://";
@@ -46,19 +34,8 @@ extern bool usetcp;
 extern uint16_t total_rank;
 extern uint16_t my_rank;
 
-typedef struct ServerAddress {
-    char* string_address;
-    hg_addr_t svr_addr;
-} ServerAddress_t;
-
-extern char** server_addresses;
-
-extern ServerRpcContext_t* unifycr_rpc_context;
+extern ServerRpcContext_t* unifycr_server_rpc_context;
 
 margo_instance_id unifycr_server_rpc_init();
-
-void unifycr_server_addresses_init();
-
-int unifycr_inter_server_client_init();
 
 #endif

--- a/server/src/unifycr_servercalls_rpc.h
+++ b/server/src/unifycr_servercalls_rpc.h
@@ -1,0 +1,18 @@
+#ifndef __UNIFYCR_SERVERCALLS_RPC_H
+#define __UNIFYCR_SERVERCALLS_RPC_H
+
+/**************************************************
+ * unifycr_servercalls_rpc.h Declarations for the
+ * RPC shared-memory interfaces to the UCR server.
+ ***************************************************/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <margo.h>
+#include <mercury.h>
+#include <mercury_proc_string.h>
+
+/* TODO: placeholder for in & out structs for rpc's */
+
+#endif


### PR DESCRIPTION
infrastructure now allows adding an rpc from the server, which
will be executed on the client

    - initialize margo client as SERVER to allow rpc's
      to be serviced from the client
    - add function to record client address in file encoded
      with app_id and cliend_id
    - add function so that server can lookup client address
    - add client_addr field to app_config struct so that
      client address is looked up and recorded for each app_id
      and client_id during mount call
    - add unifycr_server.h, unifycr_servercalls_rpc.h for later
      adding functions and storing rpc id's
    - add common/src/unifycr_util.c and common/src/unifycr_util.h
      for publish/lookup functions on client and server
