### PR TITLE
clean up app-mpiio example

### DIFF
--- a/client/src/unifycr.c
+++ b/client/src/unifycr.c
@@ -2513,6 +2513,8 @@ int unifycr_mount(const char prefix[], int rank, size_t size,
     }
 
     // initialize k-v store access
+    kv_rank = client_rank;
+    kv_nranks = size;
     rc = unifycr_keyval_init(&client_cfg, &kv_rank, &kv_nranks);
     if (rc) {
         LOGERR("failed to update configuration from runstate.");

--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -30,23 +30,32 @@
 
 #include "testlib.h"
 
-static uint64_t blocksize = 1 << 20;        /* 1MB */
-static uint64_t nblocks = 128;              /* Each process writes 128MB */
-static uint64_t chunksize = 64 * (1 << 10); /* 64KB for each write(2) call */
+#ifndef KIB
+# define KIB (1 << 10)
+#endif
 
-static int type;            /* 0 for write (default), 1 for read */
-static int pattern;         /* N to 1 (N1, default) or N to N (NN) */
+#ifndef MIB
+# define MIB (1 << 20)
+#endif
+
+static size_t blocksize = MIB;      /* 1 MiB */
+static size_t nblocks   = 128;      /* Each process writes 128 MiB */
+static size_t chunksize = 64 * KIB; /* 64 KiB for each write() call */
+
+static int standard; /* do not use UnifyCR when set */
+static int type;     /* 0 for write (default), 1 for read */
+static int iomode = MPI_MODE_CREATE | MPI_MODE_RDWR;
+static int pattern = IO_PATTERN_N1;
+
 static MPI_File fh;         /* MPI file handle */
 static MPI_Status status;   /* MPI I/O status */
-static int iomode = MPI_MODE_CREATE | MPI_MODE_RDWR;
 
-static int standard;        /* not mounting unifycr when set */
 
 /* time statistics */
 static struct timeval iostart, ioend;
 
-#define BUFSIZE 128
-static char hostname[BUFSIZE];
+#define HOSTBUFSZ 128
+static char hostname[HOSTBUFSZ];
 static int rank;
 static int total_ranks;
 
@@ -69,15 +78,17 @@ static inline void mpi_handle_error(int err, char* str)
 
     MPI_Error_string(err, msg, &len);
     fprintf(stderr, "[%s:%d] %s: %s\n", hostname, rank, str, msg);
+    fflush(NULL);
 
     mpierror = 1;
 }
 
-#define MPI_CHECK(fn) do {                                      \
-            int err = (fn);                                     \
-            if (err != MPI_SUCCESS)                             \
-                mpi_handle_error(err, #fn);                     \
-        } while (0)
+#define MPI_CHECK(fn) \
+    do {                                   \
+        int err = (fn);                    \
+        if (err != MPI_SUCCESS)            \
+            mpi_handle_error(err, #fn);    \
+    } while (0)
 
 static int read_test_type(const char* str)
 {
@@ -166,17 +177,17 @@ static void report_result(void)
     double max_io_time = .0F;
     double min_io_bw = .0F;
     double io_time = .0F;
+    double per_rank_mib = (1.0 * blocksize * nblocks) / MIB;
 
     io_time = timediff_sec(&iostart, &ioend);
-    io_bw = 1.0 * blocksize * nblocks / io_time / (1 << 20);
+    io_bw = per_rank_mib / io_time;
 
     MPI_Reduce(&io_bw, &agg_io_bw,
                1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
     MPI_Reduce(&io_time, &max_io_time,
                1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
 
-    min_io_bw = 1.0 * blocksize * nblocks * total_ranks /
-        max_io_time / (1 << 20);
+    min_io_bw = (per_rank_mib * total_ranks) / max_io_time;
 
     errno = 0;
 
@@ -184,17 +195,17 @@ static void report_result(void)
                     "\n"
                     "Number of processes:     %d\n"
                     "I/O type:                %s\n"
-                    "Each process performed:  %lf MB\n"
-                    "Total I/O size:          %lf MB\n"
+                    "Each process performed:  %zu MiB\n"
+                    "Total I/O size:          %zu MiB\n"
                     "I/O pattern:             %s\n"
                     "I/O request size:        %llu B\n"
-                    "Aggregate I/O bandwidth: %lf MB/s\n"
-                    "Min. I/O bandwidth:      %lf MB/s\n"
+                    "Aggregate I/O bandwidth: %lf MiB/s\n"
+                    "Min. I/O bandwidth:      %lf MiB/s\n"
                     "Total I/O time:          %lf sec.\n",
                     total_ranks,
                     type ? "read" : "write",
-                    1.0 * blocksize * nblocks / (1 << 20),
-                    1.0 * total_ranks * blocksize * nblocks / (1 << 20),
+                    blocksize * nblocks / MIB,
+                    total_ranks * blocksize * nblocks / MIB,
                     io_pattern_string(pattern),
                     chunksize,
                     agg_io_bw,
@@ -210,14 +221,13 @@ static struct option const long_opts[] = {
     { "filename", 1, 0, 'f' },
     { "help", 0, 0, 'h' },
     { "mount", 1, 0, 'm' },
-    { "pattern", 1, 0, 'p' },
     { "standard", 0, 0, 's' },
     { "type", 1, 0, 't' },
     { "unmount", 0, 0, 'u' },
     { 0, 0, 0, 0},
 };
 
-static char* short_opts = "b:n:c:df:hm:p:Pst:u";
+static char* short_opts = "b:n:c:df:hm:Pst:u";
 
 static const char* usage_str =
     "\n"
@@ -225,18 +235,17 @@ static const char* usage_str =
     "\n"
     "Available options:\n"
     " -b, --blocksize=<size in bytes>  logical block size for the target file\n"
-    "                                  (default 1048576, 1MB)\n"
+    "                                  (default 1 MiB)\n"
     " -n, --nblocks=<count>            count of blocks each process will write\n"
     "                                  (default 128)\n"
     " -c, --chunksize=<size in bytes>  I/O chunk size for each write operation\n"
-    "                                  (default 64436, 64KB)\n"
+    "                                  (default 64 KiB)\n"
     " -d, --debug                      pause before running test\n"
     "                                  (handy for attaching in debugger)\n"
     " -f, --filename=<filename>        target file name (default: testfile)\n"
     " -h, --help                       help message\n"
     " -m, --mount=<mountpoint>         use <mountpoint> for unifycr\n"
     "                                  (default: /unifycr)\n"
-    " -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)\n"
     " -s, --standard                   do not use unifycr but run standard I/O\n"
     " -t, --type=<write|read>          I/O type\n"
     "                                  should be 'write' (default) or 'read'\n"
@@ -263,7 +272,7 @@ int main(int argc, char* argv[])
     MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-    gethostname(hostname, BUFSIZE);
+    gethostname(hostname, HOSTBUFSZ);
 
     while ((ch = getopt_long(argc, argv,
                              short_opts, long_opts, &optidx)) >= 0) {
@@ -286,10 +295,6 @@ int main(int argc, char* argv[])
 
         case 'd':
             debug = 1;
-            break;
-
-        case 'p':
-            pattern = read_io_pattern(optarg);
             break;
 
         case 'm':
@@ -326,58 +331,54 @@ int main(int argc, char* argv[])
         exit(-1);
     }
 
-    if (chunksize % (1 << 10) > 0) {
+    if ((chunksize % KIB) > 0) {
         test_print_once(rank, "chunksize and blocksize should be divisible "
                         "by 1024.");
         exit(-1);
     }
 
-    if (static_linked(program) && standard) {
-        test_print_once(rank, "--standard, -s option only works when "
-                        "dynamically linked.");
-        exit(-1);
-    }
-
-    sprintf(targetfile, "%s/%s", mountpoint, filename);
-
-    if (debug) {
-        test_pause(rank, "Attempting to mount");
-    }
-
     if (!standard) {
+        if (debug) {
+            test_pause(rank, "Attempting to mount");
+        }
         ret = unifycr_mount(mountpoint, rank, total_ranks, 0);
         if (ret) {
             test_print(rank, "unifycr_mount failed (return = %d)", ret);
             exit(-1);
         }
+        if (!standard) {
+            printf("[%d]: unifycr mounted at %s\n", rank, mountpoint);
+        }
     }
 
-    buf = calloc(1, chunksize);
-    if (!buf) {
-        test_print(rank, "calloc failed");
-        exit(-1);
-    }
-
+    sprintf(targetfile, "%s/%s", mountpoint, filename);
     if (pattern == IO_PATTERN_NN) {
-        sprintf(&targetfile[strlen(targetfile)], "-%d", rank);
+        sprintf((targetfile + strlen(targetfile)), "-%d", rank);
     }
-
-    if (!standard) {
-        printf("[%d]: unifycr mounted at %s\n", rank, mountpoint);
-    }
+    printf("[%d]: opening %s\n", rank, targetfile);
+    fflush(NULL);
 
     MPI_Barrier(MPI_COMM_WORLD);
-
-    printf("[%d]: opening %s\n", rank, targetfile);
 
     MPI_CHECK(MPI_File_open(MPI_COMM_WORLD,
                             targetfile,
                             iomode,
                             MPI_INFO_NULL, &fh));
 
+    if (mpierror) {
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
     if (debug) {
         test_pause(rank, "Attempting to perform I/O");
     }
+
+    buf = calloc(1, chunksize);
+    if (NULL == buf) {
+        test_print(rank, "calloc failed");
+        MPI_Abort(MPI_COMM_WORLD, 1);
+    }
+    int printable = (int)'0' + (rank % 10);
+    memset(buf, printable, chunksize);
 
     if (type == 0) {
         ret = do_write(&fh);
@@ -389,17 +390,15 @@ int main(int argc, char* argv[])
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (!standard && unmount) {
-        unifycr_unmount();
-    }
+    free(buf);
 
     if (ret == 0) {
         report_result();
-    } else {
-        MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
-    free(buf);
+    if (!standard && unmount) {
+        unifycr_unmount();
+    }
 
     MPI_Finalize();
 


### PR DESCRIPTION
### Description

Most noteworthy change is removal of the '-p|--pattern'
option, since `MPI_File_open()` is collective and does not
support N-to-N.

Also includes a minor bugfix to avoid a client warning message
about keyval rank mismatch.

### How Has This Been Tested?

This gets the example working on Summitdev in '-s|--standard' mode
(i.e., not using UnifyCR). When using UnifyCR, `MPI_File_open()`
returns `MPI_ERR_NO_SUCH_FILE`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
