### PR TITLE
implement more sysio wrappers

### DIFF
--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -392,6 +392,8 @@ static int unifycr_logio_chunk_write(
     /* split the write requests larger than unifycr_key_slice_range into
      * the ones smaller than unifycr_key_slice_range
      * */
+    index_set_t tmp_index_set;
+    memset(&tmp_index_set, 0, sizeof(tmp_index_set));
     unifycr_split_index(&cur_idx, &tmp_index_set,
                         unifycr_key_slice_range);
 

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -312,9 +312,6 @@ typedef struct {
     int count;
 } read_req_set_t;
 
-read_req_set_t read_req_set;
-index_set_t tmp_index_set;
-
 extern unifycr_index_buf_t unifycr_indices;
 extern unsigned long unifycr_max_index_entries;
 extern long unifycr_spillover_max_chunks;

--- a/client/src/unifycr-sysio.c
+++ b/client/src/unifycr-sysio.c
@@ -1078,12 +1078,24 @@ ssize_t UNIFYCR_WRAP(write)(int fd, const void* buf, size_t count)
 
 ssize_t UNIFYCR_WRAP(readv)(int fd, const struct iovec* iov, int iovcnt)
 {
+    ssize_t ret;
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        /* ERROR: fn not yet supported */
-        fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-        errno = EBADF;
-        return -1;
+        ssize_t rret;
+        int i;
+        ret = 0;
+        for (i = 0; i < iovcnt; i++) {
+            rret = UNIFYCR_WRAP(read)(fd, (void*)iov[i].iov_base,
+                                      iov[i].iov_len);
+            if (-1 == rret) {
+                return -1;
+            } else if (0 == rret) {
+                return ret;
+            } else {
+                ret += rret;
+            }
+        }
+        return ret;
     } else {
         MAP_OR_FAIL(readv);
         ssize_t ret = UNIFYCR_REAL(readv)(fd, iov, iovcnt);
@@ -1095,10 +1107,22 @@ ssize_t UNIFYCR_WRAP(writev)(int fd, const struct iovec* iov, int iovcnt)
 {
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        /* ERROR: fn not yet supported */
-        fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-        errno = EBADF;
-        return -1;
+        ssize_t wret;
+        int i;
+        ret = 0;
+        for (i = 0; i < iovcnt; i++) {
+            wret = UNIFYCR_WRAP(write)(fd, (const void*)iov[i].iov_base,
+                                       iov[i].iov_len);
+            if (-1 == wret) {
+                return -1;
+            } else {
+                ret += wret;
+                if ((size_t)wret != iov[i].iov_len) {
+                    return ret;
+                }
+            }
+        }
+        return ret;
     } else {
         MAP_OR_FAIL(writev);
         ssize_t ret = UNIFYCR_REAL(writev)(fd, iov, iovcnt);
@@ -1109,50 +1133,90 @@ ssize_t UNIFYCR_WRAP(writev)(int fd, const struct iovec* iov, int iovcnt)
 int UNIFYCR_WRAP(lio_listio)(int mode, struct aiocb* const aiocb_list[],
                              int nitems, struct sigevent* sevp)
 {
-    /* TODO: missing pass through for non-intercepted lio_listio */
+    /* TODO - support for LIO_NOWAIT mode */
 
-    /* TODO: require all elements in list to refer to unify files? */
+    read_req_t* reqs = calloc(nitems, sizeof(read_req_t));
+    if (NULL == reqs) {
+        errno = ENOMEM; // EAGAIN?
+        return -1;
+    }
 
-    read_req_t* reqs = malloc(nitems * sizeof(read_req_t));
-
+    int ret = 0;
+    int reqcnt = 0;
     int i;
     for (i = 0; i < nitems; i++) {
-        if (aiocb_list[i]->aio_lio_opcode != LIO_READ) {
-            //does not support write operation currently
-            free(reqs);
-            errno = EIO;
-            return -1;
-        }
-
-        int fd = aiocb_list[i]->aio_fildes;
-        if (unifycr_intercept_fd(&fd)) {
-            /* get local file id for this request */
-            int fid = unifycr_get_fid_from_fd(fd);
-            if (fid < 0) {
-                /* TODO: need to set error code on each element */
-                errno = EIO;
-                free(reqs);
-                return -1;
+        struct aiocb* cbp = aiocb_list[i];
+        int fd = cbp->aio_fildes;
+        switch (cbp->aio_lio_opcode) {
+        case LIO_WRITE: {
+            ssize_t wret;
+            wret = UNIFYCR_WRAP(pwrite)(fd, (const void*)cbp->aio_buf,
+                                        cbp->aio_nbytes, cbp->aio_offset);
+            if (-1 == wret) {
+                AIOCB_ERROR_CODE(cbp) = errno;
+            } else {
+                AIOCB_ERROR_CODE(cbp) = 0;
+                AIOCB_RETURN_VAL(cbp) = wret;
             }
-
-            reqs[i].fid     = fid;
-            reqs[i].offset  = (size_t) aiocb_list[i]->aio_offset;
-            reqs[i].length  = aiocb_list[i]->aio_nbytes;
-            reqs[i].errcode = UNIFYCR_SUCCESS;
-            reqs[i].buf     = (char*)aiocb_list[i]->aio_buf;
+            break;
+        }
+        case LIO_READ: {
+            if (unifycr_intercept_fd(&fd)) {
+                /* get local file id for this request */
+                int fid = unifycr_get_fid_from_fd(fd);
+                if (fid < 0) {
+                    AIOCB_ERROR_CODE(cbp) = EINVAL;
+                } else {
+                    reqs[reqcnt].fid     = fid;
+                    reqs[reqcnt].offset  = (size_t)(cbp->aio_offset);
+                    reqs[reqcnt].length  = cbp->aio_nbytes;
+                    reqs[reqcnt].errcode = UNIFYCR_SUCCESS;
+                    reqs[reqcnt].buf     = (char*)(cbp->aio_buf);
+                    reqcnt++;
+                }
+            } else {
+                ssize_t rret;
+                rret = UNIFYCR_WRAP(pread)(fd, (void*)cbp->aio_buf,
+                                           cbp->aio_nbytes, cbp->aio_offset);
+                if (-1 == rret) {
+                    AIOCB_ERROR_CODE(cbp) = errno;
+                } else {
+                    AIOCB_ERROR_CODE(cbp) = 0;
+                    AIOCB_RETURN_VAL(cbp) = rret;
+                }
+            }
+            break;
+        }
+        default: // LIO_NOP
+            break;
         }
     }
 
-    int ret = unifycr_fd_logreadlist(reqs, nitems);
-
-    for (i = 0; i < nitems; i++) {
-        /* TODO: update fields to record error status
-         * see /usr/include/aio.h,
-         * update __error_code and __return_val fields? */
+    if (reqcnt) {
+        int rc = unifycr_fd_logreadlist(reqs, reqcnt);
+        if (rc != UNIFYCR_SUCCESS) {
+            /* error reading data */
+            ret = -1;
+        }
+        int ndx = 0;
+        for (i = 0; i < reqcnt; i++) {
+            /* update aiocb fields to record error status and return value */
+            for (; ndx < nitems; ndx++) {
+                if ((char*)(aiocb_list[ndx].aio_buf) == reqs[i].buf) {
+                    AIOCB_ERROR_CODE(aiocb_list[ndx]) = reqs[i].errcode;
+                    if (0 == reqs[i].errcode) {
+                        AIOCB_RETURN_VAL(aiocb_list[ndx]) = reqs[i].length;
+                    }
+                }
+            }
+        }
     }
-
+    
     free(reqs);
 
+    if (-1 == ret) {
+        errno = EIO;
+    }
     return ret;
 }
 
@@ -1430,13 +1494,13 @@ static int unifycr_coalesce_read_reqs(read_req_t* read_req, int count,
 /*
  * match the received read_requests with the
  * client's read requests
- * @param read_req: a list of read requests
+ * @param read_reqs: a list of read requests
  * @param count: number of read requests
  * @param match_req: received read request to match
  * @return error code
  *
  * */
-static int unifycr_match_received_ack(read_req_t* read_req, int count,
+static int unifycr_match_received_ack(read_req_t* read_reqs, int count,
                                       read_req_t* match_req)
 {
     /* given fid, offset, and length of match_req that holds read reply,
@@ -1451,10 +1515,10 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
     match_end.offset += match_end.length - 1;
 
     /* find index of read request that contains our first byte */
-    int start_pos = unifycr_locate_req(read_req, count, &match_start);
+    int start_pos = unifycr_locate_req(read_reqs, count, &match_start);
 
     /* find index of read request that contains our last byte */
-    int end_pos = unifycr_locate_req(read_req, count, &match_end);
+    int end_pos = unifycr_locate_req(read_reqs, count, &match_end);
 
     /* could not find a valid read request in read_req array */
     if (start_pos == -1) {
@@ -1464,7 +1528,7 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
     /* s: start of match_req, e: end of match_req */
 
     if (start_pos == 0) {
-        if (compare_read_req(&match_start, &read_req[0]) < 0) {
+        if (compare_read_req(&match_start, &read_reqs[0]) < 0) {
             /* starting offset in read reply comes before lowest
              * offset in read requests, consider this to be an error
              *
@@ -1477,10 +1541,10 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
     }
 
     /* create read request corresponding to first byte of first read request */
-    read_req_t first_start = read_req[start_pos];
+    read_req_t first_start = read_reqs[start_pos];
 
     /* create read request corresponding to last byte of first read request */
-    read_req_t first_end = read_req[start_pos];
+    read_req_t first_end = read_reqs[start_pos];
     first_end.offset += first_end.length - 1;
 
     /* check whether read reply is fully contained by first read request */
@@ -1507,16 +1571,16 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
         } else {
             /* hit an error during read, so record this fact
              * in user's original read request */
-            read_req[start_pos].errcode = match_req->errcode;
+            read_reqs[start_pos].errcode = match_req->errcode;
             return UNIFYCR_FAILURE;
         }
     }
 
     /* define read request for offset of first byte in last read request */
-    read_req_t last_start = read_req[end_pos];
+    read_req_t last_start = read_reqs[end_pos];
 
     /* define read request for offset of last byte in last read request */
-    read_req_t last_end = read_req[end_pos];
+    read_req_t last_end = read_reqs[end_pos];
     last_end.offset += last_end.length - 1;
 
     /* determine whether read reply is contained in a range of read requests */
@@ -1534,15 +1598,14 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
          * define a contiguous set of bytes */
         int i;
         for (i = start_pos + 1; i <= end_pos; i++) {
-            if (read_req[i - 1].offset + read_req[i - 1].length != read_req[i].offset) {
-                /* read requests are noncontiguous, so we returned data
-                 * covering a hole in the original array of read requests, error */
+            if ((read_reqs[i - 1].offset + read_reqs[i - 1].length)
+                != read_reqs[i].offset) {
+                /* read requests are noncontiguous, error */
                 return UNIFYCR_FAILURE;
             }
         }
 
         /* read requests are contiguous, fill all buffers in middle */
-
         if (match_req->errcode == UNIFYCR_SUCCESS) {
             /* get pointer to start of read reply data */
             char* ptr = match_req->buf;
@@ -1561,8 +1624,8 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
 
             /* copy data for middle read requests */
             for (i = start_pos + 1; i < end_pos; i++) {
-                memcpy(read_req[i].buf, ptr, read_req[i].length);
-                ptr += read_req[i].length;
+                memcpy(read_reqs[i].buf, ptr, read_reqs[i].length);
+                ptr += read_reqs[i].length;
             }
 
             /* compute bytes for last read request */
@@ -1577,7 +1640,7 @@ static int unifycr_match_received_ack(read_req_t* read_req, int count,
             /* hit an error during read, update errcode in user's
              * original read request from start to end inclusive */
             for (i = start_pos; i <= end_pos; i++) {
-                read_req[i].errcode = match_req->errcode;
+                read_reqs[i].errcode = match_req->errcode;
             }
             return UNIFYCR_FAILURE;
         }
@@ -1652,7 +1715,7 @@ static int delegator_wait()
 /* copy read data from shared memory buffer to user buffers from read
  * calls, sets done=1 on return when delegator informs us it has no
  * more data */
-static int process_read_data(read_req_t* read_req, int count, int* done)
+static int process_read_data(read_req_t* read_reqs, int count, int* done)
 {
     /* assume we'll succeed */
     int rc = UNIFYCR_SUCCESS;
@@ -1693,7 +1756,7 @@ static int process_read_data(read_req_t* read_req, int count, int* done)
 
         /* process this read reply, identify which application read
          * request this reply goes to and copy data to user buffer */
-        int tmp_rc = unifycr_match_received_ack(read_req, count, &req);
+        int tmp_rc = unifycr_match_received_ack(read_reqs, count, &req);
         if (tmp_rc != UNIFYCR_SUCCESS) {
             rc = UNIFYCR_FAILURE;
         }
@@ -1714,12 +1777,12 @@ static int process_read_data(read_req_t* read_req, int count, int* done)
 /*
  * get data for a list of read requests from the
  * delegator
- * @param read_req: a list of read requests
+ * @param read_reqs: a list of read requests
  * @param count: number of read requests
  * @return error code
  *
  * */
-int unifycr_fd_logreadlist(read_req_t* read_req, int count)
+int unifycr_fd_logreadlist(read_req_t* read_reqs, int count)
 {
     int i;
     int tot_sz = 0;
@@ -1732,7 +1795,7 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
     /* Adjust length for fitting the EOF. */
     for (i = 0; i < count; i++) {
         /* get pointer to read request */
-        read_req_t* req = &read_req[i];
+        read_req_t* req = &read_reqs[i];
 
         /* get metadata for this file */
         unifycr_filemeta_t* meta = unifycr_get_meta_from_fid(req->fid);
@@ -1760,7 +1823,7 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
     unifycr_file_attr_t* ptr_meta_entry;
     for (i = 0; i < count; i++) {
         /* look for global meta data for this local file id */
-        tmp_meta_entry.fid = read_req[i].fid;
+        tmp_meta_entry.fid = read_reqs[i].fid;
         ptr_meta_entry =
             (unifycr_file_attr_t*) bsearch(&tmp_meta_entry,
                                            unifycr_fattrs.meta_entry,
@@ -1770,7 +1833,7 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
 
         /* replace local file id with global file id in request */
         if (ptr_meta_entry != NULL) {
-            read_req[i].fid = ptr_meta_entry->gfid;
+            read_reqs[i].fid = ptr_meta_entry->gfid;
         } else {
             /* failed to find gfid for this request */
             return UNIFYCR_ERROR_BADF;
@@ -1778,14 +1841,13 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
     }
 
     /* order read request by increasing file id, then increasing offset */
-    qsort(read_req, count, sizeof(read_req_t), compare_read_req);
+    qsort(read_reqs, count, sizeof(read_req_t), compare_read_req);
 
     /* coalesce the contiguous read requests */
-    unifycr_coalesce_read_reqs(read_req, count,
+    read_req_set_t read_req_set;
+    unifycr_coalesce_read_reqs(read_reqs, count,
                                unifycr_key_slice_range,
                                &read_req_set);
-
-    shm_meta_t* tmp_sh_meta;
 
     /* prepare our shared memory buffer for delegator */
     delegator_signal();
@@ -1845,7 +1907,7 @@ int unifycr_fd_logreadlist(read_req_t* read_req, int count)
     while (!done) {
         delegator_wait();
 
-        int tmp_rc = process_read_data(read_req, count, &done);
+        int tmp_rc = process_read_data(read_reqs, count, &done);
         if (tmp_rc != UNIFYCR_SUCCESS) {
             rc = UNIFYCR_FAILURE;
         }
@@ -1927,10 +1989,7 @@ ssize_t UNIFYCR_WRAP(pread64)(int fd, void* buf, size_t count, off64_t offset)
 {
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        /* ERROR: fn not yet supported */
-        fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-        errno = EBADF;
-        return -1;
+        return UNIFYCR_WRAP(pread)(fd, buf, count, (off_t)offset);
     } else {
         MAP_OR_FAIL(pread64);
         ssize_t ret = UNIFYCR_REAL(pread64)(fd, buf, count, offset);
@@ -1974,8 +2033,7 @@ ssize_t UNIFYCR_WRAP(pwrite64)(int fd, const void* buf, size_t count,
 {
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        /* ERROR: fn not yet supported */
-        return -1;
+        return UNIFYCR_WRAP(pwrite)(fd, buf, count, (off_t)offset);
     } else {
         MAP_OR_FAIL(pwrite64);
         ssize_t ret = UNIFYCR_REAL(pwrite64)(fd, buf, count, offset);
@@ -2155,6 +2213,7 @@ void* UNIFYCR_WRAP(mmap)(void* addr, size_t length, int prot, int flags,
         errno = ENODEV;
         return MAP_FAILED;
 
+#if 0 // TODO - mmap support
         /* get the file id for this file descriptor */
         int fid = unifycr_get_fid_from_fd(fd);
         if (fid < 0) {
@@ -2203,6 +2262,7 @@ void* UNIFYCR_WRAP(mmap)(void* addr, size_t length, int prot, int flags,
         }
 
         return addr;
+#endif
     } else {
         MAP_OR_FAIL(mmap);
         void* ret = UNIFYCR_REAL(mmap)(addr, length, prot, flags, fd, offset);
@@ -2212,7 +2272,7 @@ void* UNIFYCR_WRAP(mmap)(void* addr, size_t length, int prot, int flags,
 
 int UNIFYCR_WRAP(munmap)(void* addr, size_t length)
 {
-#if 0
+#if 0 // TODO - mmap support
     fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
     errno = EINVAL;
     return -1;
@@ -2224,9 +2284,9 @@ int UNIFYCR_WRAP(munmap)(void* addr, size_t length)
 
 int UNIFYCR_WRAP(msync)(void* addr, size_t length, int flags)
 {
+#if 0 // TODO - mmap support
     /* TODO: need to keep track of all the mmaps that are linked to
      * a given file before this function can be implemented */
-#if 0
     fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
     errno = EINVAL;
     return -1;
@@ -2241,10 +2301,7 @@ void* UNIFYCR_WRAP(mmap64)(void* addr, size_t length, int prot, int flags,
 {
     /* check whether we should intercept this file descriptor */
     if (unifycr_intercept_fd(&fd)) {
-        /* ERROR: fn not yet supported */
-        fprintf(stderr, "Function not yet supported @ %s:%d\n", __FILE__, __LINE__);
-        errno = ENOSYS;
-        return MAP_FAILED;
+        return UNIFYCR_WRAP(mmap)(addr, length, prot, flags, fd, (off_t)offset);
     } else {
         MAP_OR_FAIL(mmap64);
         void* ret = UNIFYCR_REAL(mmap64)(addr, length, prot, flags, fd, offset);

--- a/client/src/unifycr-sysio.h
+++ b/client/src/unifycr-sysio.h
@@ -45,6 +45,9 @@
 
 #include "unifycr-internal.h"
 
+#define AIOCB_ERROR_CODE(cbp) (cbp->__error_code)
+#define AIOCB_RETURN_VAL(cbp) (cbp->__return_value)
+
 /* ---------------------------------------
  * POSIX wrappers: paths
  * --------------------------------------- */

--- a/common/src/unifycr_const.h
+++ b/common/src/unifycr_const.h
@@ -53,24 +53,23 @@
 #define UNIFYCR_MAX_FILENAME KIB
 
 // Metadata
-#define MAX_META_PER_SEND (512*KIB)
 #define MAX_FILE_CNT_PER_NODE KIB
 
 // Request Manager
-#define RECV_BUF_CNT 1
-#define RECV_BUF_LEN (MIB + 128*KIB)
-#define REQ_BUF_LEN (128*MIB + 4*KIB + 128*KIB)
-#define SHM_WAIT_INTERVAL 10
+#define RECV_BUF_CNT 4              /* number of remote read buffers */
+#define SENDRECV_BUF_LEN (8 * MIB)  /* remote read buffer size */
+#define MAX_META_PER_SEND 512       /* max read request count per server */
+#define REQ_BUF_LEN (MAX_META_PER_SEND * 128) /* read requests (send_msg_t) */
+#define SHM_WAIT_INTERVAL 100 /* unit: ns */
 
 // Service Manager
-#define MIN_SLEEP_INTERVAL 10
-#define SLEEP_INTERVAL 100 /* unit: us */
-#define SLEEP_SLICE_PER_UNIT 10
-#define READ_BLOCK_SIZE MIB
-#define SEND_BLOCK_SIZE (MIB + 128*KIB)
-#define READ_BUF_SZ GIB
-#define LARGE_BURSTY_DATA (500 * MIB)
+#define LARGE_BURSTY_DATA (512 * MIB)
 #define MAX_BURSTY_INTERVAL 10000 /* unit: us */
+#define MIN_SLEEP_INTERVAL 10     /* unit: us */
+#define SLEEP_INTERVAL 100        /* unit: us */
+#define SLEEP_SLICE_PER_UNIT 10   /* unit: us */
+#define READ_BLOCK_SIZE MIB
+#define READ_BUF_SZ GIB
 
 // Request and Service Managers, Command Handler
 #define MAX_NUM_CLIENTS 64 /* app processes per server */
@@ -92,26 +91,12 @@
 #define UNIFYCR_SHMEM_RECV_SIZE (MIB + 128*KIB)
 #define UNIFYCR_INDEX_BUF_SIZE  (20 * MIB)
 #define UNIFYCR_FATTR_BUF_SIZE MIB
-#define UNIFYCR_MAX_SPLIT_CNT MIB
-#define UNIFYCR_MAX_READ_CNT MIB
+#define UNIFYCR_MAX_READ_CNT KIB
 
-// Following are not currently used:
-// #define ACK_MSG_SZ 8
-// #define C_CLI_SEND_BUF_SIZE 1048576
-// #define C_CLI_RECV_BUF_SIZE 1048576
-// #define DATA_BUF_LEN (1048576 + 4096 + 131072)
-// #define IP_STR_LEN 20
-// #define MAX_CQ_SIZE 2*NUM_CLI
-// #define MAX_NUM_CONNS 10
-// /* number of messages one server sends to each of another server */
-// #define NUM_MSG 32768
-// #define NUM_OF_READ_TASKS 65536
-// #define PORT_STR_LEN 10
-// #define SH_BUF_SIZE 1048576
-// /* buffer size on the service manager for read clustering and pipelining */
-// #define SERVICE_MEM_POOL_SIZE 2147483648
+/* max read size = UNIFYCR_MAX_SPLIT_CNT * META_DEFAULT_RANGE_SZ */
+#define UNIFYCR_MAX_SPLIT_CNT KIB
 
-/* ****************** Metadata/MDHIM Default Values ******************** */
+// Metadata/MDHIM Default Values
 #define META_DEFAULT_DB_NAME unifycr_db
 #define META_DEFAULT_SERVER_RATIO 1
 #define META_DEFAULT_RANGE_SZ MIB

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -147,7 +147,7 @@ typedef struct {
 
     /* memory for posting receives for incoming read reply messages
      * from the service threads */
-    char del_recv_msg_buf[RECV_BUF_CNT][RECV_BUF_LEN];
+    char del_recv_msg_buf[RECV_BUF_CNT][SENDRECV_BUF_LEN];
 
     /* flag set by main thread indicating whether request
      * manager thread should exit */

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -767,7 +767,7 @@ static int rm_receive_remote_message(
 
     /* get number of receives to post and size of each buffer */
     int recv_buf_cnt = RECV_BUF_CNT;
-    int recv_buf_len = (int) RECV_BUF_LEN;
+    int recv_buf_len = (int) SENDRECV_BUF_LEN;
 
     /* post a window of receive buffers for incoming data */
     int i;

--- a/server/src/unifycr_service_manager.c
+++ b/server/src/unifycr_service_manager.c
@@ -532,7 +532,7 @@ static int sm_ack_remote_delegator(rank_ack_meta_t* ack_meta)
     if (send_buf_list->elems[send_buf_list->size] == NULL) {
         /* need to allocate a new buffer */
         send_buf_list->elems[send_buf_list->size] =
-            malloc(SEND_BLOCK_SIZE);
+            malloc(SENDRECV_BUF_LEN);
     }
 
     /* get pointer to send buffer */
@@ -662,7 +662,7 @@ static int insert_to_ack_list(
 
         /* check whether we can fit this data into the
          * existing send block */
-        if (curr_bytes + bytes > SEND_BLOCK_SIZE) {
+        if (curr_bytes + bytes > SENDRECV_BUF_LEN) {
             /* not enough room, send the current list of read replies */
             rc = sm_ack_remote_delegator(ack_meta);
 
@@ -1286,7 +1286,7 @@ void* sm_service_reads(void* ctx)
 {
     /* allocate a buffer to hold read data before packing
      * into send buffers */
-    read_buf = calloc(1, READ_BUF_SZ);
+    read_buf = malloc(READ_BUF_SZ);
     if (read_buf == NULL) {
         // TODO: we need a better way to handle this case
         fprintf(stderr, "Error allocating buffer!!!\n");
@@ -1441,7 +1441,7 @@ void* sm_service_reads(void* ctx)
                         /* for smaller bursts, set delay proportionally
                          * to burst size we just processed */
                         bursty_interval =
-                            (long)((double)burst_data_sz / 1048576) *
+                            (long)((double)burst_data_sz / MIB) *
                             SLEEP_SLICE_PER_UNIT;
                     }
 


### PR DESCRIPTION
### Description

The new writeread and cr examples (see PR #284) make it easy to test the various
forms of POSIX I/O. This PR implements some of the support that has been
missing thus far:
- lio_listio with non-UnifyCR file descriptors
- lio_listio for writes
- readv/writev
- pread64/pwrite64

I also took another look at the use of constants defined in `unifycr_const.h`,
and made some more rational choices on their values.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
