### PR TITLE
fix libmdhim_a_LDFLAGS warning

### DIFF
--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -27,7 +27,8 @@ libmdhim_a_SOURCES = Mlog2/mlog2.c \
                      mdhim.h \
                      uthash/uthash.h
 
-libmdhim_a_LDFLAGS = $(AM_LDFLAGS) $(LEVELDB_LDFLAGS) $(LEVELDB_LIBS) $(MPI_CLDFLAGS)
+# target_LDFLAGS is not valid for library archive targets
+#libmdhim_a_LDFLAGS = $(AM_LDFLAGS) $(LEVELDB_LDFLAGS) $(LEVELDB_LIBS) $(MPI_CLDFLAGS)
 
 AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
               -I$(top_srcdir)/meta/src/uthash \


### PR DESCRIPTION
### Description

Running autogen.sh has been producing a warning along the lines of 
"no matching target for libmdhim_a_LDFLAGS". The message is a bit
misleading, but what it really means is that "target_LDFLAGS" is not a
valid automake construct for library archive targets, since the linker
is not used to make them. If we ever need to pass flags, we should 
use target_ARFLAGS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
