### PR TITLE
Add --enable-fortran option

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -1,11 +1,19 @@
-lib_LTLIBRARIES = libunifycr.la libunifycr_gotcha.la libunifycrf.la
+lib_LTLIBRARIES = libunifycr.la libunifycr_gotcha.la
+
+if HAVE_FORTRAN
+lib_LTLIBRARIES += libunifycrf.la
+endif
 
 libunifycrdir = $(includedir)
 libunifycr_gotchadir = $(includedir)
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing
 
-include_HEADERS = unifycr.h unifycrf.h
+include_HEADERS = unifycr.h
+
+if HAVE_FORTRAN
+include_HEADERS += unifycrf.h
+endif
 
 CLIENT_COMMON_CPPFLAGS = \
   -I$(top_builddir)/client \
@@ -67,7 +75,11 @@ libunifycr_gotcha_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS) $(GOTCHA_CFLAGS)
 libunifycr_gotcha_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS) $(GOTCHA_LDFLAGS)
 libunifycr_gotcha_la_LIBADD   = $(CLIENT_COMMON_LIBADD) -lgotcha
 
+if HAVE_FORTRAN
+
 libunifycrf_la_SOURCES  = unifycrf.c
 libunifycrf_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS)
 libunifycrf_la_CFLAGS   = $(AM_CFLAGS) $(CLIENT_COMMON_CFLAGS)
 libunifycrf_la_LIBADD   = libunifycr_gotcha.la
+
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -26,9 +26,20 @@ AC_PROG_RANLIB
 AC_PROG_LIBTOOL
 
 # fortran support
+AC_ARG_ENABLE([fortran],
+              AC_HELP_STRING([--enable-fortran],
+                             [Enable fortran compatibility and features]))
+AC_MSG_CHECKING(if fortran is wanted )
+if test "x$enable_fortran" = "xyes"; then
+AC_MSG_RESULT(yes)
 AC_PROG_FC
 AC_FC_LIBRARY_LDFLAGS
 AC_FC_DUMMY_MAIN
+AM_CONDITIONAL([HAVE_FORTRAN], [true])
+else
+AC_MSG_RESULT(no)
+AM_CONDITIONAL([HAVE_FORTRAN], [false])
+fi
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_MODE_T
@@ -143,9 +154,11 @@ AC_CHECK_HEADERS(mntent.h sys/mount.h)
 
 # look for MPI and set flags
 LX_FIND_MPI
+if test "x$enable_fortran" = "xyes"; then
 AC_LANG_PUSH([Fortran])
 LX_FIND_MPI
 AC_LANG_POP
+fi
 
 # look for leveldb library, sets LEVELDB_CFLAGS/LDFLAGS/LIBS
 UNIFYCR_AC_LEVELDB

--- a/docs/api-mount.rst
+++ b/docs/api-mount.rst
@@ -7,8 +7,13 @@ In this section, we describe how to use the UnifyCR API in an application.
 .. Attention:: **Fortran Compatibility**
 
    ``unifycr_mount`` and ``unifycr_unmount`` are now usable  with GFortran.
-   There is a known issue_ with the Intel Fortran compiler. Other Fortran
-   compilers are currently unknown.
+   There is a known ifort_issue_ with the Intel Fortran compiler as well as an
+   xlf_issue_ with the IBM Fortran compiler. Other Fortran compilers are
+   currently unknown.
+
+   If using fortran, when :ref:`installing UnifyCR <build-label>` with Spack,
+   include the ``+fortran`` variant, or configure UnifyCR with the
+   ``--enable-fortran`` option if building manually.
 
 ---------------------------
 Mounting 
@@ -18,7 +23,6 @@ In ``C`` applications, include *unifycr.h*. See writeread.c_ for a full
 example.
 
 .. code-block:: C
-    :caption: C
 
         #include <unifycr.h>
 
@@ -26,7 +30,6 @@ In ``Fortran`` applications, include *unifycrf.h*. See writeread.f90_ for a
 full example.
 
 .. code-block:: Fortran
-    :caption: Fortran
 
         include 'unifycrf.h'
 
@@ -65,12 +68,13 @@ When you are finished using UnifyCR in your application, you should unmount.
 .. code-block:: Fortran
     :caption: Fortran
 
-        UNIFYCR_UNMOUNT(ierr);
+        call UNIFYCR_UNMOUNT(ierr);
 
 It is only necessary to call unmount once on rank zero.
 
 .. explicit external hyperlink targets
 
-.. _issue: https://github.com/LLNL/UnifyCR/issues/300
+.. _ifort_issue: https://github.com/LLNL/UnifyCR/issues/300
 .. _writeread.c: https://github.com/LLNL/UnifyCR/blob/dev/examples/src/writeread.c
 .. _writeread.f90: https://github.com/LLNL/UnifyCR/blob/dev/examples/src/writeread.f90
+.. _xlf_issue: https://github.com/LLNL/UnifyCR/issues/304

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -2,7 +2,7 @@ libexec_PROGRAMS = \
   cr-posix cr-gotcha cr-static \
   read-posix read-gotcha read-static \
   write-posix write-gotcha write-static \
-  writeread-posix writeread-gotcha writeread-static writeread-ftn \
+  writeread-posix writeread-gotcha writeread-static \
   sysio-write-gotcha sysio-write-static \
   sysio-read-gotcha sysio-read-static \
   sysio-writeread-gotcha sysio-writeread-static sysio-writeread-posix \
@@ -13,6 +13,11 @@ libexec_PROGRAMS = \
   app-mpiio-gotcha app-mpiio-static \
   app-btio-gotcha app-btio-static \
   app-tileio-gotcha app-tileio-static
+
+if HAVE_FORTRAN
+libexec_PROGRAMS += \
+  writeread-ftn
+endif
 
 if HAVE_HDF5
 libexec_PROGRAMS += \
@@ -32,11 +37,13 @@ noinst_HEADERS = \
 test_cppflags = $(AM_CPPFLAGS) $(MPI_CFLAGS) \
    -I$(top_srcdir)/client/src -I$(top_srcdir)/common/src
 
+if HAVE_FORTRAN
 test_ftn_flags   = $(AM_FCFLAGS) $(MPI_FFLAGS) \
    -I$(top_srcdir)/client/src -I$(top_srcdir)/common/src
 test_ftn_ldadd   = $(top_builddir)/client/src/libunifycrf.la -lrt -lm $(FCLIBS)
 test_ftn_ldflags = $(AM_LDFLAGS) $(MPI_FLDFLAGS) \
     $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
+endif
 
 test_gotcha_ldadd   = $(top_builddir)/client/src/libunifycr_gotcha.la -lrt -lm
 test_gotcha_ldflags = $(AM_LDFLAGS) $(MPI_CLDFLAGS) \
@@ -187,11 +194,6 @@ writeread_static_CPPFLAGS = $(test_cppflags)
 writeread_static_LDADD    = $(test_static_ldadd)
 writeread_static_LDFLAGS  = $(test_static_ldflags)
 
-writeread_ftn_SOURCES  = writeread.f90
-writeread_ftn_FCFLAGS  = $(test_ftn_flags)
-writeread_ftn_LDADD    = $(test_ftn_ldadd)
-writeread_ftn_LDFLAGS  = $(test_ftn_ldflags)
-
 app_mpiio_gotcha_SOURCES  = app-mpiio.c
 app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)
 app_mpiio_gotcha_LDADD    = $(test_gotcha_ldadd)
@@ -221,6 +223,15 @@ app_tileio_static_SOURCES  = app-tileio.c
 app_tileio_static_CPPFLAGS = $(test_cppflags)
 app_tileio_static_LDADD    = $(test_static_ldadd)
 app_tileio_static_LDFLAGS  = $(test_static_ldflags)
+
+if HAVE_FORTRAN
+
+writeread_ftn_SOURCES  = writeread.f90
+writeread_ftn_FCFLAGS  = $(test_ftn_flags)
+writeread_ftn_LDADD    = $(test_ftn_ldadd)
+writeread_ftn_LDFLAGS  = $(test_ftn_ldflags)
+
+endif
 
 if HAVE_HDF5
 


### PR DESCRIPTION
Require users to be proactive when they want to use fortran since we conflict with certain fortran compilers (#300, #304). This makes it easier to protect the user when installing with spack, especially with an incompatible fortran compiler.

Fixes: #313 

### Description
<!--- Describe your changes in detail -->
* _configure.ac_: Added `--enable-fortran` and only calls `AC_PROG_FC` and sets up mpif when enabled
* _client/src/Makefile.am_: only include library and header when fortran enabled
* _examples/src/Makefile.am_: only build fortran examples when fortran enabled
* _docs/api-mount.rst_: added note for users to include the fortran option if they want fortran

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Manually built with and without `--enable-fortran` and verified the associated files were included/excluded respectively. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.