### PR TITLE
fix bugs associated with attaching to existing superblock

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -1768,7 +1768,19 @@ static void* unifycr_superblock_shmget(size_t size, key_t key)
 
     /* init our global variables to point to spots in superblock */
     unifycr_init_pointers(addr);
-    unifycr_init_structures();
+
+    /* initialize structures in superblock if it's newly allocated,
+     * we depend on shm_open setting all bytes to 0 to know that
+     * it is not initialized */
+    int32_t initialized = *(int32_t*)addr;
+    if (initialized == 0) {
+        /* not yet initialized, so initialize values within superblock */
+        unifycr_init_structures();
+
+        /* superblock structure has been initialized,
+         * so set flag to indicate that fact */
+        *(int32_t*)addr = 0xDEADBEEF;
+    }
 
     /* return starting memory address of super block */
     return addr;

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2739,18 +2739,14 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
      ************************/
 
     /* add mount point as a new directory in the file list */
-    if (unifycr_get_fid_from_path(prefix) >= 0) {
-        /* we can't mount this location, because it already exists */
-        LOGERR("can't mount this location, because it already exists");
-        errno = EEXIST;
-        return -1;
-    } else {
-        /* claim an entry in our file list */
+    if (unifycr_get_fid_from_path(prefix) < 0) {
+        /* no entry exists for mount point, so create one */
         int fid = unifycr_fid_create_directory(prefix);
         if (fid < 0) {
             /* if there was an error, return it */
-            LOGERR("fid %d < 0", fid);
-            return fid;
+            LOGERR("failed to create directory entry for mount point: `%s'",
+                prefix);
+            return UNIFYCR_FAILURE;
         }
     }
 

--- a/common/src/unifycr_const.h
+++ b/common/src/unifycr_const.h
@@ -79,8 +79,6 @@
 
 // Client and Command Handler
 #define CMD_BUF_SIZE (2 * KIB)
-#define MMAP_OPEN_FLAG (O_RDWR|O_CREAT)
-#define MMAP_OPEN_MODE 00777
 
 // Client
 #define UNIFYCR_MAX_FILES 128

--- a/common/src/unifycr_shm.c
+++ b/common/src/unifycr_shm.c
@@ -34,7 +34,7 @@ void* unifycr_shm_alloc(const char* name, size_t size)
 
     /* open shared memory file */
     errno = 0;
-    int fd = shm_open(name, MMAP_OPEN_FLAG, MMAP_OPEN_MODE);
+    int fd = shm_open(name, O_RDWR | O_CREAT, 0770);
     if (fd == -1) {
         /* failed to open shared memory */
         LOGERR("Failed to open shared memory %s errno=%d (%s)",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes wo bugs:
- not a fatal error if mount point already exists in file list in unifycr_mount()
- avoid reinitializing values when attaching to an existing superblock

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
