### PR TITLE
unifycr_shm_alloc does not include config.h

### DIFF
--- a/common/src/unifycr_shm.c
+++ b/common/src/unifycr_shm.c
@@ -11,6 +11,7 @@
  * For details, see https://github.com/LLNL/UnifyCR.
  * Please read https://github.com/LLNL/UnifyCR/LICENSE for full license text.
  */
+#include <config.h>
 
 #include <unistd.h>
 #include <stdlib.h>


### PR DESCRIPTION
This results in HAVE_POSIX_FALLOCATE constant ignored.

- including <config.h> in common/src/unifycr_shm.c

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
