### PR TITLE
Fix the chunk calculation bug in PR292.

### DIFF
--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -48,8 +48,17 @@ unifycr_chunkmeta_t* filemeta_get_chunkmeta(const unifycr_filemeta_t* meta,
                                             int cid)
 {
     unifycr_chunkmeta_t* chunkmeta = NULL;
+    uint64_t limit = 0;
 
-    if (meta && (cid >= 0 && cid < unifycr_max_chunks)) {
+    if (unifycr_use_memfs) {
+        limit += unifycr_max_chunks;
+    }
+
+    if (unifycr_use_spillover) {
+        limit += unifycr_spillover_max_chunks;
+    }
+
+    if (meta && (cid >= 0 && cid < limit)) {
         chunkmeta = &unifycr_chunkmetas[meta->chunkmeta_idx + cid];
     }
 


### PR DESCRIPTION
- in filemeta_get_chunkmeta: chunk limit should be calculated by
  (max_chunks+spillover_max_chunks)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
