### PR TITLE
improve state cleanup on server shutdown

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -268,6 +268,8 @@ typedef struct {
 
     int storage;                    /* FILE_STORAGE specifies file data management */
 
+    int needs_sync;                 /* have unsynced writes */
+
     off_t chunks;                   /* number of chunks allocated to file */
     unifycr_chunkmeta_t* chunk_meta; /* meta data for chunks */
 } unifycr_filemeta_t;

--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -941,6 +941,7 @@ int unifycr_fid_create_file(const char* path)
     meta->is_dir  = 0;
     meta->log_size = 0;
     meta->storage = FILE_STORAGE_NULL;
+    meta->needs_sync = 0;
     meta->flock_status = UNLOCKED;
 
     /* PTHREAD_PROCESS_SHARED allows Process-Shared Synchronization*/

--- a/common/src/unifycr_rpc_util.c
+++ b/common/src/unifycr_rpc_util.c
@@ -20,6 +20,8 @@
 #include "unifycr_log.h"
 #include "unifycr_rpc_util.h"
 
+#define SRVR_RPC_ADDR_FILE "/dev/shm/unifycrd_id"
+
 /* publishes server RPC address */
 void rpc_publish_server_addr(const char* addr)
 {
@@ -27,12 +29,12 @@ void rpc_publish_server_addr(const char* addr)
 
     /* write server address to /dev/shm/ for client on node to
      * read from */
-    FILE* fp = fopen("/dev/shm/unifycrd_id", "w+");
+    FILE* fp = fopen(SRVR_RPC_ADDR_FILE, "w+");
     if (fp != NULL) {
         fprintf(fp, "%s", addr);
         fclose(fp);
     } else {
-        LOGERR("Error writing server rpc addr to file `/dev/shm/unifycrd_id'");
+        LOGERR("Error writing server rpc addr file " SRVR_RPC_ADDR_FILE);
     }
 }
 
@@ -47,7 +49,7 @@ char* rpc_lookup_server_addr(void)
     /* TODO: support other lookup methods here like PMIX */
 
     /* read server address string from well-known file name in ramdisk */
-    FILE* fp = fopen("/dev/shm/unifycrd_id", "r");
+    FILE* fp = fopen(SRVR_RPC_ADDR_FILE, "r");
     if (fp != NULL) {
         /* opened the file, now read the address string */
         char addr_string[256];
@@ -61,8 +63,22 @@ char* rpc_lookup_server_addr(void)
 
     /* print server address (debugging) */
     if (str != NULL) {
-        LOGDBG("rpc address: %s", str);
+        LOGDBG("found server rpc address: %s", str);
     }
 
     return str;
 }
+
+/* remove server RPC address file */
+void rpc_clean_server_addr(void)
+{
+    /* TODO: support other publish modes like PMIX */
+
+    /* write server address to /dev/shm/ for client on node to
+     * read from */
+    int rc = unlink(SRVR_RPC_ADDR_FILE);
+    if (rc != 0) {
+        LOGERR("Error removing server rpc addr file " SRVR_RPC_ADDR_FILE);
+    }
+}
+

--- a/common/src/unifycr_rpc_util.h
+++ b/common/src/unifycr_rpc_util.h
@@ -21,5 +21,8 @@ void rpc_publish_server_addr(const char* addr);
 /* lookup address of server */
 char* rpc_lookup_server_addr(void);
 
+/* remove server rpc address file */
+void rpc_clean_server_addr(void);
+
 #endif // UNIFYCR_UTIL_H
 

--- a/common/src/unifycr_runstate.c
+++ b/common/src/unifycr_runstate.c
@@ -102,6 +102,7 @@ int unifycr_write_runstate(unifycr_cfg_t* cfg)
 int unifycr_clean_runstate(unifycr_cfg_t* cfg)
 {
     int rc = (int)UNIFYCR_SUCCESS;
+    int uid = (int)getuid();
     char runstate_fname[UNIFYCR_MAX_FILENAME] = {0};
 
     if (cfg == NULL) {
@@ -110,7 +111,7 @@ int unifycr_clean_runstate(unifycr_cfg_t* cfg)
     }
 
     snprintf(runstate_fname, sizeof(runstate_fname),
-             "%s/%s", cfg->runstate_dir, runstate_file);
+             "%s/%s.%d", cfg->runstate_dir, runstate_file, uid);
 
     rc = unlink(runstate_fname);
     if (rc != 0) {

--- a/server/src/unifycr_global.h
+++ b/server/src/unifycr_global.h
@@ -149,9 +149,11 @@ typedef struct {
      * from the service threads */
     char del_recv_msg_buf[RECV_BUF_CNT][SENDRECV_BUF_LEN];
 
-    /* flag set by main thread indicating whether request
-     * manager thread should exit */
+    /* flag set to indicate request manager thread should exit */
     int exit_flag;
+
+    /* flag set after thread has exited and join completed */
+    int exited;
 
     /* app_id this thread is serving */
     int app_id;
@@ -228,7 +230,6 @@ extern arraylist_t *thrd_list;
 
 int invert_sock_ids[MAX_NUM_CLIENTS];
 
-extern pthread_t data_thrd;
 extern int glb_rank, glb_size;
 extern int *local_rank_lst;
 extern int local_rank_cnt;

--- a/server/src/unifycr_metadata.h
+++ b/server/src/unifycr_metadata.h
@@ -78,13 +78,13 @@ void debug_log_key_val(const char* ctx,
                        unifycr_key_t* key,
                        unifycr_val_t* val);
 
-int meta_sanitize();
+int meta_sanitize(void);
 int meta_init_store(unifycr_cfg_t* cfg);
 void print_bget_indices(int app_id, int client_id,
                         send_msg_t* index_set, int tot_num);
 
-int meta_init_indices();
-int meta_free_indices();
+int meta_init_indices(void);
+void meta_free_indices(void);
 void print_fsync_indices(unifycr_key_t** unifycr_keys,
                          unifycr_val_t** unifycr_vals, size_t num_entries);
 

--- a/server/src/unifycr_sock.h
+++ b/server/src/unifycr_sock.h
@@ -38,19 +38,21 @@ extern int client_sockfd;
 extern struct pollfd poll_set[MAX_NUM_CLIENTS];
 
 int sock_init_server(int srvr_id);
+void sock_sanitize_client(int client_idx);
+int sock_sanitize(void);
 int sock_add(int fd);
-void sock_reset();
-int sock_wait_cli_cmd();
-char* sock_get_cmd_buf(int sock_id);
+int sock_remove(int client_idx);
+void sock_reset(void);
+int sock_wait_cmd(int poll_timeout);
+
+#if 0 // DEPRECATED DUE TO MARGO
 int sock_handle_error(int sock_error_no);
-int sock_get_id();
-int sock_get_error_id();
-int sock_ack_cli(int sock_id, int ret_sz);
-int sock_sanitize();
-void sock_sanitize_cli(int client_id);
-char* sock_get_ack_buf(int sock_id);
-int sock_remove(int idx);
-int sock_notify_cli(int sock_id, int cmd);
-char* sock_get_cmd_buf(int sock_id);
+int sock_get_id(void);
+int sock_get_error_id(void);
+char* sock_get_cmd_buf(int client_idx);
+char* sock_get_ack_buf(int client_idx);
+int sock_ack_client(int client_idx, int ret_sz);
+int sock_notify_client(int client_idx, int cmd);
+#endif // DEPRECATED DUE TO MARGO
 
 #endif


### PR DESCRIPTION
- add termination signal handler, and restore unifycr_exit()
- send exit command to service manager thread
- avoid duplicate metadata sync on close
- fix cleanup of runstate file
- remove rpc addr file at server exit
- remove domain socket at server exit
- added debug logging to trace server exit actions

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
