### PR TITLE
This patch enables storing the file attributes in the global meta store.

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -15,9 +15,16 @@ int unifycr_sync_to_del(unifycr_mount_in_t* in);
 static int set_global_file_meta(unifycr_metaset_in_t* in,
                                 unifycr_file_attr_t* f_meta)
 {
-    in->fid      = f_meta->fid;
-    in->gfid     = f_meta->gfid;
-    in->filename = f_meta->filename;
+    in->fid       = f_meta->fid;
+    in->gfid      = f_meta->gfid;
+    in->filename  = f_meta->filename;
+    in->mode      = f_meta->mode;
+    in->uid       = f_meta->uid;
+    in->gid       = f_meta->gid;
+    in->size      = f_meta->size;
+    in->atime     = f_meta->atime;
+    in->mtime     = f_meta->mtime;
+    in->ctime     = f_meta->ctime;
 
     /* TODO: unifycr_metaset_in_t is missing struct stat info
      * in->file_attr = f_meta->file_attr; */
@@ -26,13 +33,20 @@ static int set_global_file_meta(unifycr_metaset_in_t* in,
 }
 
 static int get_global_file_meta(int gfid, unifycr_metaget_out_t* out,
-                                unifycr_file_attr_t* file_meta)
+                                unifycr_file_attr_t* f_meta)
 {
-    memset(file_meta, 0, sizeof(unifycr_file_attr_t));
+    memset(f_meta, 0, sizeof(unifycr_file_attr_t));
 
-    file_meta->gfid = gfid;
-    strcpy(file_meta->filename, out->filename);
-    file_meta->file_attr.st_size = out->st_size;
+    strcpy(f_meta->filename, out->filename);
+
+    f_meta->gfid  = gfid;
+    f_meta->mode  = out->mode;
+    f_meta->uid   = out->uid;
+    f_meta->gid   = out->gid;
+    f_meta->size  = out->size;
+    f_meta->atime = out->atime;
+    f_meta->mtime = out->mtime;
+    f_meta->ctime = out->ctime;
 
     return UNIFYCR_SUCCESS;
 }

--- a/client/src/unifycr-dirops.c
+++ b/client/src/unifycr-dirops.c
@@ -109,8 +109,11 @@ DIR* UNIFYCR_WRAP(opendir)(const char* name)
         return NULL;
     }
 
-    struct stat* sb = &gfattr.file_attr;
-    if (!S_ISDIR(sb->st_mode)) {
+    struct stat sb = { 0, };
+
+    unifycr_file_attr_to_stat(&gfattr, &sb);
+
+    if (!S_ISDIR(sb.st_mode)) {
         errno = ENOTDIR;
         return NULL;
     }
@@ -132,8 +135,8 @@ DIR* UNIFYCR_WRAP(opendir)(const char* name)
         /*
          * FIXME: also, is it safe to oeverride this local data?
          */
-        meta->size = sb->st_size;
-        meta->chunks = sb->st_blocks;
+        meta->size = sb.st_size;
+        meta->chunks = sb.st_blocks;
         meta->log_size = 0; /* no need of local storage for dir operations */
     } else {
         fid = unifycr_fid_create_file(name);
@@ -144,8 +147,8 @@ DIR* UNIFYCR_WRAP(opendir)(const char* name)
 
         meta = unifycr_get_meta_from_fid(fid);
         meta->is_dir   = 1;
-        meta->size     = sb->st_size;
-        meta->chunks   = sb->st_blocks;
+        meta->size     = sb.st_size;
+        meta->chunks   = sb.st_blocks;
         meta->log_size = 0;
     }
 

--- a/client/src/unifycr-fixed.c
+++ b/client/src/unifycr-fixed.c
@@ -389,7 +389,7 @@ static int unifycr_logio_chunk_write(
                                         sizeof(unifycr_file_attr_t),
                                         compare_fattr);
     if (ptr_meta_entry !=  NULL) {
-        ptr_meta_entry->file_attr.st_size = pos + count;
+        ptr_meta_entry->size = pos + count;
     }
 
     /* define an new index entry for this write operation */

--- a/client/src/unifycr-internal.h
+++ b/client/src/unifycr-internal.h
@@ -552,7 +552,7 @@ int unifycr_fid_unlink(int fid);
 int unifycr_generate_gfid(const char* path);
 
 int unifycr_set_global_file_meta(const char* path, int fid, int gfid,
-                                 struct stat* sb);
+                                 int isdir);
 
 int unifycr_get_global_file_meta(int fid, int gfid,
                                  unifycr_file_attr_t* gfattr);

--- a/common/src/unifycr_clientcalls_rpc.h
+++ b/common/src/unifycr_clientcalls_rpc.h
@@ -5,6 +5,7 @@
  * Declarations for client-server margo RPCs (shared-memory)
  */
 
+#include <time.h>
 #include <margo.h>
 #include <mercury.h>
 #include <mercury_proc_string.h>
@@ -44,14 +45,27 @@ MERCURY_GEN_PROC(unifycr_unmount_in_t,
 MERCURY_GEN_PROC(unifycr_unmount_out_t, ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifycr_unmount_rpc)
 
+typedef struct timespec sys_timespec_t;
+
+MERCURY_GEN_STRUCT_PROC(sys_timespec_t,
+                        ((uint64_t)(tv_sec))
+                        ((uint64_t)(tv_nsec)))
+
 /* unifycr_metaset_rpc (client => server)
  *
  * given a global file id and a file name,
  * record key/value entry for this file */
 MERCURY_GEN_PROC(unifycr_metaset_in_t,
+                 ((hg_const_string_t)(filename))
                  ((int32_t)(fid))
                  ((int32_t)(gfid))
-                 ((hg_const_string_t)(filename)))
+                 ((uint32_t)(mode))
+                 ((uint32_t)(uid))
+                 ((uint32_t)(gid))
+                 ((uint64_t)(size))
+                 ((sys_timespec_t)(atime))
+                 ((sys_timespec_t)(mtime))
+                 ((sys_timespec_t)(ctime)))
 MERCURY_GEN_PROC(unifycr_metaset_out_t, ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifycr_metaset_rpc)
 
@@ -62,9 +76,17 @@ DECLARE_MARGO_RPC_HANDLER(unifycr_metaset_rpc)
 MERCURY_GEN_PROC(unifycr_metaget_in_t,
                  ((int32_t)(gfid)))
 MERCURY_GEN_PROC(unifycr_metaget_out_t,
-                 ((hg_size_t)(st_size))
                  ((int32_t)(ret))
-                 ((hg_const_string_t)(filename)))
+                 ((hg_const_string_t)(filename))
+                 ((int32_t)(fid))
+                 ((int32_t)(gfid))
+                 ((uint32_t)(mode))
+                 ((uint32_t)(uid))
+                 ((uint32_t)(gid))
+                 ((uint64_t)(size))
+                 ((sys_timespec_t)(atime))
+                 ((sys_timespec_t)(mtime))
+                 ((sys_timespec_t)(ctime)))
 DECLARE_MARGO_RPC_HANDLER(unifycr_metaget_rpc)
 
 /* unifycr_fsync_rpc (client => server)

--- a/server/src/unifycr_cmd_handler.c
+++ b/server/src/unifycr_cmd_handler.c
@@ -501,9 +501,16 @@ static void unifycr_metaget_rpc(hg_handle_t handle)
 
     /* build our output values */
     unifycr_metaget_out_t out;
-    out.st_size  = attr_val.file_attr.st_size;
+    out.gfid = attr_val.gfid;
+    out.mode = attr_val.mode;
+    out.uid = attr_val.uid;
+    out.gid = attr_val.gid;
+    out.size = attr_val.size;
+    out.atime = attr_val.atime;
+    out.mtime = attr_val.mtime;
+    out.ctime = attr_val.ctime;
     out.filename = attr_val.filename;
-    out.ret      = ret;
+    out.ret = ret;
 
     /* send output back to caller */
     hg_return_t hret = margo_respond(handle, &out);
@@ -529,7 +536,14 @@ static void unifycr_metaset_rpc(hg_handle_t handle)
     memset(&fattr, 0, sizeof(fattr));
     fattr.gfid = in.gfid;
     strncpy(fattr.filename, in.filename, sizeof(fattr.filename));
-    /* TODO: unifycr_metaset_in_t is missing struct stat info */
+    fattr.mode = in.mode;
+    fattr.uid = in.uid;
+    fattr.gid = in.gid;
+    fattr.size = in.size;
+    fattr.atime = in.atime;
+    fattr.mtime = in.mtime;
+    fattr.ctime = in.ctime;
+
     ret = unifycr_set_file_attribute(&fattr);
 
     /* build our output values */


### PR DESCRIPTION
Instead of directly embedding the stat structure in unifycr_file_attr_t,
only necessary entries are directly included. The conversion between
unifycr_file_attr_t and stat is done by an inline function.

- common/src/unifycr_meta.h: new unifycr_file_attr_t and the conversion
  function.
- client/src/margo_client.[ch]: RPC serialization for extra members.
- server/src/unifycr_cmd_hanler.c: new server-side routine to handle the
  changes.
- other files: applying the modified unifycr_file_attr_t

Addressing #311 .

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
