### PR TITLE
Fixing the pointer bug when reattaching the superblock.

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -269,7 +269,7 @@ typedef struct {
     int storage;                    /* FILE_STORAGE specifies file data management */
 
     off_t chunks;                   /* number of chunks allocated to file */
-    unifycr_chunkmeta_t* chunk_meta; /* meta data for chunks */
+    off_t chunkmeta_idx;            /* starting index in unifycr_chunkmeta */
 } unifycr_filemeta_t;
 
 /* struct used to map a full path to its local file id,
@@ -393,6 +393,7 @@ unifycr_max_chunks; /* maximum number of chunks that fit in memory */
 extern void* free_chunk_stack;
 extern void* free_spillchunk_stack;
 extern char* unifycr_chunks;
+extern unifycr_chunkmeta_t* unifycr_chunkmetas;
 int unifycr_spilloverblock;
 
 /* -------------------------------

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -166,7 +166,8 @@ void* free_chunk_stack;
 void* free_spillchunk_stack;
 unifycr_filename_t* unifycr_filelist;
 static unifycr_filemeta_t* unifycr_filemetas;
-static unifycr_chunkmeta_t* unifycr_chunkmetas;
+
+unifycr_chunkmeta_t* unifycr_chunkmetas;
 
 char* unifycr_chunks;
 int unifycr_spilloverblock = 0;
@@ -1696,8 +1697,7 @@ static int unifycr_init_structures()
         unifycr_filemeta_t* filemeta = &unifycr_filemetas[i];
 
         /* compute offset to start of chunk meta list for this file */
-        unifycr_chunkmeta_t* chunkmetas = &(unifycr_chunkmetas[numchunks * i]);
-        filemeta->chunk_meta = chunkmetas;
+        filemeta->chunkmeta_idx = numchunks * i;
     }
 
     /* initialize stack of free file ids */


### PR DESCRIPTION
- updated unifycr_init_pointers in client/src/unifycr.c

### Motivation and Context
When the superblock is reattached from a previous instance, the chunkmeta pointers are not properly initialized (#283). This patch fixes the bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
