### PR TITLE
Update env and deps in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,28 +2,60 @@ language: c
 sudo: required
 dist: xenial
 
+addons:
+  apt:
+    update: true
+    packages:
+      - autoconf
+      - automake
+      - build-essential
+      - cmake
+      - gfortran
+      - libhdf5-openmpi-dev
+      - libopenmpi-dev
+      - libtool-bin
+      - m4
+      - openmpi-bin
+
 before_install:
   # The default environment variable $CC is known to interfere with
   # MPI projects.
   - test -n $CC && unset CC
-  - sudo apt-get -qq update
-  - sudo apt-get install --yes -qq build-essential autoconf libtool cmake
-  - sudo apt-get install --yes -qq gfortran
-  - sudo apt-get install --yes -qq libopenmpi-dev openmpi-bin
-  - sudo apt-get install --yes -qq libhdf5-openmpi-dev
   - (cd $HOME/spack; git describe) || git clone https://github.com/spack/spack $HOME/spack
+  # Create packages.yaml to prevent building dependencies that time out
+  - |
+    test -f $HOME/spack/etc/spack/packages.yaml || cat > $HOME/spack/etc/spack/packages.yaml << '  EOF'
+    packages:
+      autoconf:
+        buildable: False
+        paths:
+          autoconf@2.69: /usr
+      automake:
+        buildable: False
+        paths:
+          automake@1.15: /usr
+      cmake:
+        buildable: False
+        paths:
+            cmake@3.12.4: /usr/local/cmake-3.12.4
+      libtool:
+        buildable: False
+        paths:
+          libtool@2.4.6: /usr
+      m4:
+        buildable: False
+        paths:
+          m4@4.17: /usr
+    EOF
+
+install:
   - $HOME/spack/bin/spack install environment-modules
-  - $HOME/spack/bin/spack install leveldb
-  - $HOME/spack/bin/spack install gotcha@0.0.2
-  - $HOME/spack/bin/spack install flatcc
-  # insall margo with spack
-  - git config --global http.sslVerify false
-  - git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git $HOME/sds-repo.git
-  - $HOME/spack/bin/spack repo add $HOME/sds-repo.git
-  - $HOME/spack/bin/spack install margo@develop
-  - git config --global http.sslVerify true
-  # prepare build environment
   - . $HOME/spack/share/spack/setup-env.sh
+  - spack install leveldb
+  - spack install gotcha@0.0.2
+  - spack install flatcc
+  - spack install margo^mercury~boostsys
+  # prepare build environment
   - spack load environment-modules
   - source <(spack module tcl loads leveldb gotcha@0.0.2 flatcc mercury argobots margo)
   - eval $(./scripts/git_log_test_env.sh)
@@ -41,7 +73,7 @@ script:
   # Force git to update the shallow clone and include tags so git-describe works
   - git fetch --unshallow --tags
   - sh autogen.sh
-  - ./configure || cat config.log
+  - ./configure --enable-fortran || cat config.log
   - make -k && make distcheck
   - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes
 

--- a/docs/build-intercept.rst
+++ b/docs/build-intercept.rst
@@ -12,7 +12,7 @@ In this section, we describe how to build UnifyCR with I/O interception.
     "An MPI distribution that supports MPI_THREAD_MULTIPLE and per-object locking of
     critical sections (this excludes OpenMPI up to version 3.0.1, the current version as of this writing)"
 
-    as specified in the project `github <https://github.com/mdhim/mdhim-tng>`_
+    as specified in the project `github <https://github.com/mdhim/mdhim-tng>`_.
 
 .. _build-label:
 
@@ -34,12 +34,22 @@ or LMod installed then installing the environment-modules package with spack
 is unnecessary (so you can safely skip that step).
 
 If you use Dotkit then replace ``spack load`` with ``spack use``.
+First, install Spack if you don't already have it:
 
 .. code-block:: Bash
 
     $ git clone https://github.com/spack/spack
     $ ./spack/bin/spack install environment-modules
     $ . spack/share/spack/setup-env.sh
+
+Make use of Spack's `shell support <https://spack.readthedocs.io/en/latest/getting_started.html#add-spack-to-the-shell>`_
+to automatically add Spack to your ``PATH`` and allow the use of the ``spack``
+command.
+
+Then install UnifyCR:
+
+.. code-block:: Bash
+
     $ spack install unifycr
     $ spack load unifycr
 
@@ -52,15 +62,17 @@ build is desired. Type ``spack info unifycr`` for more info.
 .. table:: UnifyCR Build Variants
    :widths: auto
 
-   =======  ========================================  ========================
+   =======  ========================================  =========================
    Variant  Command                                   Description
-   =======  ========================================  ========================
-   Debug    ``spack install unifycr+debug``           Enable debug build
+   =======  ========================================  =========================
    HDF5     ``spack install unifycr+hdf5``            Build with parallel HDF5
 
             ``spack install unifycr+hdf5 ^hdf5~mpi``  Build with serial HDF5
+   Fortran  ``spack install unifycr+fortran``         Build with gfortran
    NUMA     ``spack install unifycr+numa``            Build with NUMA
-   =======  ========================================  ========================
+   pmpi     ``spack install unifycr+pmpi``            Transparent mount/unmount
+   PMIx     ``spack install unifycr+pmix``            Enable PMIx build options
+   =======  ========================================  =========================
 
 .. attention::
 
@@ -96,17 +108,9 @@ If you use Dotkit then replace ``spack load`` with ``spack use``.
 
 .. code-block:: Bash
 
-    $ spack install environment-modules
-    $
     $ spack install leveldb
     $ spack install gotcha@0.0.2
     $ spack install flatcc
-    $ 
-    $ git clone https://xgitlab.cels.anl.gov/sds/sds-repo.git sds-repo.git
-    $ cd sds-repo.git
-    $ spack repo add .
-    $ cd ..
-    $
     $ spack install margo
 
 .. tip::
@@ -130,9 +134,26 @@ Then to build UnifyCR:
     $ spack load margo
     $
     $ ./autogen.sh
-    $ ./configure --prefix=/path/to/install --enable-debug
+    $ ./configure --prefix=/path/to/install
     $ make
     $ make install
+
+.. note:: **Fortran Compatibility**
+
+    To build with gfortran compatibility, include the ``--enable-fortran``
+    configure option:
+
+    ``./configure --prefix=/path/to/install/ --enable-fortran``
+
+    There is a known `ifort_issue <https://github.com/LLNL/UnifyCR/issues/300>`_
+    with the Intel Fortran compiler as well as an `xlf_issue <://github.com/LLNL/UnifyCR/issues/304>`_
+    with the IBM Fortran compiler. Other Fortran compilers are currently
+    unknown.
+
+To see all available build configuration options, type ``./configure --help``
+after ``./autogen.sh`` has been run.
+
+.. TODO: Add a section in build docs that shows all the build config options
 
 Build the Dependencies without Spack
 """""""""""""""""""""""""""""""""""""
@@ -162,7 +183,7 @@ Then to build UnifyCR:
 
     $ export PKG_CONFIG_PATH=path/to/mercury/lib/pkgconfig:path/to/argobots/lib/pkgconfig:path/to/margo/lib/pkgconfig
     $ ./autogen.sh
-    $ ./configure --prefix=/path/to/install --enable-debug --with-gotcha=/path/to/gotcha --with-leveldb=/path/to/leveldb  --with-flatcc=/path/to/flatcc
+    $ ./configure --prefix=/path/to/install --with-gotcha=/path/to/gotcha --with-leveldb=/path/to/leveldb  --with-flatcc=/path/to/flatcc
     $ make
     $ make install
 


### PR DESCRIPTION
This changes how required packages are set up in Travis so they do not fail as part of the before_install stage. Also changes spack setup and gets rid of the external sds-repo since margo is now upstream in spack.

Also, mercury has now been fixed to build internal headers if not using boost. When it needed boost, travis would time out since the build would take too long. Thus this also creates a packages.yml so that spack doesn't build any dependencies that the travis environment already has and take a long time to build (i.e., cmake, perl, etc). This reduces a fresh (nothing in cache) travis build from ±35 minutes to ±10 minutes.

Also updates the docs to account for any related changes to how a user might build.

#### Note:
These changes required the travis cache be cleared. Other PRs without these changes might time out as they may attempt to build boost. They should pass again once this has been merged.

### Description
<!--- Describe your changes in detail -->
* Changed how packages are installed to the built-in travis method
* Created a packages.yml to account for dependencies travis already has and to speed up build
* Cleaned up how spack is set up
* Configure with the `--enable-fortran` option that was added in #314 
* Update build docs

#### Note for future reference:
In the event that we do want to test with boost enabled for mercury, it can be supplied by the travis environment and added to the packages.yml so that spack doesn't have to build it.

To do this, add a travis trusted boost source (using `sourceline:` [[reference](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-with-the-apt-addon)]) under `addons:` and `apt:`:
```
addons:
  apt:
    update: true
    sources:
      - sourceline: 'ppa:mhier/libboost-latest'
    packages:
      ⋮
```
and under packages, add which boost it is:
```
packages:
  ⋮
  - boost.1.68
  ⋮
```
Then in the packages.yml, add:
```
packages:
  ⋮
  boost:
    buildable: False
    paths:
      boost@1.68: /usr
  ⋮
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The sds-repo spack packages are now upstream in spack so we can remove our dependency on that repo.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested with forked repo's travis [(here](https://travis-ci.org/CamStan/UnifyCR/builds/530526384))

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.