### PR TITLE
fix read bug

### DIFF
--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -255,20 +255,20 @@ enum flock_enum {
 #define CHUNK_LOCATION_SPILLOVER 2
 
 typedef struct {
-    int location; /* CHUNK_LOCATION specifies how chunk is stored */
+    int location; /* CHUNK_LOCATION type */
     off_t id;     /* physical id of chunk in its respective storage */
 } unifycr_chunkmeta_t;
 
 typedef struct {
-    off_t size;                     /* current file size */
-    off_t log_size;                 /* real size of the file for logio*/
-    int is_dir;                     /* is this file a directory */
-    pthread_spinlock_t fspinlock;   /* file lock variable */
-    enum flock_enum flock_status;   /* file lock status */
+    off_t size;                      /* current file size */
+    off_t log_size;                  /* real size of the file for logio*/
+    int is_dir;                      /* is this file a directory */
+    pthread_spinlock_t fspinlock;    /* file lock variable */
+    enum flock_enum flock_status;    /* file lock status */
 
-    int storage;                    /* FILE_STORAGE specifies file data management */
+    int storage;                     /* FILE_STORAGE type */
 
-    int needs_sync;                 /* have unsynced writes */
+    int needs_sync;                  /* have unsynced writes */
 
     off_t chunks;                   /* number of chunks allocated to file */
     off_t chunkmeta_idx;            /* starting index in unifycr_chunkmeta */

--- a/server/src/unifycr_metadata.h
+++ b/server/src/unifycr_metadata.h
@@ -40,10 +40,10 @@
  * Key for a file extent
  */
 typedef struct {
-    /** file id */
+    /** global file id */
     int fid;
-    /** offset */
-    unsigned long offset;
+    /** logical file offset */
+    size_t offset;
 } unifycr_key_t;
 
 #define UNIFYCR_KEY_SZ (sizeof(unifycr_key_t))
@@ -51,11 +51,11 @@ typedef struct {
 #define UNIFYCR_KEY_OFF(keyp) (((unifycr_key_t*)keyp)->offset)
 
 typedef struct {
-    unsigned long addr;
-    unsigned long len;
-    int delegator_id;
-    int app_id;
-    int rank;
+    size_t addr;      /* data offset in server */
+    size_t len;       /* length of data at addr */
+    int delegator_id; /* rank of server where data lives */
+    int app_id;       /* application id in server */
+    int rank;         /* client id in server */
 } unifycr_val_t;
 
 #define UNIFYCR_VAL_SZ (sizeof(unifycr_val_t))


### PR DESCRIPTION
- use size_t in metadata keys and vals
- copy whole keys/vals in unifycr_get_file_extents

### Motivation and Context

The lipsum check was failing for writeread example, because data was being read from the
wrong client shmem data buffer. I tracked the bug down to the client id field not being
copied properly when fetching file extents. Fixed by copying whole key/val structs,
rather than piecemeal field assignment.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
