### PR TITLE
create new writeread and cr examples

### DIFF
--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -392,6 +392,8 @@ static int unifycr_logio_chunk_write(
     /* split the write requests larger than unifycr_key_slice_range into
      * the ones smaller than unifycr_key_slice_range
      * */
+    index_set_t tmp_index_set;
+    memset(&tmp_index_set, 0, sizeof(tmp_index_set));
     unifycr_split_index(&cur_idx, &tmp_index_set,
                         unifycr_key_slice_range);
 

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -312,9 +312,6 @@ typedef struct {
     int count;
 } read_req_set_t;
 
-read_req_set_t read_req_set;
-index_set_t tmp_index_set;
-
 extern unifycr_index_buf_t unifycr_indices;
 extern unsigned long unifycr_max_index_entries;
 extern long unifycr_spillover_max_chunks;

--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -45,6 +45,9 @@
 
 #include "unifycr-internal.h"
 
+#define AIOCB_ERROR_CODE(cbp) (cbp->__error_code)
+#define AIOCB_RETURN_VAL(cbp) (cbp->__return_value)
+
 /* ---------------------------------------
  * POSIX wrappers: paths
  * --------------------------------------- */

--- a/common/src/unifycr_const.h
+++ b/common/src/unifycr_const.h
@@ -53,24 +53,23 @@
 #define UNIFYCR_MAX_FILENAME KIB
 
 // Metadata
-#define MAX_META_PER_SEND (512*KIB)
 #define MAX_FILE_CNT_PER_NODE KIB
 
 // Request Manager
-#define RECV_BUF_CNT 1
-#define RECV_BUF_LEN (MIB + 128*KIB)
-#define REQ_BUF_LEN (128*MIB + 4*KIB + 128*KIB)
-#define SHM_WAIT_INTERVAL 10
+#define RECV_BUF_CNT 4              /* number of remote read buffers */
+#define SENDRECV_BUF_LEN (8 * MIB)  /* remote read buffer size */
+#define MAX_META_PER_SEND 512       /* max read request count per server */
+#define REQ_BUF_LEN (MAX_META_PER_SEND * 128) /* read requests (send_msg_t) */
+#define SHM_WAIT_INTERVAL 100 /* unit: ns */
 
 // Service Manager
-#define MIN_SLEEP_INTERVAL 10
-#define SLEEP_INTERVAL 100 /* unit: us */
-#define SLEEP_SLICE_PER_UNIT 10
-#define READ_BLOCK_SIZE MIB
-#define SEND_BLOCK_SIZE (MIB + 128*KIB)
-#define READ_BUF_SZ GIB
-#define LARGE_BURSTY_DATA (500 * MIB)
+#define LARGE_BURSTY_DATA (512 * MIB)
 #define MAX_BURSTY_INTERVAL 10000 /* unit: us */
+#define MIN_SLEEP_INTERVAL 10     /* unit: us */
+#define SLEEP_INTERVAL 100        /* unit: us */
+#define SLEEP_SLICE_PER_UNIT 10   /* unit: us */
+#define READ_BLOCK_SIZE MIB
+#define READ_BUF_SZ GIB
 
 // Request and Service Managers, Command Handler
 #define MAX_NUM_CLIENTS 64 /* app processes per server */
@@ -92,26 +91,12 @@
 #define UNIFYCR_SHMEM_RECV_SIZE (MIB + 128*KIB)
 #define UNIFYCR_INDEX_BUF_SIZE  (20 * MIB)
 #define UNIFYCR_FATTR_BUF_SIZE MIB
-#define UNIFYCR_MAX_SPLIT_CNT MIB
-#define UNIFYCR_MAX_READ_CNT MIB
+#define UNIFYCR_MAX_READ_CNT KIB
 
-// Following are not currently used:
-// #define ACK_MSG_SZ 8
-// #define C_CLI_SEND_BUF_SIZE 1048576
-// #define C_CLI_RECV_BUF_SIZE 1048576
-// #define DATA_BUF_LEN (1048576 + 4096 + 131072)
-// #define IP_STR_LEN 20
-// #define MAX_CQ_SIZE 2*NUM_CLI
-// #define MAX_NUM_CONNS 10
-// /* number of messages one server sends to each of another server */
-// #define NUM_MSG 32768
-// #define NUM_OF_READ_TASKS 65536
-// #define PORT_STR_LEN 10
-// #define SH_BUF_SIZE 1048576
-// /* buffer size on the service manager for read clustering and pipelining */
-// #define SERVICE_MEM_POOL_SIZE 2147483648
+/* max read size = UNIFYCR_MAX_SPLIT_CNT * META_DEFAULT_RANGE_SZ */
+#define UNIFYCR_MAX_SPLIT_CNT KIB
 
-/* ****************** Metadata/MDHIM Default Values ******************** */
+// Metadata/MDHIM Default Values
 #define META_DEFAULT_DB_NAME unifycr_db
 #define META_DEFAULT_SERVER_RATIO 1
 #define META_DEFAULT_RANGE_SZ MIB

--- a/common/src/unifycr_shm.c
+++ b/common/src/unifycr_shm.c
@@ -93,7 +93,7 @@ void* unifycr_shm_alloc(const char* name, size_t size)
 }
 
 /* unmaps shared memory region from memory, and releases it,
- * caller should povider the address of a pointer to the region
+ * caller should provide the address of a pointer to the region
  * in paddr, sets paddr to NULL on return,
  * returns UNIFYCR_SUCCESS on success */
 int unifycr_shm_free(const char* name, size_t size, void** paddr)
@@ -112,7 +112,7 @@ int unifycr_shm_free(const char* name, size_t size, void** paddr)
         errno = 0;
         int rc = munmap(addr, size);
         if (rc == -1) {
-            /* failed to open shared memory */
+            /* failed to unmap shared memory */
             LOGERR("Failed to unmap shared memory %s errno=%d (%s)",
                    name, errno, strerror(errno));
 
@@ -123,10 +123,12 @@ int unifycr_shm_free(const char* name, size_t size, void** paddr)
         errno = 0;
         rc = shm_unlink(name);
         if (rc == -1) {
-            /* failed to open shared memory */
-            LOGERR("Failed to unlink shared memory %s errno=%d (%s)",
-                   name, errno, strerror(errno));
-
+            int err = errno;
+            if (ENOENT != err) {
+                /* failed to remove shared memory */
+                LOGERR("Failed to unlink shared memory %s errno=%d (%s)",
+                       name, err, strerror(err));
+            }
             /* not fatal, so keep going */
         }
     }

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -1,15 +1,21 @@
-libexec_PROGRAMS = sysio-write-gotcha sysio-write-static \
-                  sysio-read-gotcha sysio-read-static \
-                  sysio-writeread-gotcha sysio-writeread-static sysio-writeread-posix \
-                  sysio-writeread2-gotcha sysio-writeread2-static \
-                  sysio-dir-gotcha sysio-dir-static \
-                  sysio-stat-gotcha sysio-stat-static \
-                  sysio-cp-gotcha sysio-cp-static \
-                  app-mpiio-gotcha app-mpiio-static \
-                  app-btio-gotcha app-btio-static \
-                  app-tileio-gotcha app-tileio-static
+libexec_PROGRAMS = \
+  sysio-write-gotcha sysio-write-static \
+  sysio-read-gotcha sysio-read-static \
+  sysio-writeread-gotcha sysio-writeread-static sysio-writeread-posix \
+  sysio-writeread2-gotcha sysio-writeread2-static \
+  sysio-dir-gotcha sysio-dir-static \
+  sysio-stat-gotcha sysio-stat-static \
+  sysio-cp-gotcha sysio-cp-static \
+  writeread-posix writeread-gotcha writeread-static \
+  cr-posix cr-gotcha cr-static \
+  app-mpiio-gotcha app-mpiio-static \
+  app-btio-gotcha app-btio-static \
+  app-tileio-gotcha app-tileio-static
 
-noinst_HEADERS = testlib.h
+noinst_HEADERS = \
+  testlib.h \
+  testutil.h \
+  testutil_rdwr.h
 
 test_gotcha_ldadd = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm $(MPI_CLDFLAGS) $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
 test_static_ldadd = $(top_builddir)/client/src/libunifycr.la -lrt -lm
@@ -91,6 +97,36 @@ sysio_cp_static_CPPFLAGS = $(test_cppflags)
 sysio_cp_static_LDADD   = $(test_static_ldadd)
 sysio_cp_static_LDFLAGS = $(test_static_ldflags)
 
+writeread_posix_SOURCES  = writeread.c
+writeread_posix_CPPFLAGS = $(AM_CPPFLAGS) -DDISABLE_UNIFYCR $(MPI_CFLAGS)
+writeread_posix_LDADD    = -lrt -lm
+writeread_posix_LDFLAGS  = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
+
+writeread_gotcha_SOURCES  = writeread.c
+writeread_gotcha_CPPFLAGS = $(test_cppflags)
+writeread_gotcha_LDADD    = $(test_gotcha_ldadd)
+writeread_gotcha_LDFLAGS  = $(AM_LDFLAGS)
+
+writeread_static_SOURCES  = writeread.c
+writeread_static_CPPFLAGS = $(test_cppflags)
+writeread_static_LDADD    = $(test_static_ldadd)
+writeread_static_LDFLAGS  = $(test_static_ldflags)
+
+cr_posix_SOURCES  = checkpoint-restart.c
+cr_posix_CPPFLAGS = $(AM_CPPFLAGS) -DDISABLE_UNIFYCR $(MPI_CFLAGS)
+cr_posix_LDADD    = -lrt -lm
+cr_posix_LDFLAGS  = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
+
+cr_gotcha_SOURCES  = checkpoint-restart.c
+cr_gotcha_CPPFLAGS = $(test_cppflags)
+cr_gotcha_LDADD    = $(test_gotcha_ldadd)
+cr_gotcha_LDFLAGS  = $(AM_LDFLAGS)
+
+cr_static_SOURCES  = checkpoint-restart.c
+cr_static_CPPFLAGS = $(test_cppflags)
+cr_static_LDADD    = $(test_static_ldadd)
+cr_static_LDFLAGS  = $(test_static_ldflags)
+
 app_mpiio_gotcha_SOURCES = app-mpiio.c
 app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)
 app_mpiio_gotcha_LDADD   = $(test_gotcha_ldadd)
@@ -122,8 +158,9 @@ app_tileio_static_LDADD   = $(test_static_ldadd)
 app_tileio_static_LDFLAGS = $(test_static_ldflags)
 
 if HAVE_HDF5
-libexec_PROGRAMS += app-hdf5-create-gotcha \
-                   app-hdf5-writeread-gotcha
+libexec_PROGRAMS += \
+  app-hdf5-create-gotcha \
+  app-hdf5-writeread-gotcha
 
 app_hdf5_create_gotcha_SOURCES = app-hdf5-create.c
 app_hdf5_create_gotcha_CPPFLAGS = $(test_cppflags) $(HDF5_CPPFLAGS)

--- a/examples/src/checkpoint-restart.c
+++ b/examples/src/checkpoint-restart.c
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#include "testutil.h"
+#include "testutil_rdwr.h"
+
+// generate N-to-1 or N-to-N checkpoints according to test config
+size_t generate_checkpoint(test_cfg* cfg, char* data, uint64_t ckpt_id,
+                           struct aiocb** req_out)
+{
+    off_t blk_off;
+    size_t blk_sz = cfg->block_sz;
+
+    size_t num_reqs = 1;
+    struct aiocb* req = calloc(num_reqs, sizeof(struct aiocb));
+    if (NULL == req) {
+        *req_out = NULL;
+        return 0;
+    }
+
+    // use beginning of data to store rank and checkpoint id
+    uint64_t* u64p = (uint64_t*) data;
+    *u64p = (uint64_t) cfg->rank;
+    u64p++;
+    *u64p = ckpt_id;
+    u64p++;
+    void* chkpt_data = (void*) u64p;
+
+    if (IO_PATTERN_N1 == cfg->io_pattern) {
+        // interleaved checkpoint blocks
+        blk_off = blk_sz * cfg->rank;
+    } else { // IO_PATTERN_NN
+        blk_off = 0;
+    }
+
+    uint64_t data_off = blk_off + (2 * sizeof(uint64_t));
+    uint64_t data_sz = blk_sz - (2 * sizeof(uint64_t));
+    if (cfg->io_check) {
+        // generate lipsum in source block
+        lipsum_generate(chkpt_data, data_sz, data_off);
+    } else {
+        // fill data with unique character per rank
+        int byte = (int)'0' + cfg->rank;
+        memset(chkpt_data, byte, (size_t)data_sz);
+    }
+
+    req->aio_fildes = cfg->fd;
+    req->aio_buf = (void*)data;
+    req->aio_nbytes = blk_sz;
+    req->aio_offset = blk_off;
+    req->aio_lio_opcode = LIO_WRITE;
+
+    *req_out = req;
+    return num_reqs;
+}
+
+// generate N-to-1 or N-to-N restart according to test config
+size_t generate_restart(test_cfg* cfg, char* data,
+                        struct aiocb** req_out)
+{
+    off_t blk_off;
+    size_t blk_sz = cfg->block_sz;
+
+    size_t num_reqs = 1;
+    struct aiocb* req = calloc(num_reqs, sizeof(struct aiocb));
+    if (NULL == req) {
+        *req_out = NULL;
+        return 0;
+    }
+
+    if (IO_PATTERN_N1 == cfg->io_pattern) {
+        // interleaved block writes
+        blk_off = blk_sz * cfg->rank;
+    } else { // IO_PATTERN_NN
+        blk_off = 0;
+    }
+
+    req->aio_fildes = cfg->fd;
+    req->aio_buf = (void*)data;
+    req->aio_nbytes = blk_sz;
+    req->aio_offset = blk_off;
+    req->aio_lio_opcode = LIO_READ;
+
+    *req_out = req;
+    return num_reqs;
+}
+
+int verify_restart_data(test_cfg* cfg, char* data, uint64_t last_ckpt_id)
+{
+    int ret = 0;
+
+    // check beginning of data for correct rank and checkpoint id
+    uint64_t rank, ckptid;
+    uint64_t* u64p = (uint64_t*) data;
+    rank = *u64p;
+    u64p++;
+    ckptid = *u64p;
+    u64p++;
+
+    if (rank != (uint64_t)cfg->rank) {
+        ret = -1;
+        test_print(cfg, "ERROR - Failed to verify restart rank\n");
+    }
+
+    if (ckptid != last_ckpt_id) {
+        ret = -1;
+        test_print(cfg, "ERROR - Failed to verify restart checkpoint id\n");
+    }
+
+    if (cfg->io_check) {
+        // check lipsum in restart block
+        uint64_t blk_off;
+        uint64_t blk_sz = cfg->block_sz;
+        if (IO_PATTERN_N1 == cfg->io_pattern) {
+            // interleaved block writes
+            blk_off = blk_sz * cfg->rank;
+        } else { // IO_PATTERN_NN
+            blk_off = 0;
+        }
+
+        uint64_t err_off;
+        uint64_t data_off = blk_off + (2 * sizeof(uint64_t));
+        uint64_t data_sz = blk_sz - (2 * sizeof(uint64_t));
+        const char* chkdata = (const char*) u64p;
+        int rc = lipsum_check(chkdata, data_sz, data_off, &err_off);
+        if (rc) {
+            ret = -1;
+            test_print(cfg, "ERROR - Failed to verify restart checkpoint data "
+                       "@ offset %" PRIu64 "\n", err_off);
+        }
+    }
+
+    return ret;
+}
+
+
+/* -------- Main Program -------- */
+
+/* Description:
+ *
+ * [ Mode 1: N-to-1 shared-file checkpoint ]
+ *    Each rank writes cfg.n_blocks checkpoints of size cfg.block_sz to
+ *    the shared file. Checkpoint blocks are rank-interleaved (i.e., the
+ *    block at offset 0 is written by rank 0, the block at offset
+ *    cfg.block_sz is written by rank 1, and so on). After writing all
+ *    checkpoint blocks, the data is synced (laminated) and the shared
+ *    file is closed. Each rank then re-opens the shared file, reads
+ *    back the last data written, and optionally checks the contents if
+ *    cfg.io_check is set.
+ *
+ * [ Mode 2: N-to-N file-per-process checkpoint ]
+ *    Each rank writes cfg.n_blocks checkpoints of size cfg.block_sz to
+ *    its own file. After writing all checkpoint blocks, the data is
+ *    synced (laminated) and the file is closed. Each rank then re-opens
+ *    its file, reads back the last data written, and optionally checks
+ *    the contents if cfg.io_check is set.
+ *
+ * [ Options for Both Modes ]
+ *    cfg.use_aio - when enabled, aio(7) will be used to issue and
+ *    deterimine completion of reads and writes.
+ *
+ *    cfg.use_lio - when enabled, lio_listio(3) will be used to batch
+ *    reads and writes. When cfg.use_aio is also enabled, the mode will
+ *    be LIO_NOWAIT.
+ *
+ *    cfg.use_mapio - support is not yet implemented. When enabled,
+ *    direct memory loads and stores will be used for reads and writes.
+ *
+ *    cfg.use_prdwr - when enabled, pread(2) and pwrite(2) will be used.
+ *
+ *    cfg.use_stdio - when enabled, fread(2) and fwrite(2) will be used.
+ *
+ *    cfg.use_vecio - support is not yet implemented. When enabled,
+ *    readv(2) and writev(2) will be used for batching reads and writes.
+ *
+ *    cfg.io_check - when enabled, ranks will verify the last checkpoint
+ *    written matches the data read on restart.
+ *
+ *    cfg.io_shuffle - ignored.
+ *
+ *    cfg.chunk_sz - ignored.
+ */
+
+int main(int argc, char* argv[])
+{
+    char* chkpt_data;
+    char* restart_data;
+    char* target_file;
+    struct aiocb* req;
+    size_t num_reqs = 0;
+    int rc;
+
+    double min_write_time, max_write_time;
+    double min_read_time, max_read_time;
+    double min_sync_time, max_sync_time;
+
+    test_cfg test_config;
+    test_cfg* cfg = &test_config;
+    test_timer time_ckpt;
+    test_timer time_restart;
+    test_timer time_sync;
+
+    timer_init(&time_ckpt, "checkpoint");
+    timer_init(&time_restart, "restart");
+    timer_init(&time_sync, "sync");
+
+    rc = test_init(argc, argv, cfg);
+    if (rc) {
+        fprintf(stderr, "ERROR - Test %s initialization failed!",
+                argv[0]);
+        fflush(NULL);
+        return rc;
+    }
+
+    if (!test_config.use_mpi) {
+        fprintf(stderr, "ERROR - Test %s requires MPI!",
+                argv[0]);
+        fflush(NULL);
+        return -1;
+    }
+
+    target_file = test_target_filename(cfg);
+    test_print_verbose_once(cfg, "DEBUG: creating target file %s",
+                            target_file);
+    rc = test_create_file(cfg, target_file, O_RDWR);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+
+    chkpt_data = malloc(test_config.block_sz);
+    if (NULL == chkpt_data) {
+        test_abort(cfg, ENOMEM);
+    }
+
+    uint64_t chkpt_id;
+    for (chkpt_id = 1; chkpt_id <= test_config.n_blocks; chkpt_id++) {
+        // generate checkpoint data and write request
+        test_print_verbose_once(cfg, "DEBUG: generating checkpoint %" PRIu64,
+                                chkpt_id);
+        num_reqs = generate_checkpoint(cfg, chkpt_data, chkpt_id, &req);
+        if (0 == num_reqs) {
+            test_abort(cfg, ENOMEM);
+        }
+
+        // do checkpoint
+        test_print_verbose_once(cfg, "DEBUG: starting checkpoint %" PRIu64,
+                                chkpt_id);
+        test_barrier(cfg);
+        timer_start(&time_ckpt);
+        rc = issue_write_req(cfg, req);
+        if (rc) {
+            test_abort(cfg, rc);
+        }
+        rc = wait_write_req(cfg, req);
+        if (rc) {
+            test_abort(cfg, rc);
+        }
+        timer_stop(&time_ckpt);
+        test_print_verbose_once(cfg, "DEBUG: finished checkpoint %" PRIu64,
+                                chkpt_id);
+
+        min_write_time = test_reduce_double_min(cfg, time_ckpt.elapsed_sec);
+        max_write_time = test_reduce_double_max(cfg, time_ckpt.elapsed_sec);
+        test_print_once(cfg, "Checkpoint %" PRIu64 " - Minimum Time is %.6lf s,"
+                        " Maximum Time is %.6lf s\n\n",
+                        chkpt_id, min_write_time, max_write_time);
+
+        sleep(15); // fake compute time
+        test_barrier(cfg);
+    }
+
+    // sync/laminate
+    timer_start(&time_sync);
+    rc = test_close_file(cfg);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    timer_stop(&time_sync);
+    test_barrier(cfg);
+    test_print_verbose_once(cfg, "DEBUG: finished sync");
+
+    min_sync_time = test_reduce_double_min(cfg, time_sync.elapsed_sec);
+    max_sync_time = test_reduce_double_max(cfg, time_sync.elapsed_sec);
+    test_print_once(cfg, "Minimum Sync Time is %.6lf s, "
+                    "Maximum Sync Time is %.6lf s\n\n",
+                    min_sync_time, max_sync_time);
+
+    // post-checkpoint cleanup
+    free(chkpt_data);
+    free(req);
+    req = NULL;
+
+    // re-open file
+    rc = test_open_file(cfg, target_file, O_RDONLY);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    // generate restart read request
+    test_print_verbose_once(cfg, "DEBUG: generating restart read request");
+    restart_data = malloc(test_config.block_sz);
+    if (NULL == restart_data) {
+        test_abort(cfg, ENOMEM);
+    }
+    num_reqs = generate_restart(cfg, restart_data, &req);
+    if (0 == num_reqs) {
+        test_abort(cfg, ENOMEM);
+    }
+
+    // do restart read
+    test_print_verbose_once(cfg, "DEBUG: starting restart read");
+    test_barrier(cfg);
+    timer_start(&time_restart);
+    rc = issue_read_req(cfg, req);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    rc = wait_read_req(cfg, req);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    timer_stop(&time_restart);
+    test_barrier(cfg);
+    test_print_verbose_once(cfg, "DEBUG: finished restart read");
+
+    min_read_time = test_reduce_double_min(cfg, time_restart.elapsed_sec);
+    max_read_time = test_reduce_double_max(cfg, time_restart.elapsed_sec);
+    test_print_once(cfg, "Minimum Restart Time is %.6lf s, "
+                    "Maximum Restart Time is %.6lf s\n\n",
+                    min_read_time, max_read_time);
+
+    test_print_verbose_once(cfg, "DEBUG: verifying data");
+    rc = verify_restart_data(cfg, restart_data, test_config.n_blocks);
+    if (rc) {
+        test_print(cfg, "ERROR - Restart data verification failed!");
+    }
+
+    // post-restart cleanup
+    free(restart_data);
+    free(req);
+    req = NULL;
+
+    // cleanup
+    free(target_file);
+
+    timer_fini(&time_ckpt);
+    timer_fini(&time_restart);
+    timer_fini(&time_sync);
+
+    test_fini(cfg);
+
+    return 0;
+}

--- a/examples/src/testutil.h
+++ b/examples/src/testutil.h
@@ -1,0 +1,1039 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#ifndef UNIFYCR_TEST_UTIL_H
+#define UNIFYCR_TEST_UTIL_H
+
+#include <aio.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#include <mpi.h>
+
+#ifndef DISABLE_UNIFYCR
+# include <unifycr.h>
+#endif
+
+/* ---------- Common Types and Definitions ---------- */
+
+#define TEST_STR_LEN 1024
+
+#ifndef KIB
+# define KIB (1024)
+#endif
+
+#ifndef MIB
+# define MIB (1048576)
+#endif
+
+#ifndef GIB
+# define GIB (1073741824)
+#endif
+
+static inline
+double bandwidth_kib(size_t bytes, double seconds)
+{
+    double kib = (double)bytes / (double)KIB;
+    return kib/seconds;
+}
+
+static inline
+double bandwidth_mib(size_t bytes, double seconds)
+{
+    double mib = (double)bytes / (double)MIB;
+    return mib/seconds;
+}
+
+static inline
+double bandwidth_gib(size_t bytes, double seconds)
+{
+    double gib = (double)bytes / (double)GIB;
+    return gib/seconds;
+}
+
+#define IO_PATTERN_N1 (0)
+#define IO_PATTERN_NN (1)
+
+static inline
+const char* io_pattern_str(int pattern)
+{
+    switch (pattern) {
+    case IO_PATTERN_N1:
+        return "N-to-1";
+    case IO_PATTERN_NN:
+        return "N-to-N";
+    default:
+        break;
+    }
+    return "Unknown I/O Pattern";
+}
+
+#define DEFAULT_IO_CHUNK_SIZE (MIB) // 1 MiB
+#define DEFAULT_IO_BLOCK_SIZE (16 * DEFAULT_IO_CHUNK_SIZE) // 16 MiB
+#define DEFAULT_IO_NUM_BLOCKS (32) // 32 blocks x 16 MiB = 512 MiB
+
+typedef struct {
+    /* program behavior options */
+    int debug;        /* during startup, wait for input at rank 0 */
+    int verbose;      /* print verbose information to stderr */
+    int use_mpi;
+    int use_unifycr;
+
+    /* I/O behavior options */
+    int io_pattern; /* N1 or NN */
+    int io_check;   /* use lipsum to verify data */
+    int io_shuffle; /* read and write different extents */
+    int use_aio;    /* use asynchronous IO */
+    int use_lio;    /* use lio_listio instead of read/write */
+    int use_mapio;  /* use mmap instead of read/write */
+    int use_prdwr;  /* use pread/pwrite instead of read/write */
+    int use_stdio;  /* use fread/fwrite instead of read/write */
+    int use_vecio;  /* use readv/writev instead of read/write */
+
+    /* I/O size options */
+    uint64_t n_blocks; /* number of I/O blocks */
+    uint64_t block_sz; /* IO block size (multiple of chunk_sz) */
+    uint64_t chunk_sz; /* per-IO-op size */
+
+    /* target file info */
+    char*  filename;
+    char*  mountpt;
+    FILE*  fp;
+    void*  mapped;     /* address of mapped extent of cfg.fd */
+    off_t  mapped_off; /* start offset for mapped extent */
+    size_t mapped_sz;  /* size of mapped extent */
+    int    fd;
+    int    fd_access;  /* access flags for cfg.fd */
+
+    /* MPI info */
+    int rank;
+    int n_ranks;
+} test_cfg;
+
+static inline
+void test_config_init(test_cfg* cfg)
+{
+    if (NULL == cfg) {
+        fprintf(stderr, "INTERNAL ERROR: %s() - cfg is NULL\n", __func__);
+        fflush(stderr);
+        return;
+    }
+
+    // set everything to 0/NULL
+    memset(cfg, 0, sizeof(test_cfg));
+
+    // N-to-1 UnifyCR by default
+    cfg->use_mpi = 1;
+    cfg->use_unifycr = 1;
+    cfg->io_pattern = IO_PATTERN_N1;
+
+    // invalidate file descriptor
+    cfg->fd = -1;
+
+    // use default I/O sizes
+    cfg->n_blocks = DEFAULT_IO_NUM_BLOCKS;
+    cfg->block_sz = DEFAULT_IO_BLOCK_SIZE;
+    cfg->chunk_sz = DEFAULT_IO_CHUNK_SIZE;
+}
+
+static inline
+void test_config_print(test_cfg* cfg)
+{
+    assert(NULL != cfg);
+
+    fprintf(stderr, "    Test Configuration\n");
+    fprintf(stderr, "==========================\n");
+
+    fprintf(stderr, "\n-- Program Behavior --\n");
+    fprintf(stderr, "\t debug       = %d\n", cfg->debug);
+    fprintf(stderr, "\t verbose     = %d\n", cfg->verbose);
+    fprintf(stderr, "\t use_mpi     = %d\n", cfg->use_mpi);
+    fprintf(stderr, "\t use_unifycr = %d\n", cfg->use_unifycr);
+
+    fprintf(stderr, "\n-- IO Behavior --\n");
+    fprintf(stderr, "\t io_pattern  = %s\n", io_pattern_str(cfg->io_pattern));
+    fprintf(stderr, "\t io_check    = %d\n", cfg->io_check);
+    fprintf(stderr, "\t io_shuffle  = %d\n", cfg->io_shuffle);
+    fprintf(stderr, "\t use_aio     = %d\n", cfg->use_aio);
+    fprintf(stderr, "\t use_lio     = %d\n", cfg->use_lio);
+    fprintf(stderr, "\t use_mapio   = %d\n", cfg->use_mapio);
+    fprintf(stderr, "\t use_prdwr   = %d\n", cfg->use_prdwr);
+    fprintf(stderr, "\t use_stdio   = %d\n", cfg->use_stdio);
+    fprintf(stderr, "\t use_vecio   = %d\n", cfg->use_vecio);
+
+    fprintf(stderr, "\n-- IO Size Config --\n");
+    fprintf(stderr, "\t n_blocks    = %" PRIu64 "\n", cfg->n_blocks);
+    fprintf(stderr, "\t block_sz    = %" PRIu64 "\n", cfg->block_sz);
+    fprintf(stderr, "\t chunk_sz    = %" PRIu64 "\n", cfg->chunk_sz);
+
+    fprintf(stderr, "\n-- Target File --\n");
+    fprintf(stderr, "\t filename    = %s\n", cfg->filename);
+    fprintf(stderr, "\t mountpt     = %s\n", cfg->mountpt);
+
+    fprintf(stderr, "\n-- MPI Info --\n");
+    fprintf(stderr, "\t rank        = %d\n", cfg->rank);
+    fprintf(stderr, "\t n_ranks     = %d\n", cfg->n_ranks);
+}
+
+static inline
+char* test_target_filename(test_cfg* cfg)
+{
+    char fname[TEST_STR_LEN];
+
+    assert(NULL != cfg);
+
+    if (IO_PATTERN_N1 == cfg->io_pattern) {
+        snprintf(fname, sizeof(fname), "%s/%s",
+                 cfg->mountpt, cfg->filename);
+    } else {
+        snprintf(fname, sizeof(fname), "%s/%s-%d",
+                 cfg->mountpt, cfg->filename, cfg->rank);
+    }
+    return strdup(fname);
+}
+
+/* ---------- Print Utilities ---------- */
+
+static inline
+void test_print(test_cfg* cfg, const char* fmt, ...)
+{
+    int err = errno;
+
+    assert(NULL != cfg);
+
+    printf("[%d] ", cfg->rank);
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stdout, fmt, args);
+    va_end(args);
+
+    if (err) {
+        printf(" (errno=%d, %s)", err, strerror(err));
+    }
+
+    printf("\n");
+    fflush(stdout);
+}
+
+static inline
+void test_print_once(test_cfg* cfg, const char* fmt, ...)
+{
+    int err = errno;
+
+    assert(NULL != cfg);
+
+    if (cfg->rank != 0) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stdout, fmt, args);
+    va_end(args);
+
+    if (err) {
+        printf(" (errno=%d, %s)\n", err, strerror(err));
+    }
+
+    printf("\n");
+    fflush(stdout);
+}
+
+static inline
+void test_print_verbose(test_cfg* cfg, const char* fmt, ...)
+{
+    assert(NULL != cfg);
+
+    if (cfg->verbose == 0) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+
+    fprintf(stderr, "\n");
+    fflush(stderr);
+}
+
+static inline
+void test_print_verbose_once(test_cfg* cfg, const char* fmt, ...)
+{
+    assert(NULL != cfg);
+
+    if ((cfg->verbose == 0) || (cfg->rank != 0)) {
+        return;
+    }
+
+    va_list args;
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+
+    fprintf(stderr, "\n");
+    fflush(stderr);
+}
+
+/* ---------- Timer Utilities ---------- */
+
+typedef struct {
+    struct timeval start;
+    struct timeval stop;
+    char* name;
+    double elapsed_sec;
+} test_timer;
+
+static inline
+double timediff_sec(struct timeval* before, struct timeval* after)
+{
+    double diff;
+    if (!before || !after) {
+        return -1.0F;
+    }
+    diff = (double)(after->tv_sec - before->tv_sec);
+    diff += 0.000001 * ((double)(after->tv_usec) - (double)(before->tv_usec));
+    return diff;
+}
+
+static inline
+double timediff_usec(struct timeval* before, struct timeval* after)
+{
+    return 1000000.0 * timediff_sec(before, after);
+}
+
+static inline
+void timer_init(test_timer* timer,
+                     const char* name)
+{
+    memset(timer, 0, sizeof(test_timer));
+    if (NULL != name) {
+        timer->name = strdup(name);
+    }
+}
+
+static inline
+void timer_fini(test_timer* timer)
+{
+    if (NULL != timer->name) {
+        free(timer->name);
+    }
+    memset(timer, 0, sizeof(test_timer));
+}
+
+static inline
+void timer_start(test_timer* timer)
+{
+    gettimeofday(&(timer->start), NULL);
+}
+
+static inline
+void timer_stop(test_timer* timer)
+{
+    gettimeofday(&(timer->stop), NULL);
+    timer->elapsed_sec = timediff_sec(&(timer->start),
+                                      &(timer->stop));
+}
+
+/* ---------- Option Parsing Utilities ---------- */
+
+static const char* unifycr_mntpt = "/unifycr";
+static const char*     tmp_mntpt = "/tmp";
+
+static inline
+int check_io_pattern(const char* pstr)
+{
+    int pattern = -1;
+
+    if (strcmp(pstr, "n1") == 0) {
+        pattern = IO_PATTERN_N1;
+    } else if (strcmp(pstr, "nn") == 0) {
+        pattern = IO_PATTERN_NN;
+    }
+
+    return pattern;
+}
+
+static inline
+int test_is_static(const char* program)
+{
+    char* pos = strstr(program, "-static");
+    return (pos != NULL);
+}
+
+// common options for all tests
+
+static const char* test_short_opts = "Ab:c:df:hkLm:Mn:p:PSUvVx";
+
+static const struct option test_long_opts[] = {
+    { "aio", 0, 0, 'A' },
+    { "blocksize", 1, 0, 'b' },
+    { "chunksize", 1, 0, 'c' },
+    { "debug", 0, 0, 'd' },
+    { "file", 1, 0, 'f' },
+    { "help", 0, 0, 'h' },
+    { "check", 0, 0, 'k' },
+    { "listio", 0, 0, 'L' },
+    { "mount", 1, 0, 'm' },
+    { "mapio", 0, 0, 'M' },
+    { "nblocks", 1, 0, 'n' },
+    { "pattern", 1, 0, 'p' },
+    { "prdwr", 0, 0, 'P' },
+    { "stdio", 0, 0, 'S' },
+    { "disable-unifycr", 0, 0, 'U' },
+    { "verbose", 0, 0, 'v' },
+    { "vecio", 0, 0, 'V' },
+    { "shuffle", 0, 0, 'x' },
+    { 0, 0, 0, 0},
+};
+
+static const char* test_usage_str =
+    "\n"
+    "Usage: %s [options...]\n"
+    "\n"
+    "Available options:\n"
+    " -A, --aio                        use asynchronous I/O instead of read|write\n"
+    "                                  (default: off)\n"
+    " -b, --blocksize=<bytes>          I/O block size\n"
+    "                                  (default: 16 MiB)\n"
+    " -c, --chunksize=<bytes>          I/O chunk size for each operation\n"
+    "                                  (default: 1 MiB)\n"
+    " -d, --debug                      for debugging, wait for input (at rank 0) at start\n"
+    "                                  (default: off)\n"
+    " -f, --file=<filename>            target file name (or path) under mountpoint\n"
+    "                                  (default: 'testfile')\n"
+    " -k, --check                      check data contents upon read\n"
+    "                                  (default: off)\n"
+    " -L, --listio                     use lio_listio instead of read|write\n"
+    "                                  (default: off)\n"
+    " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
+    "                                  (default: /unifycr)\n"
+    " -M, --mapio                      use mmap instead of read|write\n"
+    "                                  (default: off)\n"
+    " -n, --nblocks=<count>            count of blocks each process will read|write\n"
+    "                                  (default: 32)\n"
+    " -p, --pattern=<pattern>          'n1' (N-to-1 shared file) or 'nn' (N-to-N file per process)\n"
+    "                                  (default: 'n1')\n"
+    " -P, --prdwr                      use pread|pwrite instead of read|write\n"
+    "                                  (default: off)\n"
+    " -S, --stdio                      use fread|fwrite instead of read|write\n"
+    "                                  (default: off)\n"
+    " -U, --disable-unifycr            do not use UnifyCR\n"
+    "                                  (default: enable UnifyCR)\n"
+    " -v, --verbose                    print verbose information\n"
+    "                                  (default: off)\n"
+    " -V, --vecio                      use readv|writev instead of read|write\n"
+    "                                  (default: off)\n"
+    " -x, --shuffle                    read different data than written\n"
+    "                                  (default: off)\n"
+    "\n";
+
+static inline
+void test_print_usage(test_cfg* cfg, const char* program)
+{
+    test_print_once(cfg, test_usage_str, program);
+    exit(0);
+}
+
+static inline
+int test_process_argv(test_cfg* cfg,
+                      int argc, char** argv)
+{
+    const char* program;
+    int ch;
+
+    assert(NULL != cfg);
+
+    program = basename(strdup(argv[0]));
+
+    while ((ch = getopt_long(argc, argv, test_short_opts,
+                             test_long_opts, NULL)) != -1) {
+        switch (ch) {
+        case 'A':
+            cfg->use_aio = 1;
+            break;
+
+        case 'b':
+            cfg->block_sz = (uint64_t) strtoul(optarg, NULL, 0);
+            break;
+
+        case 'c':
+            cfg->chunk_sz = (uint64_t) strtoul(optarg, NULL, 0);
+            break;
+
+        case 'd':
+            cfg->debug = 1;
+            break;
+
+        case 'f':
+            cfg->filename = strdup(optarg);
+            break;
+
+        case 'k':
+            cfg->io_check = 1;
+            break;
+
+        case 'L':
+            cfg->use_lio = 1;
+            break;
+
+        case 'm':
+            cfg->mountpt = strdup(optarg);
+            break;
+
+        case 'M':
+            cfg->use_mapio = 1;
+            break;
+
+        case 'n':
+            cfg->n_blocks = (uint64_t) strtoul(optarg, NULL, 0);
+            break;
+
+        case 'p':
+            cfg->io_pattern = check_io_pattern(optarg);
+            break;
+
+        case 'P':
+            cfg->use_prdwr = 1;
+            break;
+
+        case 's':
+            cfg->io_shuffle = 1;
+            break;
+
+        case 'S':
+            cfg->use_stdio = 1;
+            break;
+
+        case 'U':
+            cfg->use_unifycr = 0;
+            break;
+
+        case 'v':
+            cfg->verbose = 1;
+            break;
+
+        case 'V':
+            cfg->use_vecio = 1;
+            break;
+
+        case 'h':
+        default:
+            if (ch != 'h') {
+                test_print_once(cfg, "USAGE ERROR: unknown flag '-%c'", ch);
+            }
+            test_print_usage(cfg, program);
+            break;
+        }
+    }
+
+    if (cfg->io_pattern < 0) {
+        test_print_once(cfg, "USAGE ERROR: pattern should be 'n1' or 'nn'");
+        exit(-1);
+    }
+
+    if ((cfg->block_sz < cfg->chunk_sz) ||
+        (cfg->block_sz % cfg->chunk_sz)) {
+        test_print_once(cfg, "USAGE ERROR: blocksize should be larger than "
+                             "and evenly divisible by chunksize.");
+        exit(-1);
+    }
+
+    if (cfg->chunk_sz % 4096 > 0) {
+        test_print_once(cfg, "USAGE ERROR: chunksize and blocksize should be "
+                             "divisible by 4096.");
+        exit(-1);
+    }
+
+#ifdef DISABLE_UNIFYCR
+    if (cfg->use_unifycr) {
+        test_print_once(cfg, "USAGE ERROR: UnifyCR enabled, "
+                             "but not compiled/linked");
+        exit(-1);
+    }
+#endif
+
+    if (test_is_static(program) && !cfg->use_unifycr) {
+        test_print_once(cfg, "USAGE ERROR: --disable-unifycr only valid when "
+                             "dynamically linked.");
+        exit(-1);
+    }
+
+    // exhaustive check of incompatible I/O modes
+    if (cfg->use_aio &&
+       (cfg->use_mapio || cfg->use_prdwr || cfg->use_stdio || cfg->use_vecio)) {
+        test_print_once(cfg, "USAGE ERROR: --aio incompatible with "
+                             "[--mapio, --prdwr, --stdio, --vecio]");
+        exit(-1);
+    }
+
+    if (cfg->use_lio &&
+       (cfg->use_mapio || cfg->use_prdwr || cfg->use_stdio || cfg->use_vecio)) {
+        test_print_once(cfg, "USAGE ERROR: --listio incompatible with "
+                             "[--mapio, --prdwr, --stdio, --vecio]");
+        exit(-1);
+    }
+
+    if (cfg->use_mapio &&
+       (cfg->use_prdwr || cfg->use_stdio || cfg->use_vecio)) {
+        test_print_once(cfg, "USAGE ERROR: --mapio incompatible with "
+                             "[--aio, --listio, --prdwr, --stdio, --vecio]");
+        exit(-1);
+    }
+
+    if (cfg->use_prdwr &&
+       (cfg->use_stdio || cfg->use_vecio)) {
+        test_print_once(cfg, "USAGE ERROR: --prdwr incompatible with "
+                             "[--aio, --listio, --mapio, --stdio, --vecio]");
+        exit(-1);
+    }
+
+    if (cfg->use_stdio && cfg->use_vecio) {
+        test_print_once(cfg, "USAGE ERROR: --stdio incompatible with "
+                             "[--aio, --listio, --mapio, --prdwr, --vecio]");
+        exit(-1);
+    }
+
+
+    if (NULL == cfg->filename) {
+        // set filename default
+        cfg->filename = strdup("testfile");
+    }
+
+    if (NULL == cfg->mountpt) {
+        // set mountpoint default
+        if (cfg->use_unifycr) {
+            cfg->mountpt = strdup(unifycr_mntpt);
+        } else {
+            cfg->mountpt = strdup(tmp_mntpt);
+        }
+    }
+
+    return 0;
+}
+
+/* ---------- Data Utilities ---------- */
+
+/*
+ * sequentially number every 8 bytes (uint64_t)
+ */
+static inline
+void lipsum_generate(char* buf, uint64_t len, uint64_t offset)
+{
+    uint64_t i;
+    uint64_t start = offset / sizeof(uint64_t);
+    uint64_t count = len / sizeof(uint64_t);
+    uint64_t* ibuf = (uint64_t*) buf;
+
+    for (i = 0; i < count; i++) {
+        ibuf[i] = start + i;
+    }
+}
+
+/*
+ * check buffer contains lipsum generated data
+ * returns 0 on success, -1 otherwise with @error_offset set.
+ */
+static inline
+int lipsum_check(const char* buf, uint64_t len, uint64_t offset,
+                 uint64_t* error_offset)
+{
+    uint64_t i, val;
+    uint64_t start = offset / sizeof(uint64_t);
+    uint64_t count = len / sizeof(uint64_t);
+    const uint64_t* ibuf = (uint64_t*) buf;
+
+    for (i = 0; i < count; i++) {
+        val = start + i;
+        if (ibuf[i] != val) {
+            *error_offset = offset + (i * sizeof(uint64_t));
+            fprintf(stderr, "DEBUG: [%" PRIu64 "] @ offset %" PRIu64
+                    ", expected=%" PRIu64 " found=%" PRIu64 "\n",
+                    i, *error_offset, val, ibuf[i]);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+/* ---------- MPI Utilities ---------- */
+
+static inline
+void test_barrier(test_cfg* cfg)
+{
+    assert(NULL != cfg);
+
+    if (cfg->use_mpi) {
+        MPI_Barrier(MPI_COMM_WORLD);
+    }
+}
+
+static inline
+double test_reduce_double_sum(test_cfg* cfg, double local_val)
+{
+    double aggr_val = 0.0;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_mpi) {
+        MPI_Reduce(&local_val, &aggr_val,
+                   1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+    } else {
+        aggr_val = local_val;
+    }
+    return aggr_val;
+}
+
+static inline
+double test_reduce_double_max(test_cfg* cfg, double local_val)
+{
+    double aggr_val = 0.0;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_mpi) {
+        MPI_Reduce(&local_val, &aggr_val,
+                   1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
+    } else {
+        aggr_val = local_val;
+    }
+    return aggr_val;
+}
+
+static inline
+double test_reduce_double_min(test_cfg* cfg, double local_val)
+{
+    double aggr_val = 0.0;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_mpi) {
+        MPI_Reduce(&local_val, &aggr_val,
+                   1, MPI_DOUBLE, MPI_MIN, 0, MPI_COMM_WORLD);
+    } else {
+        aggr_val = local_val;
+    }
+    return aggr_val;
+}
+
+/* ---------- Program Utilities ---------- */
+
+int test_access_to_mmap_prot(int access)
+{
+    switch (access) {
+    case O_RDWR:
+        return (PROT_READ | PROT_WRITE);
+    case O_RDONLY:
+        return PROT_READ;
+    case O_WRONLY:
+        return PROT_WRITE;
+    default:
+        break;
+    }
+    return PROT_NONE;
+}
+
+const char* test_access_to_stdio_mode(int access)
+{
+    switch (access) {
+    case O_RDWR:
+        return "w+";
+    case O_RDONLY:
+        return "r";
+    case O_WRONLY:
+        return "w";
+    default:
+        break;
+    }
+    return NULL;
+}
+
+/*
+ * open the given file
+ */
+static inline
+int test_open_file(test_cfg* cfg, const char* filepath, int access)
+{
+    FILE* fp = NULL;
+    const char* fmode;
+    int fd = -1;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_stdio) {
+        fmode = test_access_to_stdio_mode(access);
+        fp = fopen(filepath, fmode);
+        if (NULL == fp) {
+            test_print(cfg, "ERROR: fopen(%s) failed", filepath);
+            return -1;
+        }
+        cfg->fp = fp;
+        return 0;
+    }
+
+    fd = open(filepath, access);
+    if (-1 == fd) {
+        test_print(cfg, "ERROR: open(%s) failed", filepath);
+        return -1;
+    }
+    cfg->fd = fd;
+    cfg->fd_access = access;
+    return 0;
+}
+
+/*
+ * close the given file
+ */
+static inline
+int test_close_file(test_cfg* cfg)
+{
+    assert(NULL != cfg);
+
+    if (NULL != cfg->fp) {
+        fclose(cfg->fp);
+    }
+
+    if (NULL != cfg->mapped) {
+        munmap(cfg->mapped, cfg->mapped_sz);
+    }
+
+    if (-1 != cfg->fd) {
+        close(cfg->fd);
+    }
+    return 0;
+}
+
+/*
+ * create file at rank 0, open elsewhere
+ */
+static inline
+int test_create_file(test_cfg* cfg, const char* filepath, int access)
+{
+    FILE* fp = NULL;
+    const char* fmode;
+    int fd = -1;
+    int create_flags = O_CREAT | O_TRUNC;
+    int create_mode = 0600; // S_IRUSR | S_IWUSR
+
+    assert(NULL != cfg);
+
+    if (cfg->use_stdio) {
+        fmode = test_access_to_stdio_mode(access);
+    }
+
+    // rank 0 creates
+    if (cfg->rank == 0) {
+        if (cfg->use_stdio) {
+            fp = fopen(filepath, fmode);
+            if (NULL == fp) {
+                test_print(cfg, "ERROR: fopen(%s) failed", filepath);
+                return -1;
+            }
+            cfg->fp = fp;
+        } else {
+            fd = open(filepath, access | create_flags, create_mode);
+            if (-1 == fd) {
+                test_print(cfg, "ERROR: open(%s, CREAT) failed", filepath);
+                return -1;
+            }
+            cfg->fd = fd;
+            cfg->fd_access = access;
+        }
+    }
+
+    // barrier enforces create before open
+    test_barrier(cfg);
+
+    // other ranks just do normal open
+    if (cfg->rank != 0) {
+        return test_open_file(cfg, filepath, access);
+    }
+    return 0;
+}
+
+
+/*
+ * map a segment of an already open file
+ */
+static inline
+int test_map_file(test_cfg* cfg, off_t off, size_t len)
+{
+    void* addr;
+    int prot;
+
+    assert(NULL != cfg);
+
+    if (!cfg->use_mapio) {
+        test_print(cfg, "ERROR: cfg.use_mapio is not enabled");
+        return -1;
+    } else if (-1 == cfg->fd) {
+        test_print(cfg, "ERROR: cfg.fd is invalid, must create/open first");
+        return -1;
+    }
+
+    prot = test_access_to_mmap_prot(cfg->fd_access);
+    addr = mmap(NULL, len, prot, MAP_SHARED, cfg->fd, off);
+    if (MAP_FAILED == addr) {
+        test_print(cfg, "ERROR: mmap() failed");
+        return -1;
+    }
+    cfg->mapped = addr;
+    cfg->mapped_sz = len;
+    cfg->mapped_off = off;
+}
+
+/*
+ * wait for input at rank 0, barrier everywhere
+ */
+static inline
+void test_pause(test_cfg* cfg, const char* fmt, ...)
+{
+    assert(NULL != cfg);
+
+    if (cfg->rank == 0) {
+        va_list args;
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+
+        fprintf(stderr, "press ENTER to continue ... ");
+        (void) getchar();
+    }
+    test_barrier(cfg);
+}
+
+/*
+ * abort the test everywhere
+ */
+static inline
+void test_abort(test_cfg* cfg, int rc)
+{
+    assert(NULL != cfg);
+
+    if (cfg->use_mpi) {
+        MPI_Abort(MPI_COMM_WORLD, rc);
+    } else {
+        exit(rc);
+    }
+}
+
+/*
+ * initialize test using argv to set config
+ */
+static inline
+int test_init(int argc, char** argv,
+              test_cfg* cfg)
+{
+    int rc;
+
+    if (NULL == cfg) {
+        fprintf(stderr, "INTERNAL ERROR: %s() : cfg is NULL\n", __func__);
+        return -1;
+    }
+
+    test_config_init(cfg);
+
+    rc = test_process_argv(cfg, argc, argv);
+    if (rc) {
+        fprintf(stderr, "ERROR: failed to process command-line args");
+        return rc;
+    }
+
+    if (cfg->use_mpi) {
+        MPI_Init(&argc, &argv);
+        MPI_Comm_size(MPI_COMM_WORLD, &(cfg->n_ranks));
+        MPI_Comm_rank(MPI_COMM_WORLD, &(cfg->rank));
+    } else {
+        cfg->n_ranks = 1;
+    }
+
+    if (cfg->verbose) {
+        // must come after test_mpi_init() to pick up MPI info
+        test_config_print(cfg);
+    }
+
+    if (cfg->use_unifycr) {
+#ifndef DISABLE_UNIFYCR
+        if (cfg->debug) {
+            test_pause(cfg, "Before unifycr_mount()");
+        }        rc = unifycr_mount(cfg->mountpt, cfg->rank, cfg->n_ranks, 0);
+        if (rc) {
+            test_print(cfg, "ERROR: unifycr_mount() failed (rc=%d)", rc);
+            test_abort(cfg, rc);
+        }
+#endif
+        test_barrier(cfg);
+    } else {
+        if (cfg->debug) {
+            test_pause(cfg, "Finished test initialization");
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * finalize test and free allocated config state
+ */
+static inline
+void test_fini(test_cfg* cfg)
+{
+    if (NULL == cfg) {
+        fprintf(stderr, "INTERNAL ERROR: %s() : cfg is NULL\n", __func__);
+        return;
+    }
+
+    test_close_file(cfg);
+
+    if (cfg->use_unifycr) {
+#ifndef DISABLE_UNIFYCR
+        int rc = unifycr_unmount();
+        if (rc) {
+            test_print(cfg, "ERROR: unifycr_unmount() failed (rc=%d)", rc);
+        }
+#endif
+    }
+
+    if (cfg->use_mpi) {
+        MPI_Finalize();
+    }
+
+    if (NULL != cfg->filename) {
+        free(cfg->filename);
+    }
+
+    if (NULL != cfg->mountpt) {
+        free(cfg->mountpt);
+    }
+
+    memset(cfg, 0, sizeof(test_cfg));
+}
+
+#endif /* UNIFYCR_TEST_UTIL_H */

--- a/examples/src/testutil_rdwr.h
+++ b/examples/src/testutil_rdwr.h
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#ifndef UNIFYCR_TESTUTIL_RDWR_H
+#define UNIFYCR_TESTUTIL_RDWR_H
+
+/* -------- Write Helper Methods -------- */
+
+static inline
+int issue_write_req(test_cfg* cfg, struct aiocb* req)
+{
+    int rc, err;
+    ssize_t ss;
+    size_t written, remaining;
+    off_t off;
+    void* src;
+
+    assert(NULL != cfg);
+
+    errno = 0;
+    if (cfg->use_aio) { // aio_write(2)
+        rc = aio_write(req);
+        if (-1 == rc) {
+            test_print(cfg, "aio_write() failed");
+        }
+        return rc;
+    } else if (cfg->use_mapio) { // mmap(2)
+        return ENOTSUP;
+    } else if (cfg->use_prdwr) { // pwrite(2)
+        written = 0;
+        remaining = req->aio_nbytes;
+        do {
+            src = (void*)((char*)req->aio_buf + written);
+            ss = pwrite(req->aio_fildes, src, remaining,
+                        (req->aio_offset + written));
+            if (-1 == ss) {
+                err = errno;
+                if ((EINTR == err) || (EAGAIN == err)) {
+                    continue;
+                }
+                test_print(cfg, "pwrite() failed");
+                return -1;
+            }
+            written += (size_t)ss;
+            remaining -= (size_t)ss;
+        } while (remaining);
+    } else if (cfg->use_stdio) { // fwrite(3)
+        return ENOTSUP;
+    } else if (cfg->use_vecio) { // writev(2)
+        return EINVAL;
+    } else { // write(2)
+        written = 0;
+        remaining = req->aio_nbytes;
+        off = lseek(req->aio_fildes, req->aio_offset, SEEK_SET);
+        if (-1 == off) {
+            test_print(cfg, "lseek() failed");
+            return -1;
+        }
+        do {
+            src = (void*)((char*)req->aio_buf + written);
+            ss = write(req->aio_fildes, src, remaining);
+            if (-1 == ss) {
+                err = errno;
+                if ((EINTR == err) || (EAGAIN == err)) {
+                    continue;
+                }
+                test_print(cfg, "write() failed");
+                return -1;
+            }
+            written += (size_t)ss;
+            remaining -= (size_t)ss;
+        } while (remaining);
+    }
+    return 0;
+}
+
+static inline
+int issue_write_req_batch(test_cfg* cfg, size_t n_reqs, struct aiocb* reqs)
+{
+    int rc, ret, lio_mode;
+    size_t i;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_lio) { // lio_listio(2)
+        struct aiocb* lio_vec[n_reqs];
+        for (i = 0; i < n_reqs; i++) {
+            lio_vec[i] = reqs + i;
+        }
+        lio_mode = LIO_WAIT;
+        if (cfg->use_aio) {
+            lio_mode = LIO_NOWAIT;
+        }
+        errno = 0;
+        rc = lio_listio(lio_mode, lio_vec, (int)n_reqs, NULL);
+        if (-1 == rc) {
+            test_print(cfg, "lio_listio() failed");
+        }
+        return rc;
+    } else if (cfg->use_mapio) { // mmap(2)
+        return ENOTSUP;
+    } else if (cfg->use_vecio) { // writev(2)
+        return ENOTSUP;
+    } else {
+        ret = 0;
+        for (i = 0; i < n_reqs; i++) {
+            rc = issue_write_req(cfg, reqs + i);
+            if (rc) {
+                test_print(cfg, "write req %zu failed", i);
+                ret = -1;
+            }
+        }
+        return ret;
+    }
+}
+
+static inline
+int wait_write_req(test_cfg* cfg, struct aiocb* req)
+{
+    assert(NULL != cfg);
+
+    if (cfg->use_aio) {
+        ssize_t ss;
+        const struct aiocb* creq = (const struct aiocb*)req;
+        int rc = aio_suspend(&creq, 1, NULL);
+        if (-1 == rc) {
+            test_print(cfg, "aio_suspend() failed");
+            return rc;
+        }
+        do {
+            rc = aio_error(creq);
+            if (EINPROGRESS == rc) {
+                continue;
+            }
+            if (rc) {
+                errno = rc;
+                test_print(cfg, "aio_error() reported async write failure");
+            }
+            break;
+        } while (1);
+        ss = aio_return(req);
+        if (ss != req->aio_nbytes) {
+            test_print(cfg, "partial async write (%zd of %zu)",
+                       ss, req->aio_nbytes);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static inline
+int wait_write_req_batch(test_cfg* cfg, size_t n_reqs, struct aiocb* reqs)
+{
+    int rc, ret = 0;
+    size_t i;
+
+    assert(NULL != cfg);
+
+    for (i = 0; i < n_reqs; i++) {
+        rc = wait_write_req(cfg, reqs + i);
+        if (rc) {
+            test_print(cfg, "write req %zu failed", i);
+            ret = -1;
+        }
+    }
+    return ret;
+}
+
+static inline
+int write_sync(test_cfg* cfg)
+{
+    int rc;
+
+    assert(NULL != cfg);
+
+    if (NULL != cfg->fp) { // fflush(3)
+        rc = fflush(cfg->fp);
+        if (-1 == rc) {
+            test_print(cfg, "fflush() failed");
+            return -1;
+        }
+    } else if (NULL != cfg->mapped) { // msync(2)
+        rc = msync(cfg->mapped, cfg->mapped_sz, MS_SYNC);
+        if (-1 == rc) {
+            test_print(cfg, "msync() failed");
+            return -1;
+        }
+    } else if (-1 != cfg->fd) { // fsync(2)
+        rc = fsync(cfg->fd);
+        if (-1 == rc) {
+            test_print(cfg, "fsync() failed");
+            return -1;
+        }
+    }
+    return 0;
+}
+
+/* -------- Read Helper Methods -------- */
+
+static inline
+int issue_read_req(test_cfg* cfg, struct aiocb* req)
+{
+    int rc, err;
+    ssize_t ss;
+    size_t nread, remaining;
+    off_t off;
+    void* dst;
+
+    assert(NULL != cfg);
+
+    errno = 0;
+    if (cfg->use_aio) { // aio_read(2)
+        rc = aio_read(req);
+        if (-1 == rc) {
+            test_print(cfg, "aio_read() failed");
+        }
+        return rc;
+    } else if (cfg->use_mapio) { // mmap(2)
+        return ENOTSUP;
+    } else if (cfg->use_prdwr) { // pread(2)
+        nread = 0;
+        remaining = req->aio_nbytes;
+        do {
+            dst = (void*)((char*)req->aio_buf + nread);
+            ss = pread(req->aio_fildes, dst, remaining,
+                       (req->aio_offset + nread));
+            if (-1 == ss) {
+                err = errno;
+                if ((EINTR == err) || (EAGAIN == err)) {
+                    continue;
+                }
+                test_print(cfg, "pread() failed");
+                return -1;
+            } else if (0 == ss) {
+                test_print(cfg, "pread() EOF");
+                return -1;
+            }
+            nread += (size_t)ss;
+            remaining -= (size_t)ss;
+        } while (remaining);
+    } else if (cfg->use_stdio) { // fread(3)
+        return ENOTSUP;
+    } else if (cfg->use_vecio) { // readv(2)
+        return EINVAL;
+    } else { // read(2)
+        nread = 0;
+        remaining = req->aio_nbytes;
+        off = lseek(req->aio_fildes, req->aio_offset, SEEK_SET);
+        if (-1 == off) {
+            test_print(cfg, "lseek() failed");
+            return -1;
+        }
+        do {
+            dst = (void*)((char*)req->aio_buf + nread);
+            ss = read(req->aio_fildes, dst, remaining);
+            if (-1 == ss) {
+                err = errno;
+                if ((EINTR == err) || (EAGAIN == err)) {
+                    continue;
+                }
+                test_print(cfg, "read() failed");
+                return -1;
+            } else if (0 == ss) {
+                test_print(cfg, "read() EOF");
+                return -1;
+            }
+            nread += (size_t)ss;
+            remaining -= (size_t)ss;
+        } while (remaining);
+    }
+    return 0;
+}
+
+static inline
+int issue_read_req_batch(test_cfg* cfg, size_t n_reqs, struct aiocb* reqs)
+{
+    int rc, ret, lio_mode;
+    size_t i;
+
+    assert(NULL != cfg);
+
+    if (cfg->use_lio) { // lio_listio(2)
+        struct aiocb* lio_vec[n_reqs];
+        for (i = 0; i < n_reqs; i++) {
+            lio_vec[i] = reqs + i;
+        }
+        lio_mode = LIO_WAIT;
+        if (cfg->use_aio) {
+            lio_mode = LIO_NOWAIT;
+        }
+        errno = 0;
+        rc = lio_listio(lio_mode, lio_vec, (int)n_reqs, NULL);
+        if (-1 == rc) {
+            test_print(cfg, "lio_listio() failed");
+        }
+        return rc;
+    } else if (cfg->use_mapio) { // mmap(2)
+        return ENOTSUP;
+    } else if (cfg->use_vecio) { // readv(2)
+        return ENOTSUP;
+    } else {
+        ret = 0;
+        for (i = 0; i < n_reqs; i++) {
+            rc = issue_read_req(cfg, reqs + i);
+            if (rc) {
+                test_print(cfg, "read req %zu failed", i);
+                ret = -1;
+            }
+        }
+        return ret;
+    }
+}
+
+static inline
+int wait_read_req(test_cfg* cfg, struct aiocb* req)
+{
+    assert(NULL != cfg);
+
+    if (cfg->use_aio) {
+        ssize_t ss;
+        const struct aiocb* creq = (const struct aiocb*)req;
+        int rc = aio_suspend(&creq, 1, NULL);
+        if (-1 == rc) {
+            test_print(cfg, "aio_suspend() failed");
+            return rc;
+        }
+        do {
+            rc = aio_error(creq);
+            if (EINPROGRESS == rc) {
+                continue;
+            }
+            if (rc) {
+                errno = rc;
+                test_print(cfg, "aio_error() reported async read failure");
+            }
+            break;
+        } while (1);
+        ss = aio_return(req);
+        if (ss != req->aio_nbytes) {
+            test_print(cfg, "partial async read (%zd of %zu)",
+                       ss, req->aio_nbytes);
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static inline
+int wait_read_req_batch(test_cfg* cfg, size_t n_reqs, struct aiocb* reqs)
+{
+    int rc, ret = 0;
+    size_t i;
+
+    assert(NULL != cfg);
+
+    for (i = 0; i < n_reqs; i++) {
+        rc = wait_read_req(cfg, reqs + i);
+        if (rc) {
+            test_print(cfg, "read req %zu failed", i);
+            ret = -1;
+        }
+    }
+    return ret;
+}
+
+static inline
+int check_read_req(test_cfg* cfg, struct aiocb* req)
+{
+    int ret = 0;
+
+    assert(NULL != cfg);
+
+    if (cfg->io_check) {
+        uint64_t error_offset = 0;
+        uint64_t len = (uint64_t) req->aio_nbytes;
+        uint64_t off = (uint64_t) req->aio_offset;
+        int rc = lipsum_check((const char*)req->aio_buf, len, off,
+                              &error_offset);
+        if (-1 == rc) {
+            test_print(cfg, "data check failed at offset %" PRIu64,
+                       error_offset);
+            ret = -1;
+        }
+    }
+    return ret;
+}
+
+static inline
+int check_read_req_batch(test_cfg* cfg, size_t n_reqs, struct aiocb* reqs)
+{
+    int ret = 0;
+
+    assert(NULL != cfg);
+
+    if (cfg->io_check) {
+        size_t i;
+        for (i = 0; i < n_reqs; i++) {
+            int rc = check_read_req(cfg, reqs + i);
+            if (rc) {
+                test_print(cfg, "read req %zu data check failed", i);
+                ret = -1;
+            }
+        }
+    }
+    return ret;
+}
+
+#endif /* UNIFYCR_TESTUTIL_RDWR_H */

--- a/examples/src/writeread.c
+++ b/examples/src/writeread.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#include "testutil.h"
+#include "testutil_rdwr.h"
+
+// generate N-to-1 or N-to-N writes according to test config
+size_t generate_write_reqs(test_cfg* cfg, char* srcbuf,
+                           struct aiocb** reqs_out)
+{
+    off_t blk_off, chk_off;
+    size_t i, j, ndx = 0;
+    size_t blk_sz = cfg->block_sz;
+    size_t tran_sz = cfg->chunk_sz;
+    size_t n_tran_per_blk = blk_sz / tran_sz;
+
+    size_t num_reqs = cfg->n_blocks * n_tran_per_blk;
+    struct aiocb* req;
+    struct aiocb* reqs = calloc(num_reqs, sizeof(struct aiocb));
+    if (NULL == reqs) {
+        *reqs_out = NULL;
+        return 0;
+    }
+
+    if (!cfg->io_check) {
+        // fill srcbuf with unique character per rank
+        int byte = (int)'0' + cfg->rank;
+        memset(srcbuf, byte, tran_sz);
+    }
+
+    req = reqs;
+    for (i = 0; i < cfg->n_blocks; i++) {
+        if (IO_PATTERN_N1 == cfg->io_pattern) {
+            // interleaved block writes
+            blk_off = (i * blk_sz * cfg->n_ranks)
+                      + (cfg->rank * blk_sz);
+        } else { // IO_PATTERN_NN
+            // blocked writes
+            blk_off = (i * blk_sz);
+        }
+
+        if (cfg->io_check) {
+            // generate lipsum in source block
+            lipsum_generate((srcbuf + ndx), blk_sz, blk_off);
+        }
+
+        for (j = 0; j < n_tran_per_blk; j++) {
+            chk_off = blk_off + (j * tran_sz);
+
+            req->aio_fildes = cfg->fd;
+            req->aio_buf = (void*)(srcbuf + ndx);
+            req->aio_nbytes = tran_sz;
+            req->aio_offset = chk_off;
+            req->aio_lio_opcode = LIO_WRITE;
+
+            req++;
+            ndx += tran_sz;
+        }
+    }
+
+    *reqs_out = reqs;
+    return num_reqs;
+}
+
+// generate N-to-1 or N-to-N reads according to test config
+size_t generate_read_reqs(test_cfg* cfg, char* dstbuf,
+                          struct aiocb** reqs_out)
+{
+    int read_rank = cfg->rank;
+    off_t blk_off, chk_off;
+    size_t i, j, ndx = 0;
+    size_t blk_sz = cfg->block_sz;
+    size_t tran_sz = cfg->chunk_sz;
+    size_t n_tran_per_blk = blk_sz / tran_sz;
+
+    size_t num_reqs = cfg->n_blocks * n_tran_per_blk;
+    struct aiocb* req;
+    struct aiocb* reqs = calloc(num_reqs, sizeof(struct aiocb));
+    if (NULL == reqs) {
+        *reqs_out = NULL;
+        return 0;
+    }
+
+    if (cfg->io_shuffle) {
+        // 0 reads data written by N-1, N-1 reads from 0, etc.
+        read_rank = (cfg->n_ranks - 1) - cfg->rank;
+    }
+
+    req = reqs;
+    for (i = 0; i < cfg->n_blocks; i++) {
+        if (IO_PATTERN_N1 == cfg->io_pattern) {
+            // interleaved block writes
+            blk_off = (i * blk_sz * cfg->n_ranks)
+                      + (read_rank * blk_sz);
+        } else { // IO_PATTERN_NN
+            // blocked writes
+            blk_off = (i * blk_sz);
+        }
+
+        for (j = 0; j < n_tran_per_blk; j++) {
+            chk_off = blk_off + (j * tran_sz);
+
+            req->aio_fildes = cfg->fd;
+            req->aio_buf = (void*)(dstbuf + ndx);
+            req->aio_nbytes = tran_sz;
+            req->aio_offset = chk_off;
+            req->aio_lio_opcode = LIO_READ;
+
+            req++;
+            ndx += tran_sz;
+        }
+    }
+
+    *reqs_out = reqs;
+    return num_reqs;
+}
+
+
+/* -------- Main Program -------- */
+
+/* Description:
+ *
+ * [ Mode 1: N-to-1 shared-file ]
+ *    Each rank writes cfg.n_blocks blocks of size cfg.block_sz to the
+ *    shared file, using I/O operation sizes of cfg.chunk_sz. Blocks are
+ *    rank-interleaved (i.e., the block at offset 0 is written by rank 0,
+ *    the block at offset cfg.block_sz is written by rank 1, and so on).
+ *    After writing all blocks, the written data is synced (laminated).
+ *    Each rank then reads back the written blocks using I/O operation
+ *    sizes of cfg.chunk_sz. If cfg.io_shuffle is enabled, each rank will
+ *    read different blocks than it wrote.
+ *
+ * [ Mode 2: N-to-N file-per-process ]
+ *    Each rank writes cfg.n_blocks blocks of size cfg.block_sz using
+ *    I/O operation sizes of cfg.chunk_sz. The cfg.io_shuffle option is
+ *    ignored.
+ *
+ * [ Options for Both Modes ]
+ *    cfg.use_aio - when enabled, aio(7) will be used for issuing and
+ *    completion of reads and writes.
+ *
+ *    cfg.use_lio - when enabled, lio_listio(3) will be used for batching
+ *    reads and writes. When cfg.use_aio is also enabled, the mode will
+ *    be LIO_NOWAIT.
+ *
+ *    cfg.use_mapio - support is not yet implemented. When enabled,
+ *    direct memory loads and stores will be used for reads and writes.
+ *
+ *    cfg.use_prdwr - when enabled, pread(2) and pwrite(2) will be used.
+ *
+ *    cfg.use_stdio - when enabled, fread(2) and fwrite(2) will be used.
+ *
+ *    cfg.use_vecio - support is not yet implemented. When enabled,
+ *    readv(2) and writev(2) will be used for batching reads and writes.
+ *
+ *    cfg.io_check - when enabled, lipsum data is used when writing
+ *    the file and verified when reading.
+ */
+
+int main(int argc, char* argv[])
+{
+    char* wr_buf;
+    char* rd_buf;
+    char* target_file;
+    struct aiocb* reqs;
+    size_t num_reqs = 0;
+    int rc;
+
+    test_cfg test_config;
+    test_cfg* cfg = &test_config;
+    test_timer time_wr;
+    test_timer time_rd;
+    test_timer time_sync;
+
+    timer_init(&time_wr, "write");
+    timer_init(&time_rd, "read");
+    timer_init(&time_sync, "sync");
+
+    rc = test_init(argc, argv, cfg);
+    if (rc) {
+        fprintf(stderr, "ERROR - Test %s initialization failed!",
+                argv[0]);
+        fflush(NULL);
+        return rc;
+    }
+
+    if (!test_config.use_mpi) {
+        fprintf(stderr, "ERROR - Test %s requires MPI!",
+                argv[0]);
+        fflush(NULL);
+        return -1;
+    }
+
+    target_file = test_target_filename(cfg);
+    test_print_verbose_once(cfg, "DEBUG: creating target file %s",
+                            target_file);
+    rc = test_create_file(cfg, target_file, O_RDWR);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+
+    // generate write requests
+    test_print_verbose_once(cfg, "DEBUG: generating write requests");
+    wr_buf = calloc(test_config.n_blocks, test_config.block_sz);
+    if (NULL == wr_buf) {
+        test_abort(cfg, ENOMEM);
+    }
+    num_reqs = generate_write_reqs(cfg, wr_buf, &reqs);
+    if (0 == num_reqs) {
+        test_abort(cfg, ENOMEM);
+    }
+
+    // do writes
+    test_print_verbose_once(cfg, "DEBUG: starting write requests");
+    test_barrier(cfg);
+    timer_start(&time_wr);
+    rc = issue_write_req_batch(cfg, num_reqs, reqs);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    rc = wait_write_req_batch(cfg, num_reqs, reqs);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    timer_stop(&time_wr);
+    test_print_verbose_once(cfg, "DEBUG: finished write requests");
+
+    // sync/laminate
+    timer_start(&time_sync);
+    rc = write_sync(cfg);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    timer_stop(&time_sync);
+    test_barrier(cfg);
+    test_print_verbose_once(cfg, "DEBUG: finished sync");
+
+    // post-write cleanup
+    free(wr_buf);
+    free(reqs);
+    reqs = NULL;
+
+    // generate read requests
+    test_print_verbose_once(cfg, "DEBUG: generating read requests");
+    rd_buf = calloc(test_config.n_blocks, test_config.block_sz);
+    if (NULL == rd_buf) {
+        test_abort(cfg, ENOMEM);
+    }
+    num_reqs = generate_read_reqs(cfg, rd_buf, &reqs);
+    if (0 == num_reqs) {
+        test_abort(cfg, ENOMEM);
+    }
+
+    // do reads
+    test_print_verbose_once(cfg, "DEBUG: starting read requests");
+    test_barrier(cfg);
+    timer_start(&time_rd);
+    rc = issue_read_req_batch(cfg, num_reqs, reqs);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    rc = wait_read_req_batch(cfg, num_reqs, reqs);
+    if (rc) {
+        test_abort(cfg, rc);
+    }
+    timer_stop(&time_rd);
+    test_barrier(cfg);
+    test_print_verbose_once(cfg, "DEBUG: finished read requests");
+
+    if (test_config.io_check) {
+        test_print_verbose_once(cfg, "DEBUG: verifying data");
+        rc = check_read_req_batch(cfg, num_reqs, reqs);
+    }
+
+    // post-read cleanup
+    free(rd_buf);
+    free(reqs);
+    reqs = NULL;
+
+    // calculate achieved bandwidth rates
+    size_t rank_bytes = test_config.n_blocks * test_config.block_sz;
+    double write_bw, read_bw;
+    double aggr_write_bw, aggr_read_bw;
+    double max_write_time, max_read_time;
+    double min_sync_time, max_sync_time;
+
+    write_bw = bandwidth_mib(rank_bytes, time_wr.elapsed_sec);
+    aggr_write_bw = test_reduce_double_sum(cfg, write_bw);
+    max_write_time = test_reduce_double_max(cfg, time_wr.elapsed_sec);
+
+    min_sync_time = test_reduce_double_min(cfg, time_sync.elapsed_sec);
+    max_sync_time = test_reduce_double_max(cfg, time_sync.elapsed_sec);
+
+    read_bw = bandwidth_mib(rank_bytes, time_rd.elapsed_sec);
+    aggr_read_bw = test_reduce_double_sum(cfg, read_bw);
+    max_read_time = test_reduce_double_max(cfg, time_rd.elapsed_sec);
+
+    if (test_config.rank == 0) {
+        size_t total_bytes = rank_bytes * test_config.n_ranks;
+        double eff_write_bw, eff_read_bw;
+        eff_write_bw = bandwidth_mib(total_bytes, max_write_time);
+        eff_read_bw = bandwidth_mib(total_bytes, max_read_time);
+
+        printf("Aggregate Write BW is %.3lf MiB/s\n"
+               "Effective Write BW is %.3lf MiB/s\n\n",
+               aggr_write_bw, eff_write_bw);
+        printf("Minimum Sync Time is %.6lf s\n"
+               "Maximum Sync Time is %.6lf s\n\n",
+               min_sync_time, max_sync_time);
+        printf("Aggregate Read BW is %.3lf MiB/s\n"
+               "Effective Read BW is %.3lf MiB/s\n\n",
+               aggr_read_bw, eff_read_bw);
+        fflush(stdout);
+    }
+
+    // cleanup
+    free(target_file);
+
+    timer_fini(&time_wr);
+    timer_fini(&time_rd);
+    timer_fini(&time_sync);
+
+    test_fini(cfg);
+
+    return 0;
+}

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -147,7 +147,7 @@ typedef struct {
 
     /* memory for posting receives for incoming read reply messages
      * from the service threads */
-    char del_recv_msg_buf[RECV_BUF_CNT][RECV_BUF_LEN];
+    char del_recv_msg_buf[RECV_BUF_CNT][SENDRECV_BUF_LEN];
 
     /* flag set by main thread indicating whether request
      * manager thread should exit */

--- a/server/src/unifycr_init.c
+++ b/server/src/unifycr_init.c
@@ -828,20 +828,20 @@ static int unifycr_exit()
         for (j = 0; j < MAX_NUM_CLIENTS; j++) {
             /* release request buffer shared memory region */
             if (app->shm_req_bufs[j] != NULL) {
-                unifycr_shm_free(app->req_buf_name[j],
-                    app->req_buf_sz, (void**)&(app->shm_req_bufs[j]));
+                unifycr_shm_free(app->req_buf_name[j], app->req_buf_sz,
+                                 (void**)&(app->shm_req_bufs[j]));
             }
 
             /* release receive buffer shared memory region */
             if (app->shm_recv_bufs[j] != NULL) {
-                unifycr_shm_free(app->recv_buf_name[j],
-                app->recv_buf_sz, (void**)&(app->shm_recv_bufs[j]));
+                unifycr_shm_free(app->recv_buf_name[j], app->recv_buf_sz,
+                                 (void**)&(app->shm_recv_bufs[j]));
             }
 
             /* release super block shared memory region */
             if (app->shm_superblocks[j] != NULL) {
-                unifycr_shm_free(app->super_buf_name[j],
-                    app->superblock_sz, (void**)&(app->shm_superblocks[j]));
+                unifycr_shm_free(app->super_buf_name[j], app->superblock_sz,
+                                 (void**)&(app->shm_superblocks[j]));
             }
 
             /* close spill log file and delete it */

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -767,7 +767,7 @@ static int rm_receive_remote_message(
 
     /* get number of receives to post and size of each buffer */
     int recv_buf_cnt = RECV_BUF_CNT;
-    int recv_buf_len = (int) RECV_BUF_LEN;
+    int recv_buf_len = (int) SENDRECV_BUF_LEN;
 
     /* post a window of receive buffers for incoming data */
     int i;

--- a/server/src/unifycr_service_manager.c
+++ b/server/src/unifycr_service_manager.c
@@ -532,7 +532,7 @@ static int sm_ack_remote_delegator(rank_ack_meta_t* ack_meta)
     if (send_buf_list->elems[send_buf_list->size] == NULL) {
         /* need to allocate a new buffer */
         send_buf_list->elems[send_buf_list->size] =
-            malloc(SEND_BLOCK_SIZE);
+            malloc(SENDRECV_BUF_LEN);
     }
 
     /* get pointer to send buffer */
@@ -662,7 +662,7 @@ static int insert_to_ack_list(
 
         /* check whether we can fit this data into the
          * existing send block */
-        if (curr_bytes + bytes > SEND_BLOCK_SIZE) {
+        if (curr_bytes + bytes > SENDRECV_BUF_LEN) {
             /* not enough room, send the current list of read replies */
             rc = sm_ack_remote_delegator(ack_meta);
 
@@ -1286,7 +1286,7 @@ void* sm_service_reads(void* ctx)
 {
     /* allocate a buffer to hold read data before packing
      * into send buffers */
-    read_buf = calloc(1, READ_BUF_SZ);
+    read_buf = malloc(READ_BUF_SZ);
     if (read_buf == NULL) {
         // TODO: we need a better way to handle this case
         fprintf(stderr, "Error allocating buffer!!!\n");
@@ -1441,7 +1441,7 @@ void* sm_service_reads(void* ctx)
                         /* for smaller bursts, set delay proportionally
                          * to burst size we just processed */
                         bursty_interval =
-                            (long)((double)burst_data_sz / 1048576) *
+                            (long)((double)burst_data_sz / MIB) *
                             SLEEP_SLICE_PER_UNIT;
                     }
 


### PR DESCRIPTION
### Description

This is the first step in cleaning up our examples by
improving code reuse. New headers have been created
that extend the functionality of the previous testlib.h.

The new writeread example improves upon sysio-writeread
and uses command-line switches to modify its behavior,
allowing the user to select the style of write/read.
Supported styles include standard write|read, pwrite|pread,
async I/O, and lio_listio. The example also supports modes
of operation where data is checked on read, or different
data is read than written.

The new cr example, short for checkpoint-restart, does
multiple checkpoints before laminating the target file,
then re-opens the file before reading the restart data.
The cr example also supports the varied write/read
styles.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
