### PR TITLE
Fixes the following error when building meta/ without using spack:

### DIFF
--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -35,7 +35,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
               -I$(top_srcdir)/common/src \
               -I$(top_srcdir)/server/src
 
-AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS) $(MPI_CFLAGS)
+AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS) $(MPI_CFLAGS) $(MARGO_CFLAGS)
 AM_CFLAGS += -Wall
 
 CLEANFILES =


### PR DESCRIPTION
The problem is detailed in #280 .  

CC       data_store.o ..
  ..
  fatal error: margo.h: No such file or directory
  #include <margo.h>
  ..

  - Appended MARGO_CFLAGS in meta/src/Makefile.am

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
