### PR TITLE
Fix pointer bug

### DIFF
--- a/server/src/unifycr_metadata.c
+++ b/server/src/unifycr_metadata.c
@@ -463,20 +463,27 @@ int unifycr_get_file_extents(int num_keys, unifycr_key_t** keys,
             return rc;
         }
 
-       for (i = 0; i < bgrmp->num_keys; i++) {
-            tmp_key = (unifycr_key_t*)bgrm->keys[i];
-            tmp_val = (unifycr_val_t*)bgrm->values[i];
-            (*keyval)[tot_num].key.fid = tmp_key->fid;
-            (*keyval)[tot_num].key.offset = tmp_key->offset;
+        if (tot_num < MAX_META_PER_SEND) {
+            for (i = 0; i < bgrmp->num_keys; i++) {
+                tmp_key = (unifycr_key_t*)bgrm->keys[i];
+                tmp_val = (unifycr_val_t*)bgrm->values[i];
+                (*keyval)[tot_num].key.fid = tmp_key->fid;
+                (*keyval)[tot_num].key.offset = tmp_key->offset;
 
-            (*keyval)[tot_num].val.addr = tmp_val->addr;
-            (*keyval)[tot_num].val.app_id = tmp_val->app_id;
-            (*keyval)[tot_num].val.delegator_id = tmp_val->delegator_id;
-            (*keyval)[tot_num].val.addr = tmp_val->len;
-            tot_num++;
-       }
-       bgrm = bgrmp->next;
-       mdhim_full_release_msg(bgrmp);
+                (*keyval)[tot_num].val.addr = tmp_val->addr;
+                (*keyval)[tot_num].val.app_id = tmp_val->app_id;
+                (*keyval)[tot_num].val.delegator_id = tmp_val->delegator_id;
+                (*keyval)[tot_num].val.addr = tmp_val->len;
+                tot_num++;
+                if (MAX_META_PER_SEND == tot_num) {
+                    fprintf(stderr, "Error: maximum number of values!\n");
+                    rc = UNIFYCR_FAILURE;
+                    break;
+                }
+            }
+        }
+        bgrm = bgrmp->next;
+        mdhim_full_release_msg(bgrmp);
     }
 
     *num_values = tot_num;

--- a/server/src/unifycr_metadata.c
+++ b/server/src/unifycr_metadata.c
@@ -476,7 +476,7 @@ int unifycr_get_file_extents(int num_keys, unifycr_key_t** keys,
                 (*keyval)[tot_num].val.addr = tmp_val->len;
                 tot_num++;
                 if (MAX_META_PER_SEND == tot_num) {
-                    fprintf(stderr, "Error: maximum number of values!\n");
+                    LOGERR("Error: maximum number of values!");
                     rc = UNIFYCR_FAILURE;
                     break;
                 }

--- a/server/src/unifycr_request_manager.c
+++ b/server/src/unifycr_request_manager.c
@@ -231,6 +231,7 @@ int rm_cmd_filesize(
     unifycr_key_t key1, key2;
     unifycr_key_t* unifycr_keys[2] = {&key1, &key2};
     unifycr_keyval_t* keyvals;
+    keyvals = calloc(sizeof(unifycr_keyval_t), MAX_META_PER_SEND);
 
     /* create key to describe first byte we'll read */
     unifycr_keys[0]->fid = gfid;
@@ -502,7 +503,7 @@ int rm_cmd_mread(int app_id, int client_id, int gfid,
 
     pthread_mutex_lock(&thrd_ctrl->thrd_lock);
     unifycr_keyval_t* keyvals;
-    keyvals = calloc(sizeof(unifycr_keyval_t), 1024);
+    keyvals = calloc(sizeof(unifycr_keyval_t), MAX_META_PER_SEND);
 
      /* get the locations of all the read requests from the key-value store */
     LOGDBG("app_id:%d, client_id:%d, thrd_id:%d",


### PR DESCRIPTION
This fixes a pointer bug (unallocated array in rm_cmd_filesize)
Makes sure we return an error if unifycr_get_file_extents returns more
then MAX_META_PER_SEND values.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
