### PR TITLE
Initialize uid and gid when creating a file

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -750,6 +750,9 @@ void unifycr_init_file_attr(unifycr_file_attr_t* fattr, int isdir)
 
         fattr->mode = isdir ? UNIFYCR_STAT_DEFAULT_DIR_MODE
                             : UNIFYCR_STAT_DEFAULT_FILE_MODE;
+
+        fattr->uid = getuid();
+        fattr->gid = getgid();
     }
 }
 


### PR DESCRIPTION
### Description
Initializes the uid and gid metadata for a newly created file based on the system uid and gid.

### How Has This Been Tested?
Walked through with totalview and verified the file's uid and gid were set to the correct values before calling `invoke_client_metaset_rpc` and that the correct values were retrieved from the global metadata by a non-rank 0 process when calling `invoke_client_metaget_rpc`.

Fixes: #326 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.