### PR TITLE
Add bootstrap.sh, fix build errors on GCC 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ t/sys/open.t
 t/test-results/
 t/unifycr_unmount.t
 t/test_run_env.sh
+deps
+install

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#
+# This is an easy-bake script to download and build all UnifyCR's dependencies.
+#
+
+ROOT="$(pwd)"
+
+mkdir -p deps
+mkdir -p install
+INSTALL_DIR=$ROOT/install
+
+cd deps
+
+repos=(	git://git.mcs.anl.gov/bmi
+	https://github.com/google/leveldb.git
+	https://github.com/LLNL/GOTCHA.git
+	https://github.com/pmodels/argobots.git
+	https://github.com/mercury-hpc/mercury.git
+	https://xgitlab.cels.anl.gov/sds/margo.git
+	https://github.com/dvidelabs/flatcc.git
+)
+
+for i in "${repos[@]}" ; do
+	# Get just the name of the project (like "mercury")
+	name=$(basename $i | sed 's/\.git//g')
+	if [ -d $name ] ; then
+		echo "$name already exists, skipping it"
+	else
+		if [ "$name" == "mercury" ] ; then
+			git clone --recurse-submodules $i
+		else
+			git clone $i
+		fi
+	fi
+done
+
+echo "### building bmi ###"
+cd bmi
+./prepare && ./configure --enable-shared --enable-bmi-only \
+	--prefix="$INSTALL_DIR"
+make -j $(nproc) && make install
+cd ..
+
+echo "### building leveldb ###"
+cd leveldb
+mkdir -p build && cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+	-DBUILD_SHARED_LIBS=yes ..
+make -j $(nproc) && make install
+cd ..
+cd ..
+
+echo "### building GOTCHA ###"
+cd GOTCHA
+# Unify won't build against latest GOTCHA, so use a known compatible version.
+git checkout 0.0.2
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ..
+make -j $(nproc) && make install
+cd ..
+cd ..
+
+echo "### building argobots ###"
+cd argobots
+./autogen.sh && ./configure --prefix="$INSTALL_DIR"
+make -j $(nproc) && make install
+cd ..
+
+echo "### building mercury ###"
+cd mercury
+mkdir -p build && cd build
+cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DMERCURY_USE_BOOST_PP=ON \
+	-DBUILD_SHARED_LIBS=on ..
+make -j $(nproc) && make install
+cd ..
+cd ..
+
+echo "### building margo ###"
+cd margo
+export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig"
+./prepare.sh
+./configure --prefix="$INSTALL_DIR"
+make -j $(nproc) && make install
+cd ..
+
+echo "### building flatcc ###"
+cd flatcc
+# need -DBUILD_SHARED_LIBS=ye
+mkdir -p build && cd build
+cmake -DBUILD_SHARED_LIBS=on -DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DFLATCC_INSTALL=on ..
+make -j $(nproc) && make install
+cd ..
+cd ..
+
+cd "$ROOT"
+
+echo "*************************************************************************"
+echo "Dependencies are all built.  You can now build Unify with:"
+echo ""
+echo "  export PKG_CONFIG_PATH=$INSTALL_DIR/lib/pkgconfig"
+echo "  ./autogen.sh && ./configure --with-leveldb=$INSTALL_DIR" \
+	"--with-gotcha=$INSTALL_DIR --with-flatcc=$INSTALL_DIR"
+echo "  make"
+echo ""
+echo "*************************************************************************"

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,10 @@ LX_FIND_MPI
 AC_LANG_POP
 fi
 
+if test "$have_C_mpi" != "yes" ; then
+    AC_MSG_ERROR(["Couldn't find MPI"])
+fi
+
 # look for leveldb library, sets LEVELDB_CFLAGS/LDFLAGS/LIBS
 UNIFYCR_AC_LEVELDB
 

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -22,6 +22,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <dirent.h>

--- a/m4/leveldb.m4
+++ b/m4/leveldb.m4
@@ -6,7 +6,7 @@ AC_DEFUN([UNIFYCR_AC_LEVELDB], [
   AC_ARG_WITH([leveldb], [AC_HELP_STRING([--with-leveldb=PATH],
     [path to installed libleveldb [default=/usr/local]])], [
     LEVELDB_CFLAGS="-I${withval}/include"
-    LEVELDB_LDFLAGS="-L${withval}/lib"
+    LEVELDB_LDFLAGS="-L${withval}/lib -L${withval}/lib64"
     CFLAGS="$CFLAGS ${LEVELDB_CFLAGS}"
     LDFLAGS="$LDFLAGS ${LEVELDB_LDFLAGS}"
   ], [])

--- a/m4/lx_find_mpi.m4
+++ b/m4/lx_find_mpi.m4
@@ -155,7 +155,7 @@ AC_DEFUN([LX_QUERY_MPI_COMPILER],
          # set a shell variable that the caller can test outside this macro
          have_$3_mpi='yes'
      else
-         Echo Unable to find suitable MPI Compiler. Try setting $1.
+         echo Unable to find suitable MPI Compiler. Try setting $1.
          have_$3_mpi='no'
      fi
 ])


### PR DESCRIPTION
### Description
- Add bootstrap.sh to automatically download and build depedencies
- Fix some build errors on GCC 9
- Fail in configure when MPI is not detected

Use `bootstrap.sh` to download and build all UnifyCR's dependencies.  The dependencies are built in `UnifyCR/deps`, and their headers, libs, and binaries are installed to `UnifyCR/install`.   After the dependencies are built, the script prints something like this:
```
*******************************************************************************
Dependencies are all built.  You can now build Unify with:

  export PKG_CONFIG_PATH=/home/hutter/UnifyCR/install/lib/pkgconfig
  ./configure --with-leveldb=/home/hutter/UnifyCR/install --with-gotcha=/home/hutter/UnifyCR/install --with-flatcc=/home/hutter/UnifyCR/install
  make

*******************************************************************************
```

### Motivation and Context
Easily get UnifyCR built on a spack-less system.  Fix GCC 9 build errors.  This doesn't fix the build warnings though, since they're numerous and can be addressed in a separate PR.

### How Has This Been Tested?
Ran `bootstrap.sh` and built Unify on Fedora 30.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
