### PR TITLE
Add missing fattrs to input struct in client metaset rpc

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -260,8 +260,13 @@ int invoke_client_metaset_rpc(unifycr_file_attr_t* f_meta)
     in.fid      = f_meta->fid;
     in.gfid     = f_meta->gfid;
     in.filename = f_meta->filename;
-    /* TODO: unifycr_metaset_in_t is missing struct stat info
-     * in->file_attr = f_meta->file_attr; */
+    in.mode     = f_meta->mode;
+    in.uid      = f_meta->uid;
+    in.gid      = f_meta->gid;
+    in.size     = f_meta->size;
+    in.atime    = f_meta->atime;
+    in.mtime    = f_meta->mtime;
+    in.ctime    = f_meta->ctime;
 
     LOGDBG("invoking the metaset rpc function in client");
     hret = margo_forward(handle, &in);


### PR DESCRIPTION
### Description
This adds fattrs to the input struct in the client metaset rpc so that when other ranks aside from rank 0 get the global file size, it is accurate.

See #324 for full description.

### How Has This Been Tested?
By running the examples in multiple ways as described in issue #324.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)