### PR TITLE
add MPI_Init and MPI_Finalize PMPI wrappers

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -7,70 +7,64 @@ AM_CFLAGS = -Wall -Wno-strict-aliasing
 
 include_HEADERS = unifycr.h
 
-libunifycr_la_SOURCES = \
+CLIENT_COMMON_CPPFLAGS = \
+  -I$(top_builddir)/client \
+  -I$(top_srcdir)/common/src
+
+CLIENT_COMMON_CFLAGS = \
+  $(MPI_CFLAGS) \
+  $(MERCURY_CFLAGS) $(ARGOBOTS_CFLAGS) $(MARGO_CFLAGS) \
+  $(FLATCC_CFLAGS)
+
+CLIENT_COMMON_LDFLAGS = \
+  -version-info $(LIBUNIFYCR_LT_VERSION) \
+  $(MPI_CLDFLAGS) \
+  $(MERCURY_LDFLAGS) $(MERCURY_LIBS) \
+  $(ARGOBOTS_LDFLAGS) $(ARGOBOTS_LIBS) \
+  $(MARGO_LDFLAGS) $(MARGO_LIBS) \
+  $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
+
+CLIENT_COMMON_LIBADD = \
+  $(top_builddir)/common/src/libunifycr_common.la \
+  -lcrypto -lrt -lpthread
+
+CLIENT_COMMON_SOURCES = \
+  flatbuffers_common_builder.h \
+  flatbuffers_common_reader.h \
+  ucr_read_builder.h \
+  ucr_read_reader.h \
+  unifycr.c \
   unifycr.h \
+  unifycr-dirops.h \
+  unifycr-dirops.c \
   unifycr-fixed.c \
   unifycr-fixed.h \
+  unifycr-internal.h \
   unifycr-stack.c \
   unifycr-stack.h \
   unifycr-stdio.c \
   unifycr-stdio.h \
   unifycr-sysio.c \
   unifycr-sysio.h \
-  unifycr-dirops.h \
-  unifycr-dirops.c \
-  unifycr.c \
-  unifycr.h \
-  unifycr-internal.h \
   unifycr_client.c \
-  flatbuffers_common_builder.h \
-  flatbuffers_common_reader.h \
-  ucr_read_builder.h \
-  ucr_read_reader.h \
   uthash.h \
   utlist.h
 
-libunifycr_la_CPPFLAGS = \
-  -I$(top_builddir)/client \
-  -I$(top_srcdir)/common/src
+if USE_PMPI_WRAPPERS
+CLIENT_COMMON_SOURCES += \
+  pmpi_wrappers.c \
+  pmpi_wrappers.h
+endif
 
-libunifycr_la_CFLAGS = $(MPI_CFLAGS) $(MERCURY_CFLAGS) $(ARGOBOTS_CFLAGS) $(MARGO_CFLAGS) $(FLATCC_CFLAGS)
-libunifycr_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(MPI_CLDFLAGS) $(MERCURY_LDFLAGS) $(MERCURY_LIBS) $(ARGOBOTS_LDFLAGS) $(ARGOBOTS_LIBS) $(MARGO_LDFLAGS) $(MARGO_LIBS) $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
-libunifycr_la_LIBADD = $(top_builddir)/common/src/libunifycr_common.la \
-					   -lcrypto -lrt -lpthread
+libunifycr_la_SOURCES  = $(CLIENT_COMMON_SOURCES)
+libunifycr_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS)
+libunifycr_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS)
+libunifycr_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS)
+libunifycr_la_LIBADD   = $(CLIENT_COMMON_LIBADD)
 
-libunifycr_gotcha_la_SOURCES = \
-  unifycr.h \
-  unifycr-fixed.c \
-  unifycr-fixed.h \
-  unifycr-stack.c \
-  unifycr-stack.h \
-  unifycr-stdio.c \
-  unifycr-stdio.h \
-  unifycr-sysio.c \
-  unifycr-sysio.h \
-  unifycr-dirops.h \
-  unifycr-dirops.c \
-  unifycr.c \
-  unifycr.h \
-  gotcha_map_unifycr_list.h \
-  unifycr-internal.h \
-  unifycr_client.c \
-  flatbuffers_common_builder.h \
-  flatbuffers_common_reader.h \
-  ucr_read_builder.h \
-  ucr_read_reader.h \
-  uthash.h \
-  utlist.h
-
-libunifycr_gotcha_la_CPPFLAGS = \
-  -DUNIFYCR_GOTCHA \
-  -I$(top_builddir)/client \
-  -I$(top_srcdir)/common/src
-
-libunifycr_gotcha_la_CFLAGS = $(GOTCHA_CFLAGS) $(MPI_CFLAGS) $(MERCURY_CFLAGS) $(ARGOBOTS_CFLAGS) $(MARGO_CFLAGS) $(FLATCC_CFLAGS)
-libunifycr_gotcha_la_LDFLAGS = -version-info $(LIBUNIFYCR_LT_VERSION) $(GOTCHA_LDFLAGS) $(MPI_CLDFLAGS) $(MERCURY_LDFLAGS) $(MERCURY_LIBS) $(ARGOBOTS_LDFLAGS) $(ARGOBOTS_LIBS) $(MARGO_LDFLAGS) $(MARGO_LIBS) $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
-libunifycr_gotcha_la_LIBADD = $(top_builddir)/common/src/libunifycr_common.la \
-                              -lgotcha -lcrypto -lrt -lpthread
-
+libunifycr_gotcha_la_SOURCES  = $(CLIENT_COMMON_SOURCES) gotcha_map_unifycr_list.h
+libunifycr_gotcha_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS) -DUNIFYCR_GOTCHA
+libunifycr_gotcha_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS) $(GOTCHA_CFLAGS)
+libunifycr_gotcha_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS) $(GOTCHA_LDFLAGS)
+libunifycr_gotcha_la_LIBADD   = $(CLIENT_COMMON_LIBADD) -lgotcha
 

--- a/client/src/pmpi_wrappers.c
+++ b/client/src/pmpi_wrappers.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#include "pmpi_wrappers.h"
+#include "unifycr.h"
+#include <mpi.h>
+#include <stdio.h>
+
+int unifycr_mpi_init(int* argc, char*** argv)
+{
+    int rc, ret;
+    int rank;
+    int world_sz = 0;
+    int app_id = 0;
+
+    //fprintf(stderr, "DEBUG: %s - before PMPI_Init()\n", __func__);
+
+    ret = PMPI_Init(argc, argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &world_sz);
+
+    //fprintf(stderr, "DEBUG: %s - after PMPI_Init(), rank=%d ret=%d\n",
+    //        __func__, rank, ret);
+
+    rc = unifycr_mount("/unifycr", rank, (size_t)world_sz, app_id);
+    if (UNIFYCR_SUCCESS != rc) {
+        fprintf(stderr, "UNIFYCR ERROR: unifycr_mount() failed with '%s'\n",
+                unifycr_error_enum_description((unifycr_error_e)rc));
+    }
+
+    return ret;
+}
+
+int MPI_Init(int* argc, char*** argv)
+{
+    return unifycr_mpi_init(argc, argv);
+}
+
+void mpi_init_(MPI_Fint* ierr)
+{
+    int argc = 0;
+    char** argv = NULL;
+    int rc = unifycr_mpi_init(&argc, &argv);
+
+    if (NULL != ierr) {
+        *ierr = (MPI_Fint)rc;
+    }
+}
+
+int unifycr_mpi_finalize(void)
+{
+    int rc, ret;
+
+    rc = unifycr_unmount();
+    if (UNIFYCR_SUCCESS != rc) {
+        fprintf(stderr, "UNIFYCR ERROR: unifycr_unmount() failed with '%s'\n",
+                unifycr_error_enum_description((unifycr_error_e)rc));
+    }
+
+    //fprintf(stderr, "DEBUG: %s - before PMPI_Finalize()\n", __func__);
+
+    ret = PMPI_Finalize();
+
+    //fprintf(stderr, "DEBUG: %s - after PMPI_Finalize(), ret=%d\n",
+    //        __func__, ret);
+
+    return ret;
+}
+
+int MPI_Finalize(void)
+{
+    return unifycr_mpi_finalize();
+}
+
+void mpi_finalize_(MPI_Fint* ierr)
+{
+    int rc = unifycr_mpi_finalize();
+
+    if (NULL != ierr) {
+        *ierr = (MPI_Fint)rc;
+    }
+}

--- a/client/src/pmpi_wrappers.h
+++ b/client/src/pmpi_wrappers.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyCR.
+ * For details, see https://github.com/LLNL/UnifyCR.
+ * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
+ */
+
+#ifndef UNIFYCR_PMPI_WRAPPERS_H
+#define UNIFYCR_PMPI_WRAPPERS_H
+
+/* MPI_Init PMPI wrapper */
+int unifycr_mpi_init(int* argc, char*** argv);
+int MPI_Init(int* argc, char*** argv);
+void mpi_init_(MPI_Fint* ierr);
+
+/* MPI_Finalize PMPI wrapper */
+int unifycr_mpi_finalize(void);
+int MPI_Finalize(void);
+void mpi_finalize_(MPI_Fint* ierr);
+
+#endif /* UNIFYCR_PMPI_WRAPPERS_H */

--- a/client/src/unifycr.h
+++ b/client/src/unifycr.h
@@ -73,10 +73,6 @@ typedef struct {
     int rank;
 } name_rank_pair_t;
 
-#if 0
-int unifycr_mount(const char prefix[], int rank, size_t size,
-                  int l_app_id, int subtype);
-#endif
 int unifycr_mount(const char prefix[], int rank, size_t size,
                   int l_app_id);
 int unifycr_unmount(void);

--- a/common/src/err_enumerator.h
+++ b/common/src/err_enumerator.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2019, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -10,21 +10,6 @@
  * This is the license for UnifyCR.
  * For details, see https://github.com/LLNL/UnifyCR.
  * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
- */
-
-/*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
- * Produced at the Lawrence Livermore National Laboratory.
- * Copyright (c) 2017, Florida State University. Contributions from
- * the Computer Architecture and Systems Research Laboratory (CASTL)
- * at the Department of Computer Science.
- *
- * Written by: Teng Wang, Adam Moody, Weikuan Yu, Kento Sato, Kathryn Mohror
- * LLNL-CODE-728877. All rights reserved.
- *
- * This file is part of burstfs.
- * For details, see https://github.com/llnl/burstfs
- * Please read https://github.com/llnl/burstfs/LICENSE for full license text.
  */
 
 /*  Copyright (c) 2018 - Michael J. Brim
@@ -106,7 +91,7 @@ extern "C" {
 #endif
 
 /**
- * @brief supported consistency models
+ * @brief enum for error codes
  */
 typedef enum {
     UNIFYCR_INVALID_ERROR = -2,
@@ -120,22 +105,22 @@ typedef enum {
 } unifycr_error_e;
 
 /**
- * @brief get C-string for given consistency model enum value
+ * @brief get C-string for given error enum value
  */
 const char *unifycr_error_enum_str(unifycr_error_e e);
 
 /**
- * @brief get description for given consistency model enum value
+ * @brief get description for given error enum value
  */
 const char *unifycr_error_enum_description(unifycr_error_e e);
 
 /**
- * @brief check validity of given consistency model enum value
+ * @brief check validity of given error enum value
  */
 int check_valid_unifycr_error_enum(unifycr_error_e e);
 
 /**
- * @brief get enum value for given consistency model C-string
+ * @brief get enum value for given error C-string
  */
 unifycr_error_e unifycr_error_enum_from_str(const char *s);
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,16 @@ AC_CHECK_FUNCS([ftruncate getpagesize gettimeofday memset socket floor])
 AC_CHECK_FUNCS([gethostbyname strcasecmp strdup strerror strncasecmp strrchr])
 AC_CHECK_FUNCS([gethostname strstr strtoumax strtol uname posix_fallocate])
 
+# PMPI Init/Fini mount/unmount option
+AC_ARG_ENABLE([mpi-mount],
+              AC_HELP_STRING([--enable-mpi-mount],
+                             [Enable transparent mount/unmount at MPI_Init/Finalize.]))
+if test "x$enable_mpi_mount" = "xyes"; then
+AM_CONDITIONAL([USE_PMPI_WRAPPERS], [true])
+else
+AM_CONDITIONAL([USE_PMPI_WRAPPERS], [false])
+fi
+
 # PMIx support build option
 AC_ARG_ENABLE([pmix],
               AC_HELP_STRING([--enable-pmix],


### PR DESCRIPTION
### Description

Adds a configure option for `--enable-mpi-mount`, which adds PMPI wrappers for `MPI_Init` and `MPI_Finalize` that call `unifycr_mount` and `unifycr_unmount` respectively.

Fortran support is also included.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
