### PR TITLE
Change travis virtualization env to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 sudo: required
+dist: xenial
 
 before_install:
   # The default environment variable $CC is known to interfere with


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Travis defaults to using Ubuntu 14.04 which has apparently started having issues of cloning certain git repositories.

This was resulting in the following error when attempting to clone the sds-repo for margo and thus causing all of our builds to fail.
```
Cloning into '/home/travis/sds-repo.git'...
fatal: unable to access 'https://xgitlab.cels.anl.gov/sds/sds-repo.git/': gnutls_handshake() failed: Handshake failed
The command "git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git $HOME/sds-repo.git" failed and exited with 128 during .
Your build has been stopped.
```
Apparently others have had similar issues with this version of Ubuntu as well.

 Changing the virtualization environment travis uses to Ubuntu 16.04 seems to fix this problem, but hopefully there isn't a deeper issue. Once margo is in spack, this shouldn't be a problem.

More discussion leading up to this can be found in #274

NOTE: The build might take a while since it'll be a new environment.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested with travis on forked repo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)