### PR TITLE
Add continuous integration testing suite

### DIFF
--- a/docs/api-mount.rst
+++ b/docs/api-mount.rst
@@ -24,14 +24,14 @@ example.
 
 .. code-block:: C
 
-        #include <unifycr.h>
+    #include <unifycr.h>
 
 In ``Fortran`` applications, include *unifycrf.h*. See writeread.f90_ for a
 full example.
 
 .. code-block:: Fortran
 
-        include 'unifycrf.h'
+    include 'unifycrf.h'
 
 To use the UnifyCR filesystem a user will have to provide a path prefix. All 
 file operations under the path prefix will be intercepted by the UnifyCR 
@@ -41,12 +41,12 @@ filesystem. For instance, to use UnifyCR on all path prefixes that begin with
 .. code-block:: C
     :caption: C
 
-        unifycr_mount('/tmp', rank, rank_num, 0);
+    unifycr_mount('/tmp', rank, rank_num, 0);
 
 .. code-block:: Fortran
     :caption: Fortran
 
-        call UNIFYCR_MOUNT('/tmp', rank, size, 0, ierr);
+    call UNIFYCR_MOUNT('/tmp', rank, size, 0, ierr);
 
 Where /tmp is the path prefix you want UnifyCR to intercept. The rank and rank 
 number is the rank you are currently on, and the number of tasks you have 
@@ -61,14 +61,14 @@ When you are finished using UnifyCR in your application, you should unmount.
 .. code-block:: C
     :caption: C
 
-        if (rank == 0) {
-            unifycr_unmount();
-        }
+    if (rank == 0) {
+        unifycr_unmount();
+    }
 
 .. code-block:: Fortran
     :caption: Fortran
 
-        call UNIFYCR_UNMOUNT(ierr);
+    call UNIFYCR_UNMOUNT(ierr);
 
 It is only necessary to call unmount once on rank zero.
 

--- a/docs/build-intercept.rst
+++ b/docs/build-intercept.rst
@@ -71,6 +71,7 @@ build is desired. Type ``spack info unifycr`` for more info.
    Fortran  ``spack install unifycr+fortran``         Build with gfortran
    NUMA     ``spack install unifycr+numa``            Build with NUMA
    pmpi     ``spack install unifycr+pmpi``            Transparent mount/unmount
+   PMI      ``spack install unifycr+pmi``             Enable PMI2 build options
    PMIx     ``spack install unifycr+pmix``            Enable PMIx build options
    =======  ========================================  =========================
 
@@ -97,6 +98,8 @@ Building the Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 UnifyCR requires MPI, LevelDB, and GOTCHA(version 0.0.2).
+
+.. _spack-build-label:
 
 Build the Dependencies with Spack
 """"""""""""""""""""""""""""""""""

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -76,6 +76,8 @@ in the *examples/src* directory and the GOTCHA example programs in the
 
 ------------
 
+.. _run-ex-label:
+
 Running the Examples
 ====================
 
@@ -88,41 +90,53 @@ to aid in this process.
 
 .. code-block:: none
 
-    [prompt]$ ./sysio-write-static --help
+    [prompt]$ ./write-static --help
 
-    Usage: sysio-write-static [options...]
+    Usage: write-static [options...]
 
     Available options:
-     -b, --blocksize=<size in bytes>  logical block size for the target file
-                                      (default 1048576, 1MB)
-     -n, --nblocks=<count>            count of blocks each process will write
-                                      (default 128)
-     -c, --chunksize=<size in bytes>  I/O chunk size for each write operation
-                                      (default 64436, 64KB)
-     -d, --debug                      pause before running test
-                                      (handy for attaching in debugger)
-     -f, --filename=<filename>        target file name under mountpoint
-                                      (default: testfile)
-     -h, --help                       help message
-     -L, --lipsum                     generate contents to verify correctness
-     -m, --mount=<mountpoint>         use <mountpoint> for unifycr
-                                      (default: /unifycr)
-     -P, --pwrite                     use pwrite(2) instead of write(2)
-     -p, --pattern=<pattern>          should be 'n1'(n to 1) or 'nn' (n to n)
-                                      (default: n1)
-     -S, --synchronous                sync metadata on each write
-     -s, --standard                   do not use unifycr but run standard I/O
-     -u, --unmount                    unmount the filesystem after test
-
-Notice the mountpoint is defaulted to ``-mount=/unifycr``. If you chose a
-different mountpoint during :doc:`start-stop`, the ``-m`` option for the
-example will need to be provided to match.
+     -a, --appid=<id>          use given application id
+                               (default: 0)
+     -A, --aio                 use asynchronous I/O instead of read|write
+                               (default: off)
+     -b, --blocksize=<bytes>   I/O block size
+                               (default: 16 MiB)
+     -c, --chunksize=<bytes>   I/O chunk size for each operation
+                               (default: 1 MiB)
+     -d, --debug               for debugging, wait for input (at rank 0) at start
+                               (default: off)
+     -f, --file=<filename>     target file name (or path) under mountpoint
+                               (default: 'testfile')
+     -k, --check               check data contents upon read
+                               (default: off)
+     -L, --listio              use lio_listio instead of read|write
+                               (default: off)
+     -m, --mount=<mountpoint>  use <mountpoint> for unifycr
+                               (default: /unifycr)
+     -M, --mapio               use mmap instead of read|write
+                               (default: off)
+     -n, --nblocks=<count>     count of blocks each process will read|write
+                               (default: 32)
+     -p, --pattern=<pattern>   'n1' (N-to-1 shared file) or 'nn' (N-to-N file per process)
+                               (default: 'n1')
+     -P, --prdwr               use pread|pwrite instead of read|write
+                               (default: off)
+     -S, --stdio               use fread|fwrite instead of read|write
+                               (default: off)
+     -U, --disable-unifycr     do not use UnifyCR
+                               (default: enable UnifyCR)
+     -v, --verbose             print verbose information
+                               (default: off)
+     -V, --vecio               use readv|writev instead of read|write
+                               (default: off)
+     -x, --shuffle             read different data than written
+                               (default: off)
 
 One form of running this example could be:
 
 .. code-block:: Bash
 
-    $ srun -N4 -n4 sysio-write-static -m /myMountPoint -f myTestFile
+    $ srun -N4 -n4 write-static -m /myMountPoint -f myTestFile
 
 .. explicit external hyperlink targets
 

--- a/t/README.md
+++ b/t/README.md
@@ -1,4 +1,30 @@
-#Testing
+# Testing
+
+UnifyCR's unit testing and continuous integration testing suites.
 
 Our [Testing Guide](https://unifycr.readthedocs.io/en/dev/testing.html) has our
 complete testing documentation.
+
+## Unit Tests
+
+The UnifyCR Unit Test Suite uses the Test Anything Protocol (TAP) and the
+Automake test harness. By convention, test scripts and programs that output TAP
+are named with a “.t” extension.
+
+Test cases in shell scripts are implemented with
+[sharness](https://github.com/chriscool/sharness), which is included in
+the UnifyCR source distribution. See the file `sharness.sh` for all available
+test interfaces. UnifyCR-specific sharness code is implemented in scripts in the
+directory `sharness.d/`. Scripts in `sharness.d/` are primarily used to set
+environment variables and define convenience functions.  All scripts in
+`sharness.d/` are automatically included when your script sources `sharness.sh`.
+
+C programs use the [libtap library](https://github.com/zorgnax/libtap)
+to implement test cases. Convenience functions common to test cases written in
+C are implemmented in the library `lib/testutil.c`.
+
+## Continuous Integration Tests
+
+The UnifyCR Continuous Integration (CI) Test Suite is found in `ci/` and also uses [sharness](https://github.com/chriscool/sharness).
+Additional sharness convenience functions and variables needed for the CI tests
+are also found in `ci/` and are sourced when running `ci/001-setup.sh`.

--- a/t/ci/001-setup.sh
+++ b/t/ci/001-setup.sh
@@ -1,0 +1,252 @@
+#!/bin/sh
+
+# This script checks for an installation of UnifyCR (either with Spack or in
+# $HOME/UnifyCR/install) and then sets up variables needed for testing.
+#
+# All of this is done in this script so that tests can be run individually if
+# desired. To run all tests simply run the RUN_TESTS.sh script. If Individual
+# tests are desired to be run, source the 001-setup.sh script first, followed by
+# 002-start-server.sh. Then source each desired script after that preceded by
+# `$CI_DIR`. When finished, source the 990-stop-server.sh script last.
+#
+# E.g.:
+#      $ . full/path/to/001-setup.sh
+#      $ . $CI_DIR/002-start-server.sh
+#      $ . $CI_DIR/100-writeread-tests.sh
+#      $ . $CI_DIR/990-stop-server.sh
+#
+# To run all of the tests, simply run RUN_CI_TESTS.sh
+#
+# E.g.:
+#     $ ./RUN_CI_TESTS.sh
+#   or
+#     $ prove -v RUN_CI_TESTS.sh
+#
+# Before doing either of these, make sure you have interactively allocated nodes
+# or are submitting a batch job.
+
+test_description="Set up UnifyCR testing environment"
+
+SETUP_USAGE="$(cat <<EOF
+usage: ./001-setup.sh -h|--help
+
+You can run individually desired test files (i.e., 100-writeread-tests.sh and no
+other tests) by first sourcing 001-setup.sh followed by 002-start-server.sh.
+Then source any desired test files. Lastly, source 990-stop-server.sh.
+
+E.g.:
+    $ . full/path/to/001-setup.sh
+    $ . $CI_DIR/002-start-server.sh
+    $ . $CI_DIR/100-writeread-tests.sh
+    $ . $CI_DIR/990-stop-server.sh
+
+To run all of the tests, simply run RUN_CI_TESTS.sh.
+
+E.g.:
+    $ ./RUN_CI_TESTS.sh
+  or
+    $ prove -v RUN_CI_TESTS.sh
+
+Before doing either of these, make sure you have interactively allocated nodes
+or are submitting a batch job.
+EOF
+)"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            echo "$SETUP_USAGE"
+            exit
+            ;;
+        *)
+            echo "usage: ./001-setup.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+
+########## Set up messages and vars needed before sourcing sharness  ##########
+
+[[ -z $infomsg ]] && infomsg="-- UNIFYCR JOB INFO:"
+[[ -z $errmsg ]] && errmsg="!!!! UNIFYCR JOB ERROR:"
+
+export CI_PROJDIR=${CI_PROJDIR:-$HOME}
+export TMPDIR=${TMPDIR:-/tmp}
+export SYSTEM_NAME=$(echo $(hostname) | sed -r 's/(^[[:alpha:]]*)(.*)/\1/')
+
+
+########## Set up sharness, variables, and functions for TAP testing  ##########
+
+# Set up sharness variables and functions for TAP testing.
+echo "$infomsg Setting up sharness"
+CI_DIR=${CI_DIR:-$(dirname "$(readlink -fm $BASH_SOURCE)")}
+SHARNESS_DIR="$(dirname "$CI_DIR")"
+echo "$infomsg CI_DIR: $CI_DIR"
+echo "$infomsg SHARNESS_DIR: $SHARNESS_DIR"
+source ${SHARNESS_DIR}/sharness.sh
+source $SHARNESS_DIR/sharness.d/02-functions.sh
+source $CI_DIR/ci-functions.sh
+
+
+########## Locate UnifyCR install and examples ##########
+
+# Check if we have Spack and if UnifyCR is installed.
+# If don't have both, fall back to checking for non-spack install.
+# If neither, fail out.
+# Set UNIFYCR_INSTALL to skip searching.
+echo "$infomsg Looking for UnifyCR install directory..."
+
+# Look for UnifyCR install directory if the user didn't already set
+# $UNIFYCR_INSTALL to the directory containing bin/ and libexec/
+if [[ -z $UNIFYCR_INSTALL ]]; then
+    # Check for $SPACK_ROOT and if unifycr is installed
+    if [[ -n $SPACK_ROOT && -d $(spack location -i unifycr 2>/dev/null) ]];
+    then
+        # Might have a problem with variants and arch
+        UNIFYCR_INSTALL="$(spack location -i unifycr)"
+    # Else search for unifycrd starting in $CI_PROJDIR and omitting spack_root
+    elif [[ -x $(find_executable $CI_PROJDIR "*/bin/unifycrd" $SPACK_ROOT) ]];
+    then
+        # Set UNIFYCR_INSTALL to the dir containing bin/ and libexec/
+        UNIFYCR_INSTALL="$(dirname "$(dirname \
+            "$(find_executable $CI_PROJDIR "*/bin/unifycrd" $SPACK_ROOT)")")"
+    else
+        echo >&2 "$errmsg Unable to find UnifyCR install directory"
+        echo >&2 "$errmsg \`spack install unifycr\`, set the" \
+                 "\$UNIFYCR_INSTALL envar to the directory containing bin/" \
+                 "and libexec/, or manually install to \$CI_PROJDIR/*"
+        exit 1
+    fi
+fi
+
+# Make sure UNIFYCR_INSTALL, bin/, and libexec/ exist
+if [[ -d $UNIFYCR_INSTALL && -d ${UNIFYCR_INSTALL}/bin &&
+      -d ${UNIFYCR_INSTALL}/libexec ]]; then
+    echo "$infomsg Found UnifyCR install directory: $UNIFYCR_INSTALL"
+
+    UNIFYCR_BIN="$UNIFYCR_INSTALL/bin"
+    UNIFYCR_EXAMPLES="$UNIFYCR_INSTALL/libexec"
+    echo "$infomsg Found UnifyCR bin directory: $UNIFYCR_BIN"
+    echo "$infomsg Found UnifyCR examples directory: $UNIFYCR_EXAMPLES"
+else
+    echo >&2 "$errmsg Ensure \$UNIFYCR_INSTALL exists and is the directory" \
+             "containing bin/ and libexec/"
+fi
+
+# Check for necessary spack modules
+loaded_modules=$(module list 2>&1)
+modules="gotcha leveldb flatcc argobots mercury margo"
+for mod in $modules; do
+   [[ $(echo "$loaded_modules" | fgrep "$mod") ]] ||
+        { echo "$errmsg Please 'spack load $mod'"; exit 1; }
+done
+
+
+########## Determine job launcher and source associated setup ##########
+
+# Source envar, functions, and set up JOB_RUN_COMMAND if lsf, slurm, or mpirun
+# TODO: mpirun compatibility
+echo "$infomsg Finding job launcher"
+if [[ -n $(which jsrun 2>/dev/null) ]]; then
+    source $CI_DIR/setup-lsf.sh
+elif [[ -n $(which srun 2>/dev/null) ]]; then
+    source $CI_DIR/setup-slurm.sh
+else
+    echo >&2 "$errmsg Failed to find a suitable parallel job launcher"
+    exit 1
+fi
+echo "$infomsg JOB_RUN_COMMAND established: $JOB_RUN_COMMAND"
+
+
+########## Set up CI and UNIFYCR configuration variables ##########
+
+# Turn up log verbosity
+export UNIFYCR_LOG_VERBOSITY=${UNIFYCR_LOG_VERBOSITY:-5}
+
+# Set up location for logs and potentially auto cleanup if user didn't provide
+# an alternate location for the logs
+if [[ -z $UNIFYCR_LOG_DIR ]]; then
+    # User can choose to not cleanup logs on success
+    export CI_LOG_CLEANUP=${CI_LOG_CLEANUP:-yes}
+    # If no log cleanup, move logs to $CI_DIR
+    if [[ $CI_LOG_CLEANUP =~ ^(no|NO)$ || $CI_CLEANUP =~ ^(no|NO)$ ]]; then
+        logdir=$CI_DIR/${SYSTEM_NAME}_${JOB_ID}_logs
+    else # else put logs in sharness trash dir that sharness deletes
+        logdir=$SHARNESS_TRASH_DIRECTORY/${SYSTEM_NAME}_${JOB_ID}_logs
+        echo "$infomsg Set CI_LOG_CLEANUP=no to keep logs when all tests pass"
+    fi
+    mkdir -p $logdir
+fi
+export UNIFYCR_LOG_DIR=${UNIFYCR_LOG_DIR:-$logdir}
+echo "$infomsg Logs are in UNIFYCR_LOG_DIR: $UNIFYCR_LOG_DIR"
+
+export UNIFYCR_SHAREDFS_DIR=${UNIFYCR_SHAREDFS_DIR:-$UNIFYCR_LOG_DIR}
+echo "$infomsg UNIFYCR_SHAREDFS_DIR set as $UNIFYCR_SHAREDFS_DIR"
+
+# daemonize
+export UNIFYCR_DAEMONIZE=${UNIFYCR_DAEMONIZE:-off}
+
+# temp
+nlt=${TMPDIR}/unifycr.${USER}.${SYSTEM_NAME}.${JOB_ID}
+export CI_TEMP_DIR=${CI_TEMP_DIR:-$nlt}
+export UNIFYCR_RUNSTATE_DIR=${UNIFYCR_RUNSTATE_DIR:-$CI_TEMP_DIR}
+export UNIFYCR_META_DB_PATH=${UNIFYCR_META_DB_PATH:-$CI_TEMP_DIR}
+echo "$infomsg UNIFYCR_RUNSTATE_DIR set as $UNIFYCR_RUNSTATE_DIR"
+echo "$infomsg UNIFYCR_META_DB_PATH set as $UNIFYCR_META_DB_PATH"
+echo "$infomsg Set CI_TEMP_DIR to change both of these to same path"
+
+# storage
+nls=$nlt
+export CI_STORAGE_DIR=${CI_STORAGE_DIR:-$nls}
+export UNIFYCR_SPILLOVER_SIZE=${UNIFYCR_SPILLOVER_SIZE:-$GB}
+export UNIFYCR_SPILLOVER_ENABLED=${UNIFYCR_SPILLOVER_ENABLED:-yes}
+export UNIFYCR_SPILLOVER_DATA_DIR=${UNIFYCR_SPILLOVER_DATA_DIR:-$CI_STORAGE_DIR}
+export UNIFYCR_SPILLOVER_META_DIR=${UNIFYCR_SPILLOVER_META_DIR:-$CI_STORAGE_DIR}
+echo "$infomsg UNIFYCR_SPILLOVER_DATA_DIR set as $UNIFYCR_SPILLOVER_DATA_DIR"
+echo "$infomsg UNIFYCR_SPILLOVER_META_DIR set as $UNIFYCR_SPILLOVER_META_DIR"
+echo "$infomsg Set CI_STORAGE_DIR to change both of these to same path"
+
+
+########## Set up mountpoints and sharness testing prereqs ##########
+
+# Running tests with UNIFYCR_MOUNTPOINT set to a real dir will disable posix
+# tests unless user sets CI_TEST_POSIX=yes
+export UNIFYCR_MP=${UNIFYCR_MOUNTPOINT:-/unifycr}
+# If UNIFYCR_MOUNTPOINT is real dir, disable posix tests (unless user wants it)
+# and set REAL_MP prereq to enable test that checks if UNIFYCR_MOUNTPOINT is
+# empty
+if [[ -d $UNIFYCR_MP ]]; then
+    export CI_TEST_POSIX=no
+    test_set_prereq REAL_MP
+fi
+echo "$infomsg UNIFYCR_MOUNTPOINT established: $UNIFYCR_MP"
+
+export CI_TEST_POSIX=${CI_TEST_POSIX:-yes}
+# Set up a real mountpoint for posix tests to write files to and allow tests to
+# check that those files exist
+if [[ ! $CI_TEST_POSIX =~ ^(no|NO)$ ]]; then
+    if [[ -z $CI_POSIX_MP ]]; then
+        # needs to be a shared file system
+        pmp=${SHARNESS_TRASH_DIRECTORY}/unify_posix_mp.${SYSTEM_NAME}.${JOB_ID}
+        mkdir $pmp
+    fi
+    export CI_POSIX_MP=${CI_POSIX_MP:-$pmp}
+    echo "$infomsg CI_POSIX_MP established: $CI_POSIX_MP"
+
+    # Set test_posix prereq
+    test_set_prereq TEST_POSIX
+fi
+
+# prereq for pdsh for cleaning hosts
+[[ -n $(which pdsh 2>/dev/null) ]] && test_set_prereq PDSH
+
+# skip cleanup_hosts test in 990-stop_server.sh if cleanup is not desired
+export CI_HOST_CLEANUP=${CI_HOST_CLEANUP:-yes}
+if ! [[ $CI_HOST_CLEANUP =~ ^(no|NO)$ || $CI_CLEANUP =~ ^(no|NO)$ ]]; then
+    test_set_prereq CLEAN
+fi
+
+# capture environment after all job setup completed
+env &> ${UNIFYCR_LOG_DIR}/job.environ

--- a/t/ci/002-start-server.sh
+++ b/t/ci/002-start-server.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# This test check the mountpoints and then starts the unifycrd server. It then
+# checks that the server is still running for all subsequent tests. If the
+# servers fails to start, cleanup_hosts is called and testing is exited.
+
+test_description="Start the UnifyCR server"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        *)
+            echo "usage ./002-start-server.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+# Verify we have the mountpoints needed for testing
+if test_have_prereq REAL_MP; then
+    test_expect_success "UNIFYCR_MOUNTPOINT ($UNIFYCR_MP) is real directory" '
+        test_path_is_dir $UNIFYCR_MP ||
+        { test_set_prereq FAIL; return 1; }
+    '
+
+    # If FAIL prereq is set, then UNIFYCR_MOUNTPOINT was set to a real dir, but
+    # it is not a shared directory. If this is the case, no point in starting
+    # servers to proceed with tests.
+    if test_have_prereq FAIL; then
+        say "UNIFYCR_MOUNTPOINT set to real dir; dir not found on all hosts."
+        say "Exiting."
+        test_done
+    fi
+else # ensure mountpoint is a non-real directory
+    test_expect_success "UNIFYCR_MOUNTPOINT ($UNIFYCR_MP) is fake directory" '
+        test_must_fail test_path_is_dir $UNIFYCR_MP
+    '
+fi
+
+# If running posix tests, posix mountpoint needs to be a real, shared dir
+# If it's not, prereq will not be set and posix tests will be skipped
+test_expect_success TEST_POSIX "CI_POSIX_MP ($CI_POSIX_MP) is shared dir" '
+    test_path_is_shared_dir $CI_POSIX_MP &&
+    test_set_prereq POSIX
+'
+
+# Start the server
+test_expect_success "unifycrd hasn't started yet" '
+    process_is_not_running unifycrd 10
+'
+
+$UNIFYCR_BIN/unifycr start -c -d -S $UNIFYCR_SHAREDFS_DIR \
+    -e $UNIFYCR_BIN/unifycrd &> ${UNIFYCR_LOG_DIR}/unifycr.start.out &
+
+test_expect_success "unifycrd started" '
+    process_is_running unifycrd 10 ||
+    { test_set_prereq FAIL; return 1; }
+'
+
+# If FAIL prereq is set, then unifycrd failed to start.
+# No point in proceeding with testing, so cleanup and exit early
+if test_have_prereq FAIL; then
+    say "unifycrd failed to start."
+    say "Try setting longer wait time. Cleaning up and exiting."
+    cleanup_hosts
+    test_done
+fi
+
+# If unifycrd doesn't stay running running, set fail test prereq
+test_expect_success "unifycrd hasn't died" '
+    test_must_fail process_is_not_running unifycrd 10 ||
+    { test_set_prereq FAIL; return 1; }
+'
+
+# If FAIL prereq is set, then unifycrd failed to stay running.
+# No point in proceeding with testing, so cleanup and exit early
+if test_have_prereq FAIL; then
+    say "unifycrd failed to stay running. Cleaning up and exiting."
+    cleanup_hosts
+    test_done
+fi
+
+# unifycrd has started by this point. Set up a trap to cleanup the hosts in the
+# event of an early/unexpected non-zero exit. This trap gets removed after the
+# final cleanup_hosts is called in 990-stop-server.sh. This is to prevent the
+# trap from triggering when the overall test suite exits with 1 if/when any
+# tests have failed.
+clean_fail() {
+    echo >&2 "Error in $1. Cleaning hosts"
+    cleanup_hosts
+}
+trap 'clean_fail $BASH_SOURCE' EXIT

--- a/t/ci/100-writeread-tests.sh
+++ b/t/ci/100-writeread-tests.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# This contains all the tests for the writeread example.
+#
+# There are convenience functions such as `unify_run_test()` and get_filename()
+# in the ci-functions.sh script that can make adding new tests easier. See the
+# full UnifyCR documentatation for more info.
+#
+# There are multiple ways to to run an example using `unify_run_test()`
+#     1. unify_run_test $app_name "$app_args" app_output
+#     2. app_output=$(unify_run_test $app_name "app_args")
+#
+#     ---- Method 1
+#     app_output=$(unify_run_test $app_name "$app_args")
+#     rc=$?
+
+#     echo "$app_output"
+#     lcount=$(printf "%s" "$app_output" | wc -l)
+#     ----
+
+#     ---- Method 2
+#     unify_run_test $app_name "$app_args" app_output
+#     rc=$?
+#
+#     lcount=$(echo "$app_output" | wc -l)
+#     ----
+#
+# The output of an example can then be tested with sharness, for example:
+#
+#     test_expect_success "$app_name $app_args: (line_count=$lcount, rc=$rc)" '
+#         test $rc = 0 &&
+#         test $lcount = 8
+#     '
+#
+# For these tests, always include -b -c -n and -p in the app_args
+# Then for the necessary tests, include -k -M -P -S -V or -x.
+
+
+test_description="Writeread Tests"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        *)
+            echo "usage ./100-writeread-tests.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+# These two functions are simply to prevent code duplication since testing the
+# output of each example with sharness is the same process. These do not need to
+# be used, especially if wanting to test for something specific when running an
+# example.
+unify_test_writeread() {
+    app_name=writeread-${1}
+
+    # Run the test and get output
+    unify_run_test $app_name "$2" app_output
+    rc=$?
+    lcount=$(echo "$app_output" | wc -l)
+
+    # Evaluate output
+    test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 8
+    '
+}
+
+unify_test_writeread_posix() {
+    app_name=writeread-posix
+
+    # Run the test and get output
+    if test_have_prereq POSIX; then
+        unify_run_test $app_name "$1" app_output
+        rc=$?
+        lcount=$(echo "$app_output" | wc -l)
+        filename=$(get_filename $app_name "$1" ".app")
+    fi
+
+    # Evaluate output
+    test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 8 &&
+        if [[ $io_pattern =~ (n1)$ ]]; then
+            test_path_is_file ${CI_POSIX_MP}/$filename
+        else
+            test_path_has_file_per_process $CI_POSIX_MP $filename
+        fi
+    '
+}
+
+# writeread-static -p n1 -n 2 -c 4KB -b 16KB
+runmode=static
+io_pattern="-p n1"
+io_sizes="-n 2 -c $((4 * $KB)) -b $((16 * $KB))"
+app_args="$io_pattern $io_sizes"
+unify_test_writeread $runmode "$app_args"
+
+# writeread-gotcha -p n1 -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-posix -p n1 -n 2 -c 4KB -b 16KB
+runmode=posix
+unify_test_writeread_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# writeread-posix -p nn -n 2 -c 4KB -b 16KB
+unify_test_writeread_posix "$app_args"
+
+# writeread-gotcha -p nn -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-static -p nn -n 2 -c 4KB -b 16KB
+runmode=static
+unify_test_writeread $runmode "$app_args"
+
+# Increase sizes: -n 16 -c 32KB -b 1MB
+
+# writeread-static -p nn -n 16 -c 32KB -b 1MB
+io_sizes="-n 16 -c $((32 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_writeread $runmode "$app_args"
+
+# writeread-gotcha -p nn -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-posix -p nn -n 16 -c 32KB -b 1MB
+runmode=posix
+unify_test_writeread_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# writeread-posix -p n1 -n 16 -c 32KB -b 1MB
+unify_test_writeread_posix "$app_args"
+
+# writeread-gotcha -p n1 -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-static -p n1 -n 16 -c 32KB -b 1MB
+runmode=static
+unify_test_writeread $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 64KB -b 1MB
+
+# writeread-static -p n1 -n 32 -c 64KB -b 1MB
+io_sizes="-n 32 -c $((64 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_writeread $runmode "$app_args"
+
+# writeread-gotcha -p n1 -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-posix -p n1 -n 32 -c 64KB -b 1MB
+runmode=posix
+unify_test_writeread_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# writeread-posix -p nn -n 32 -c 64KB -b 1MB
+unify_test_writeread_posix "$app_args"
+
+# writeread-gotcha -p nn -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-static -p nn -n 32 -c 64KB -b 1MB
+runmode=static
+unify_test_writeread $runmode "$app_args"
+
+# Increase sizes: -n 64 -c 1MB -b 4MB
+
+# writeread-static -p nn -n 64 -c 1MB -b 4MB
+io_sizes="-n 64 -c $MB -b $((4 *  $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_writeread $runmode "$app_args"
+
+# writeread-gotcha -p nn -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-posix -p nn -n 64 -c 1MB -b 4MB
+runmode=posix
+unify_test_writeread_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# writeread-posix -p n1 -n 64 -c 1MB -b 4MB
+unify_test_writeread_posix "$app_args"
+
+# writeread-gotcha -p n1 -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-static -p n1 -n 64 -c 1MB -b 4MB
+runmode=static
+unify_test_writeread $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 1MB -b 16MB
+
+# writeread-static -p n1 -n 32 -c 1MB -b 16MB
+io_sizes="-n 32 -c $MB -b $((16 * $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_writeread $runmode "$app_args"
+
+# writeread-gotcha -p n1 -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-posix -p n1 -n 32 -c 1MB -b 16MB
+runmode=posix
+unify_test_writeread_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# writeread-posix -p nn -n 32 -c 1MB -b 16MB
+unify_test_writeread_posix "$app_args"
+
+# writeread-gotcha -p nn -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_writeread $runmode "$app_args"
+
+# writeread-static -p nn -n 32 -c 1MB -b 16MB
+runmode=static
+unify_test_writeread $runmode "$app_args"

--- a/t/ci/110-write-tests.sh
+++ b/t/ci/110-write-tests.sh
@@ -1,0 +1,246 @@
+#!/bin/bash
+
+# This contains all the tests for the write example.
+#
+# There are convenience functions such as `unify_run_test()` and get_filename()
+# in the ci-functions.sh script that can make adding new tests easier. See the
+# full UnifyCR documentatation for more info.
+#
+# There are multiple ways to to run an example using `unify_run_test()`
+#     1. unify_run_test $app_name "$app_args" app_output
+#     2. app_output=$(unify_run_test $app_name "app_args")
+#
+#     ---- Method 1
+#     app_output=$(unify_run_test $app_name "$app_args")
+#     rc=$?
+
+#     echo "$app_output"
+#     lcount=$(printf "%s" "$app_output" | wc -l)
+#     ----
+
+#     ---- Method 2
+#     unify_run_test $app_name "$app_args" app_output
+#     rc=$?
+#
+#     lcount=$(echo "$app_output" | wc -l)
+#     ----
+#
+# The output of an example can then be tested with sharness, for example:
+#
+#     test_expect_success "$app_name $app_args: (line_count=$lcount, rc=$rc)" '
+#         test $rc = 0 &&
+#         test $lcount = 8
+#     '
+#
+# For these tests, always include -b -c -n and -p in the app_args
+# Then for the necessary tests, include -M -P -S -V or -x.
+
+
+test_description="Write Tests"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        *)
+            echo "usage ./200-write-tests.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+# These two functions are simply to prevent code duplication since testing the
+# output of each example with sharness is the same process. These do not need to
+# be used, especially if wanting to test for something specific when running an
+# example.
+unify_test_write() {
+    app_name=write-${1}
+
+    # Run the test and get output
+    unify_run_test $app_name "$2" app_output
+    rc=$?
+    lcount=$(echo "$app_output" | wc -l)
+
+    # Evaluate output
+    test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 11
+    '
+}
+
+unify_test_write_posix() {
+    app_name=write-posix
+
+    # Run the test and get output
+    if test_have_prereq POSIX; then
+        unify_run_test $app_name "$1" app_output
+        rc=$?
+        lcount=$(echo "$app_output" | wc -l)
+        filename=$(get_filename $app_name "$1" ".app")
+    fi
+
+    # Evaluate output
+    test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 11 &&
+        if [[ $io_pattern =~ (n1)$ ]]; then
+            test_path_is_file ${CI_POSIX_MP}/$filename
+        else
+            test_path_has_file_per_process $CI_POSIX_MP $filename
+        fi
+    '
+}
+
+# write-static -p n1 -n 2 -c 4KB -b 16KB
+runmode=static
+io_pattern="-p n1"
+io_sizes="-n 2 -c $((4 * $KB)) -b $((16 * $KB))"
+app_args="$io_pattern $io_sizes"
+unify_test_write $runmode "$app_args"
+
+# write-gotcha -p n1 -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-posix -p n1 -n 2 -c 4KB -b 16KB
+runmode=posix
+unify_test_write_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# write-posix -p nn -n 2 -c 4KB -b 16KB
+unify_test_write_posix "$app_args"
+
+# write-gotcha -p nn -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-static -p nn -n 2 -c 4KB -b 16KB
+runmode=static
+unify_test_write $runmode "$app_args"
+
+# Increase sizes: -n 16 -c 32KB -b 1MB
+
+# write-static -p nn -n 16 -c 32KB -b 1MB
+io_sizes="-n 16 -c $((32 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_write $runmode "$app_args"
+
+# write-gotcha -p nn -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-posix -p nn -n 16 -c 32KB -b 1MB
+runmode=posix
+unify_test_write_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# write-posix -p n1 -n 16 -c 32KB -b 1MB
+unify_test_write_posix "$app_args"
+
+# write-gotcha -p n1 -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-static -p n1 -n 16 -c 32KB -b 1MB
+runmode=static
+unify_test_write $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 64KB -b 1MB
+
+# write-static -p n1 -n 32 -c 64KB -b 1MB
+io_sizes="-n 32 -c $((64 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_write $runmode "$app_args"
+
+# write-gotcha -p n1 -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-posix -p n1 -n 32 -c 64KB -b 1MB
+runmode=posix
+unify_test_write_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# write-posix -p nn -n 32 -c 64KB -b 1MB
+unify_test_write_posix "$app_args"
+
+# write-gotcha -p nn -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-static -p nn -n 32 -c 64KB -b 1MB
+runmode=static
+unify_test_write $runmode "$app_args"
+
+# Increase sizes: -n 64 -c 1MB -b 4MB
+
+# write-static -p nn -n 64 -c 1MB -b 4MB
+io_sizes="-n 64 -c $MB -b $((4 *  $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_write $runmode "$app_args"
+
+# write-gotcha -p nn -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-posix -p nn -n 64 -c 1MB -b 4MB
+runmode=posix
+unify_test_write_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# write-posix -p n1 -n 64 -c 1MB -b 4MB
+unify_test_write_posix "$app_args"
+
+# write-gotcha -p n1 -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-static -p n1 -n 64 -c 1MB -b 4MB
+runmode=static
+unify_test_write $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 1MB -b 16MB
+
+# write-static -p n1 -n 32 -c 1MB -b 16MB
+io_sizes="-n 32 -c $MB -b $((16 * $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_write $runmode "$app_args"
+
+# write-gotcha -p n1 -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-posix -p n1 -n 32 -c 1MB -b 16MB
+runmode=posix
+unify_test_write_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# write-posix -p nn -n 32 -c 1MB -b 16MB
+unify_test_write_posix "$app_args"
+
+# write-gotcha -p nn -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_write $runmode "$app_args"
+
+# write-static -p nn -n 32 -c 1MB -b 16MB
+runmode=static
+unify_test_write $runmode "$app_args"

--- a/t/ci/120-read-tests.sh
+++ b/t/ci/120-read-tests.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+# This contains all the tests for the read example.
+#
+# There are convenience functions such as `unify_run_test()` and get_filename()
+# in the ci-functions.sh script that can make adding new tests easier. See the
+# full UnifyCR documentatation for more info.
+#
+# There are multiple ways to to run an example using `unify_run_test()`
+#     1. unify_run_test $app_name "$app_args" app_output
+#     2. app_output=$(unify_run_test $app_name "app_args")
+#
+#     ---- Method 1
+#     app_output=$(unify_run_test $app_name "$app_args")
+#     rc=$?
+
+#     echo "$app_output"
+#     lcount=$(printf "%s" "$app_output" | wc -l)
+#     ----
+
+#     ---- Method 2
+#     unify_run_test $app_name "$app_args" app_output
+#     rc=$?
+#
+#     lcount=$(echo "$app_output" | wc -l)
+#     ----
+#
+# The output of an example can then be tested with sharness, for example:
+#
+#     test_expect_success "$app_name $app_args: (line_count=$lcount, rc=$rc)" '
+#         test $rc = 0 &&
+#         test $lcount = 8
+#     '
+#
+# For these tests, always include -b -c -n and -p in the app_args
+# Then for the necessary tests, include -M -P -S -V or -x.
+
+
+test_description="Read Tests"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        *)
+            echo "usage ./300-read-tests.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+# These two functions are simply to prevent code duplication since testing the
+# output of each example with sharness is the same process. These do not need to
+# be used, especially if wanting to test for something specific when running an
+# example.
+unify_test_read() {
+    app_name=read-${1}
+
+    # Run the test and get output
+    unify_run_test $app_name "$2" app_output
+    rc=$?
+    lcount=$(echo "$app_output" | wc -l)
+
+    # Evaluate output
+    test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 11
+    '
+}
+
+unify_test_read_posix() {
+    app_name=read-posix
+
+    # Run the test and get output
+    if test_have_prereq POSIX; then
+        unify_run_test $app_name "$1" app_output
+        rc=$?
+        lcount=$(echo "$app_output" | wc -l)
+    fi
+
+    # Evaluate output
+    test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 11
+    '
+}
+
+# read-static -p n1 -n 2 -c 4KB -b 16KB
+runmode=static
+io_pattern="-p n1"
+io_sizes="-n 2 -c $((4 * $KB)) -b $((16 * $KB))"
+app_args="$io_pattern $io_sizes"
+unify_test_read $runmode "$app_args"
+
+# read-gotcha -p n1 -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-posix -p n1 -n 2 -c 4KB -b 16KB
+runmode=posix
+unify_test_read_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# read-posix -p nn -n 2 -c 4KB -b 16KB
+unify_test_read_posix "$app_args"
+
+# read-gotcha -p nn -n 2 -c 4KB -b 16KB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-static -p nn -n 2 -c 4KB -b 16KB
+runmode=static
+unify_test_read $runmode "$app_args"
+
+# Increase sizes: -n 16 -c 32KB -b 1MB
+
+# read-static -p nn -n 16 -c 32KB -b 1MB
+io_sizes="-n 16 -c $((32 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_read $runmode "$app_args"
+
+# read-gotcha -p nn -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-posix -p nn -n 16 -c 32KB -b 1MB
+runmode=posix
+unify_test_read_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# read-posix -p n1 -n 16 -c 32KB -b 1MB
+unify_test_read_posix "$app_args"
+
+# read-gotcha -p n1 -n 16 -c 32KB -b 1MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-static -p n1 -n 16 -c 32KB -b 1MB
+runmode=static
+unify_test_read $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 64KB -b 1MB
+
+# read-static -p n1 -n 32 -c 64KB -b 1MB
+io_sizes="-n 32 -c $((64 * $KB)) -b $MB"
+app_args="$io_pattern $io_sizes"
+unify_test_read $runmode "$app_args"
+
+# read-gotcha -p n1 -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-posix -p n1 -n 32 -c 64KB -b 1MB
+runmode=posix
+unify_test_read_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# read-posix -p nn -n 32 -c 64KB -b 1MB
+unify_test_read_posix "$app_args"
+
+# read-gotcha -p nn -n 32 -c 64KB -b 1MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-static -p nn -n 32 -c 64KB -b 1MB
+runmode=static
+unify_test_read $runmode "$app_args"
+
+# Increase sizes: -n 64 -c 1MB -b 4MB
+
+# read-static -p nn -n 64 -c 1MB -b 4MB
+io_sizes="-n 64 -c $MB -b $((4 *  $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_read $runmode "$app_args"
+
+# read-gotcha -p nn -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-posix -p nn -n 64 -c 1MB -b 4MB
+runmode=posix
+unify_test_read_posix "$app_args"
+
+# Switch back to -p n1
+io_pattern="-p n1"
+app_args="$io_pattern $io_sizes"
+
+# read-posix -p n1 -n 64 -c 1MB -b 4MB
+unify_test_read_posix "$app_args"
+
+# read-gotcha -p n1 -n 64 -c 1MB -b 4MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-static -p n1 -n 64 -c 1MB -b 4MB
+runmode=static
+unify_test_read $runmode "$app_args"
+
+# Increase sizes: -n 32 -c 1MB -b 16MB
+
+# read-static -p n1 -n 32 -c 1MB -b 16MB
+io_sizes="-n 32 -c $MB -b $((16 * $MB))"
+app_args="$io_pattern $io_sizes"
+unify_test_read $runmode "$app_args"
+
+# read-gotcha -p n1 -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-posix -p n1 -n 32 -c 1MB -b 16MB
+runmode=posix
+unify_test_read_posix "$app_args"
+
+# Switch to -p nn
+io_pattern="-p nn"
+app_args="$io_pattern $io_sizes"
+
+# read-posix -p n1 -n 32 -c 1MB -b 16MB
+unify_test_read_posix "$app_args"
+
+# read-gotcha -p n1 -n 32 -c 1MB -b 16MB
+runmode=gotcha
+unify_test_read $runmode "$app_args"
+
+# read-static -p n1 -n 32 -c 1MB -b 16MB
+runmode=static
+unify_test_read $runmode "$app_args"

--- a/t/ci/990-stop-server.sh
+++ b/t/ci/990-stop-server.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# This test checks that the server terminated successfully, checks the
+# mountpoints, and then cleans up the hosts (if desired).
+
+test_description="Stopping the UnifyCR server"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        *)
+            echo "usage ./990-stop-server.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+test_expect_success "unifycrd is still running" '
+    process_is_running unifycrd 10
+'
+
+$UNIFYCR_BIN/unifycr terminate -d &> ${UNIFYCR_LOG_DIR}/unifycr.terminate.out
+
+test_expect_success "unifycrd has stopped" '
+    process_is_not_running unifycrd 10
+'
+
+test_expect_success "verify unifycrd has stopped" '
+    test_must_fail process_is_running unifycrd 10
+'
+
+# If UNIFYCR_MOUNTPOINT is an existing dir, verify that is it empty
+test_expect_success REAL_MP "Verify UNIFYCR_MOUNTPOINT ($UNIFYCR_MP) is empty" '
+    test_dir_is_empty $UNIFYCR_MP
+'
+
+# Cleanup posix mountpoint
+test_expect_success POSIX "Cleanup CI_POSIX_MP: $CI_POSIX_MP" '
+    rm -rf $CI_POSIX_MP/*posix*
+'
+
+# cleanup_hosts
+test_expect_success PDSH,CLEAN "Cleanup hosts" '
+    cleanup_hosts
+'
+# Remove trap
+# If any tests failed, the suite will exit with 1 which will trigger the trap.
+# Since the hosts were already cleaned at this point, can remove trap to prevent
+# cleanup_hosts from being called again.
+trap - EXIT
+
+# end here if running tests individually
+[[ -z $full_run ]] && test_done

--- a/t/ci/README.md
+++ b/t/ci/README.md
@@ -1,0 +1,77 @@
+# Integration Testing
+
+The UnifyCR [examples](https://github.com/LLNL/UnifyCR/tree/dev/examples) are
+being used as integration tests with continuous integration tools. These scripts
+depend on [sharness](https://github.com/chriscool/sharness) which is set up in
+the containing directory (`UnifyCR/t/`) and may not function properly if moved.
+
+The numbered scripts are the setup and tests being run by `RUN_CI_TESTS.sh`.
+
+`001-setup.sh`
+: Checks for an installation of UnifyCR and sets up variables needed for
+testing.
+
+`002-start-server.sh`
+: Starts unifycrd and tests to ensure it is running.
+
+`100-900`
+: Scripts for testing the examples.
+
+`990-stop-server.sh`
+: Stops unifycrd and cleans up.
+
+The other scripts (`ci-functions.sh`, `setup-lsf.sh`, and `setup-slurm.sh`)
+contain helper functions and variables used by the tests. Full details can be
+found in [UnifyCR testing documentation](https://unifycr.readthedocs.io/en/dev/testing.html#integration-tests).
+
+## Quickstart
+
+In order to run these scripts, make sure you are either submitting a batch job
+to run them, or are first in an interactive allocation.
+
+> **Note:** `mpirun` is currently not supported but coming soon.
+
+To run all of the tests, simply run `./RUN_CI_TESTS.sh`.
+
+E.g.:
+
+```shell
+$ ./RUN_CI_TESTS.sh
+```
+
+or
+
+```shell
+$ prove -v RUN_CI_TESTS.sh
+```
+
+In order to run individual tests, source the `001-setup.sh` script first,
+followed by `002-start-server.sh`. Then source each desired script after that
+preceded by `$CI_DIR`. When finished, source the `990-stop-server.sh` script
+last.
+
+E.g.:
+
+```shell
+$ . full/path/to/001-setup.sh
+$ . $CI_DIR/002-start-server.sh
+$ . $CI_DIR/100-writeread-tests.sh
+$ . $CI_DIR/990-stop-server.sh
+```
+
+If additional tests are desired, create a script after the fashion of
+`100-writeread-tests.sh` where the prefixed number indicates the desired order
+for running the tests. Then source that script in `RUN_CI_TESTS.sh` in the
+desired order.
+
+### Environment Variables
+
+There are environment variables that can be set to change the default behavior
+of this testing suite. See our [testing
+guide](https://unifycr.readthedocs.io/en/dev/testing.html#configuration-variables)
+for a full list.
+
+## Developers
+
+See our [Testing Guide](https://unifycr.readthedocs.io/en/dev/testing.html#integration-tests)
+for full documentation on writing and adding additional tests.

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+# This script is to run the entire integration test suite of TAP tests for
+# Unify.
+# In order to run individual tests, run `./001-setup.sh -h`.
+#
+# To run all of the tests, simply run RUN_CI_TESTS.sh.
+#
+# E.g.:
+#     $ ./RUN_CI_TESTS.sh
+#   or
+#     $ prove -v RUN_CI_TESTS.sh
+#
+# If individual tests are desired to be run, source the 001-setup.sh script
+# first, followed by 002-start-server.sh. Then source each desired script after
+# that preceded by `$CI_DIR`. When finished, source the 990-stop-server.sh
+# script last.
+#
+# E.g.:
+#      $ . full/path/to/001-setup.sh
+#      $ . $CI_DIR/002-start-server.sh
+#      $ . $CI_DIR/100-writeread-tests.sh
+#      $ . $CI_DIR/990-stop-server.sh
+#
+# Before doing either of these, make sure you have interactively allocated nodes
+# or are submitting a batch job.
+#
+# If additional tests are desired, create a script after the fashion of
+# 100-writeread-tests.sh where the prefixed number indicates the desired order
+# for running the tests. Then source that script in this script below, in the
+# desired order.
+
+test_description="Unify Integration Testing Suite"
+
+RUN_CI_TESTS_USAGE="$(cat <<EOF
+usage: ./RUN_CI_TESTS.sh -h|--help
+
+This script is to run the entire integration test suite of TAP tests for Unify.
+In order to run individual tests, run './001-setup.sh -h'.
+
+To run all of the tests, simply run RUN_CI_TESTS.sh.
+
+E.g.:
+    $ ./RUN_CI_TESTS.sh
+  or
+    $ prove -v RUN_CI_TESTS.sh
+
+You can run individually desired test files (i.e., 100-writeread-tests.sh and no
+other tests) by first sourcing 001-setup.sh followed by 002-start-server.sh.
+Then source any desired test files. Lastly, source 990-stop-server.sh.
+
+E.g.:
+    $ . full/path/to/001-setup.sh
+    $ . $CI_DIR/002-start-server.sh
+    $ . $CI_DIR/100-writeread-tests.sh
+    $ . $CI_DIR/990-stop-server.sh
+
+Before doing either of these, make sure you have interactively allocated nodes
+or are submitting a batch job.
+EOF
+)"
+
+while [[ $# -gt 0 ]]
+do
+    case $1 in
+        -h|--help)
+            echo "$RUN_CI_TESTS_USAGE"
+            exit
+            ;;
+        *)
+            echo "usage: ./RUN_CI_TESTS.sh -h|--help"
+            exit 1
+            ;;
+    esac
+done
+
+SECONDS=0
+start_time=$SECONDS
+echo "Started RUN_TESTS.sh @: $(date)"
+
+# Set up CI_DIR if this script is called first
+CI_DIR=${CI_DIR:-"$(dirname "$(readlink -fm $BASH_SOURCE)")"}
+echo "CI_DIR in run_test: $CI_DIR"
+
+# test_done gets called in 990-stop-server.sh if this is not set.
+# If not set, tests can be run individually
+full_run=true
+
+# setup testing
+source $CI_DIR/001-setup.sh
+
+# start unifycrd
+source $CI_DIR/002-start-server.sh
+
+# determine time setup took
+setup_time=$SECONDS
+echo "Setup time -- $(elapsed_time start_time setup_time)"
+
+##############################################################################
+# Add additional testing files between here and the final testing time (before
+# 990-stop-server.sh) in the desired order to run them.
+##############################################################################
+
+# writeread example tests
+source $CI_DIR/100-writeread-tests.sh
+
+##############################################################################
+# DO NOT add additional tests after this point
+##############################################################################
+# determine time testing took
+testing_time=$SECONDS
+echo "Testing time -- $(elapsed_time setup_time testing_time)"
+
+# stop unifycrd and cleanup
+source $CI_DIR/990-stop-server.sh
+
+end_time=$SECONDS
+echo "All done @ $(date)"
+echo "Total run time -- $(elapsed_time start_time end_time)"
+
+test_done
+exit 0

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -80,7 +80,6 @@ echo "Started RUN_TESTS.sh @: $(date)"
 
 # Set up CI_DIR if this script is called first
 CI_DIR=${CI_DIR:-"$(dirname "$(readlink -fm $BASH_SOURCE)")"}
-echo "CI_DIR in run_test: $CI_DIR"
 
 # test_done gets called in 990-stop-server.sh if this is not set.
 # If not set, tests can be run individually
@@ -103,6 +102,12 @@ echo "Setup time -- $(elapsed_time start_time setup_time)"
 
 # writeread example tests
 source $CI_DIR/100-writeread-tests.sh
+
+# write example tests
+source $CI_DIR/110-write-tests.sh
+
+# read example tests
+source $CI_DIR/120-read-tests.sh
 
 ##############################################################################
 # DO NOT add additional tests after this point

--- a/t/ci/ci-functions.sh
+++ b/t/ci/ci-functions.sh
@@ -1,0 +1,450 @@
+#!/bin/sh
+
+export KB=$((2**10))
+export MB=$((2**20))
+export GB=$((2**30))
+app_id=0
+
+### Project-local sharness code for UnifyCR's integration tests ###
+
+# Override `process_is_running()` function in sharness.d/02-functions.sh.
+# Check if a process with a given name is running on each host, retrying up to a
+# given number of seconds before giving up.
+#
+# $1 - Name of a process to check for
+# $2 - Number of seconds to wait before giving up
+#
+# Returns 0 if the named process is found on each host, otherwise returns 1.
+process_is_running()
+{
+    local proc=${1:-"unifycrd"}
+    local secs_to_wait=${2:-15}
+    local max_loops=$(($secs_to_wait * 2))
+    local i=0
+
+    while test "$i" -le "$max_loops"; do
+        if test "$($JOB_RUN_ONCE_PER_NODE pidof $proc | wc -w)" -eq "$nnodes"
+        then
+            return 0
+        else
+            sleep .5
+        fi
+        i=$(($i + 1))
+    done
+    return 1
+}
+
+# Override `process_is_not_running()` function in sharness.d/02-functions.sh.
+# Check if a process with a given name is not running on each host, retrying up
+# to a given number of seconds before giving up.
+#
+# $1 - Name of a process to check for
+# $2 - Number of seconds to wait before giving up
+#
+# Returns 0 if the named process is not found on each host, otherwise returns 1.
+process_is_not_running()
+{
+    local proc=${1:-"unifycrd"}
+    local secs_to_wait=${2:-15}
+    local max_loops=$(($secs_to_wait * 2))
+    local i=0
+
+    while test "$i" -le "$max_loops"; do
+        if test "$($JOB_RUN_ONCE_PER_NODE pidof $proc | wc -w)" -eq 0; then
+            return 0
+        else
+            sleep .5
+        fi
+        i=$(($i + 1))
+    done
+    return 1
+}
+
+# Override `test_path_is_dir()` function in sharness.sh.
+# Checks that a directory of the given name exists and is accessible from each
+# host in the allocation. Does NOT need to be a shared directory. (i.e.,
+# /dev/shm)
+#
+# $1 - Path of the directory to check for
+# $2 - Can be given to provide a more precise diagnosis
+#
+# Returns 0 if $1 exists on each host, 1 otherwise.
+test_path_is_dir() {
+    if ! $($JOB_RUN_ONCE_PER_NODE test -d "$1"); then
+        echo "Directory $1 is not an existing directory on all hosts. $2"
+        false
+    fi
+}
+
+# Check if same directory exists and is accessible from each host in the
+# allocation.
+#
+# $1 - Path of the shared directory to check for
+# $2 - Can be given to provide a more precise diagnosis
+#
+# Returns 0 if $1 is a shared directory, 1 otherwise.
+test_path_is_shared_dir() {
+    # Fail if $1 doesn't exist on each host
+    test_path_is_dir "$1" "$2" || return false
+
+    # Get array of inode numbers for $1 on each host
+    local l_inodes=($($JOB_RUN_ONCE_PER_NODE stat -c "%i" "$1"))
+    local l_length=${#l_inodes[@]}
+    local l_first_inode=${l_inodes[0]}
+
+    # Make sure each inode number equals the first inode number, else fail
+    for (( i=1; i<$l_length; i++ ))
+    do
+        if [[ ${l_inodes[$i]} -ne $l_first_inode ]]; then
+            echo "Directory $1 is not a shared directory. $2"
+            return false
+        fi
+    done
+}
+
+# Check if the provided path ($1) contains a file-per-process of the provided
+# file name ($2). Assumes $1 is a shared directory.
+#
+# This check tacks on "-n" for each process number to the end of the file and
+# checks for that files existence in the provided path.
+#
+# $1 - Path of the shared directory to check for the files
+# $2 - File name without the appended process number
+# $3 - Can be given to provide a more precise diagnosis
+#
+# Returns 0 if a file with the given name can be found for each process, 1
+# otherwise.
+test_path_has_file_per_process() {
+    # Make sure $1 is a shared dir
+    test_path_is_shared_dir "$1" "$3" || return false
+
+    local l_count=$(( $nres_sets * $nprocs ))
+    for (( i=0; i<$l_count; i++ ))
+    do
+        local l_file_n="${1}/${2}-${i}"
+        test_path_is_file $l_file_n "$3" || return false
+    done
+}
+
+
+### Unify integration testing helper functions ###
+
+# Find given executable starting in given path, ignoring an optional given path.
+#
+# $1 - Absolute path of where to start search
+# $2 - Executable and optional prefix (i.e., /dir/executable)
+# $3 - Optional single path to exclude from search.
+#
+# Returns path of first executable found with given name and optional prefix
+find_executable()
+{
+    # USAGE: find_executable abs_path *file_name|*path/file_name [prune_path]
+    if [[ $# -lt 2 || $# -gt 3 ]]; then
+       echo >&2 "$errmsg USAGE: $FUNCNAME abs_path *file|*path/file" \
+                "[prune_path]"
+       return 1
+    fi
+
+    # If dir provided in $3, set it as prune
+    [[ -n $3 ]] && local l_prune="-ipath $3 -prune -o"
+    local l_target="-path $2 -print -quit"
+
+    local l_ret="$(find $1 -executable $l_prune $l_target)"
+    echo $l_ret
+    return 0
+}
+
+# Calculate the elapsed time between the two given times.
+# $2 should be >= $1
+#
+# $1 - The initial of the two times (in seconds)
+# $2 - The latter of the two times (in seconds)
+#
+# Returns the elapsed time formated as HH:MM:SS
+elapsed_time()
+{
+    # USAGE: elapsed_time start_time_in_seconds end_time_in_seconds
+    if [[ $# -ne 2 || $2 -lt $1 ]]; then
+        echo >&2 "$errmsg USAGE: $FUNCNAME start_time_in_sec end_time_in_sec"
+        return 1
+    else
+        local l_start_time=$1
+        local l_end_time=$2
+        local l_diff=$(( l_end_time - l_start_time ))
+        # Determining the time $diff is since EPOC allows for it to auto format
+        local l_elap=$(date -u --date="@$l_diff" +'%X')
+        echo $l_elap
+        return 0
+    fi
+}
+
+# Format $1 bytes to KB, MB, or GB (e.g., format_bytes "1024" becomes 1KB)
+#
+# $1 - The positive whole number of bytes to format as KB, MB, or GB
+#
+# Returns $1 formatted as KB, MB, or GB
+format_bytes()
+{
+    # USAGE: format_bytes int
+    if [[ -z $1 || $1 -lt 0 ]]; then
+        echo >&2 "$errmsg USAGE: $FUNCNAME int"
+        return 1
+    fi
+
+    if [[ $1 -lt $MB ]]; then # less than 1MB
+        if !(($1 % $KB)); then # divisible by 1KB
+            echo $(($1/$KB))KB
+        else # not divisible by 1KB
+            echo $(bc -l <<< "scale=2;$1/(2^10)")KB
+        fi
+    elif [[ $1 -ge $MB && $1 -lt $GB ]]; then # between 1MB and 1GB
+        if !(($1 % $MB)); then # divisible by 1MB
+            echo $(($1/$MB))MB
+        else # not divisible by 1MB
+            echo $(bc -l <<< "scale=2;$1/(2^20)")MB
+        fi
+    else # greater than or equal to 1GB
+        if !(($1 % $GB)); then # divisible by 1GB
+            echo $(($1/$GB))GB
+        else # not divisible by 1GB
+            echo $(bc -l <<< "scale=2;$1/(2^30)")GB
+        fi
+    fi
+    return 0
+}
+
+# Build the filename for an example so that if it shows up in the
+# $UNIFYCR_MOUNTPOINT, it can be tracked to it's originating test
+#
+# Also allows testers to get what the filename will be in advance if called
+# from test suite. This could be used for posix tests to ensure the file showed
+# up in the mount point, as well as for cp/stat tests that potentially need the
+# filename from a previous test.
+#
+# Bear in mind, the filename created in unify_run_test will have a .app suffix.
+#
+# $1 - The app_name that will be prepended to the formated app_args in the
+#      resulting filename
+# $2 - The app_args that will be formated and appended to the app_name
+# $3 - Optional suffix to append to the end of the file
+#
+# Returns a string with the spaces removed and hyphens replaced by underscores
+# E.g.,: get_filename write-gotcha "-p n1 -n 32 -c 1024 -b 1048576" ".app"
+#        becomes
+#        write-gotcha_pn1_n32_c1KB_b1MB.app
+get_filename()
+{
+    # USAGE: get_filename app_name app_args [app_suffix]
+    if [[ $# -lt 2 || $# -gt 3 || -z $1 || -z $2 ]]; then
+        echo >&2 "$errmsg USAGE: $FUNCNAME app_name app_args [app_suffix]"
+        return 1
+    fi
+
+    # Remove any blank spaces
+    local l_remove_spaces=${2//[[:blank:]]/}
+    # Replace hyphen(-) with underscore(_)
+    local l_replace_hyphens=${l_remove_spaces//-/_}
+
+    # Parse out chunksize and blocksize values
+    local l_cs=$(echo $l_replace_hyphens | sed -r 's/.*c([0-9]{3,}).*/\1/')
+    local l_bs=$(echo $l_replace_hyphens | sed -r 's/.*b([0-9]{3,}).*/\1/')
+
+    # Format chunksize and blocksize to KB, MB, or GB and replace them in the
+    # original string
+    local l_replace_chunk=${l_replace_hyphens//$l_cs/$(format_bytes "$l_cs")}
+    local l_replace_block=${l_replace_chunk//$l_bs/$(format_bytes "$l_bs")}
+
+    # Finally build the filename
+    if [[ -n $3 ]]; then
+        # Append suffix if provided
+        local l_filename="${1}${l_replace_block}${3}"
+    else
+        local l_filename="${1}${l_replace_block}"
+    fi
+    echo $l_filename
+}
+
+# Builds the test command that will be executed. Automatically sets any options
+# that are always wanted (-vkf and the appropriate -m if posix test or not).
+#
+# Automatically builds the filename for -f based on the input app_name and
+# app_args and has .app appended to the end. This filename then also has .err
+# appended and is used for the stderr output file with JOB_RUN_COMMAND.
+#
+# Args that can be passed in are ([-pncbx][-A|-M|-P|-S|-V]). All other args are
+# set automatically.
+#
+# $1 - Name of the example application to be tested (basetest-runmode)
+# $2 - Args for $1 consisting of ([-pncbx][-A|-M|-P|-S|-V]). Encase in quotes.
+# $3 - The runmode of test, used to determine if posix and set correct args
+#
+# Returns the full test command ready to be executed.
+build_test_command()
+{
+    # USAGE: build_test_command app_exe_name app_args([-pncbx][-A|-M|-P|-S|-V])
+    if [[ $# -ne 3 ]]; then
+        echo >&2 "$errmsg USAGE: $FUNCNAME app_name" \
+                 "app_args([-pncbx][-A|-M|-P|-S|-V]) runmode"
+        return 1
+    fi
+
+    # Autogenerate and format the filename based on app_name and app_args
+    local l_filename="$(get_filename $1 "$2")"
+
+    # Add stderr output file to finish building JOB_RUN_COMMAND
+    local l_err_filename="$app_err ${UNIFYCR_LOG_DIR}/${l_filename}.err"
+    local l_job_run_command="$JOB_RUN_COMMAND $l_err_filename"
+
+    # Build example_command with options that are always wanted. Might need to
+    # adjust for other tests (i.e., app-mpiio), or write new functions
+    local l_verbose="-v"
+    local l_app_id="-a $app_id"
+
+    # Filename needs to be the write file if testing the read example
+    local l_app_name=$(echo $1 | sed -r 's/(\w)-.*/\1/')
+    if [[ $l_app_name = "read" ]]; then
+        local l_app_filename="-f $(get_filename write-$3 "$2").app"
+    else
+        local l_check="-k"
+        local l_app_filename="-f ${l_filename}.app"
+    fi
+
+    # Set mountpoint to an existing one if running posix test
+    if [[ $3 = "posix" ]]; then
+        local l_mount="-U -m $CI_POSIX_MP"
+    else
+        local l_mount="-m $UNIFYCR_MP"
+    fi
+
+    # Assemble full example_command
+    local l_app_args="$2 $l_app_id $l_check $l_verbose $l_mount $l_app_filename"
+    local l_full_app_name="${UNIFYCR_EXAMPLES}/${1} $l_app_args"
+
+    # Assemble full test_command
+    local l_test_command="$l_job_run_command $l_full_app_name"
+    echo $l_test_command
+}
+
+# Given a example application name and application args, run the example with
+# the appropriate MPI runner and args. This function is meant to make running
+# the cr, write, read, and writeread examples as easy as possible from the
+# testing files.
+#
+# The build_test_command is called which automatically sets any options that
+# are always wanted (-vkf and appropriate -m if posix test or not). The stderr
+# output file is also created (based on the filename that is autogenerated) and
+# the appropriate option is set for the JOB_RUN_COMMAND.
+#
+# Args that can be passed in are ([-pncbx][-A|-M|-P|-S|-V]). All other args are
+# set automatically, including the filename (which is generated based on the
+# input app_name and app_args).
+#
+# The third parameter is an optional "pass-by-reference" parameter that can
+# contain the variable name for the resulting output to be stored in.
+# Thus this function can be called in two different way:
+#     1. unify_run_test $app_name "$app_args" app_output
+#     2. app_output=$(unify_run_test $app_name "app_args")
+#
+# $1 - Name and runmode of the example application to be tested
+# $2 - Args for $1 consisting of ([-pncbx][-A|-M|-P|-S|-V]). Encase in quotes.
+# $3 - Optional output variable that is "passed by reference".
+#
+# Returns the return code of the executed example as well as the output
+# produced by running the example.
+unify_run_test()
+{
+    # USAGE: unify_run_test app_name app_args([-pncbx][-A|-M|-P|-S|-V])
+    # [output_variable_name]
+    if [[ $# -lt 2 || $# -gt 3 ]]; then
+        echo >&2 "$errmsg USAGE: $FUNCNAME app_name" \
+                 "app_args([-pncbx][-A|-M|-P|-S|-V]) [output_variable_name]"
+        return 1
+    fi
+
+    # Parse out the runmode and check if valid
+    local l_runmode=$(echo $1 | sed -r 's/.*-(\w)/\1/')
+    if [[ ! $l_runmode =~ ^(static|gotcha|posix)$ ]]; then
+        echo >&2 "$errmsg In $FUNCNAME, runmode not valid in app_name ($1)"
+        return 1
+    fi
+
+    # Skip this test if posix test and CI_TEST_POSIX=no|NO
+    if ! test_have_prereq POSIX && [[ $l_runmode = "posix" ]]; then
+        return 42
+    fi
+
+    # Fail if user passed in filename, mountpoint, verbose or disable
+    # UnifyCR since these are auto added
+    local opt='(-f|--file|-m|--mount|-v|--verbose|-U|--disable-unifycr)'
+    for s in $2; do
+        if [[ $s =~ $opt ]]; then
+            echo >&2 "$errmsg Call $FUNCNAME without $opt. Found $s"
+            return 1
+        fi
+    done
+
+    # Finally build and run the test
+    local l_test_command=$(build_test_command $1 "$2" $l_runmode)
+    say "Results for unifycr_run_test: $l_test_command:"
+
+    # Uncomment to change app_id (-a) for each test. Comment to leave as 0.
+    #app_id=$(echo $(($app_id + 1)))
+
+    # Get resulting output and rc of running the test
+    local l_app_output; l_app_output="$($l_test_command)"
+    local l_rc=$?
+
+    # Put the resulting output in the optional reference parameter
+    local l_input_var=$3
+    if [[ "$l_input_var" ]]; then
+        eval $l_input_var="'$l_app_output'"
+    fi
+
+    echo "$l_app_output"
+    return $l_rc
+
+}
+
+# Does some post-testing cleanup to include checking if any unifycrd is still
+# running and kills them after creating a stack trace. Also removes any files
+# that were leftover on the hosts.
+cleanup_hosts()
+{
+
+    # Capture all output from cleanup in a log
+    exec 3>&1 4>&2
+    exec &> ${UNIFYCR_LOG_DIR}/hosts.cleanup
+
+    # Get the list of hosts in this allocation
+    local l_hl=$(get_hostlist)
+    echo "Hostlist: $l_hl"
+    local l_app=unifycrd
+
+    echo "+++++ cleaning processes +++++"
+    echo " --- collecting stacks ---"
+    # unifycrd should have already been terminated at this point, so for each
+    # host, check if unifycrd is still running. If so, export the pid for
+    # convenience, echo a message, and generate a stack. If not, echo it's not.
+    pdsh -w $l_hl '[[ -n $(pgrep "'$l_app'") ]] && \
+        (export upid=$(pgrep "'$l_app'") && \
+         echo "'$l_app' (pid $upid) still running - creating stack..." && \
+         gstack $upid > \
+            "'${UNIFYCR_LOG_DIR}'"/"'${l_app}'".pid-${upid}.stack) || \
+        echo "'$l_app' not running"'
+
+    echo " --- killing processes ---"
+    pdsh -w $l_hl 'pkill -e "'$l_app'"'
+
+    echo "+++++ cleaning files +++++"
+    pdsh -w $l_hl 'test -f /dev/shm/svr_id && /bin/cat /dev/shm/svr_id'
+    pdsh -w $l_hl 'test -f /dev/shm/unifycrd_id && /bin/cat \
+                   /dev/shm/unifycrd_id'
+    pdsh -w $l_hl '/bin/rm -rfv /tmp/na_sm /tmp/*unifycr* /var/tmp/*unifycr* \
+                   /dev/shm/unifycrd_id /dev/shm/svr_id /dev/shm/*na_sm* \
+                   "'${UNIFYCR_SPILLOVER_DATA_DIR}'"/spill*.log \
+                   "'${UNIFYCR_SPILLOVER_META_DIR}'"/spill*.log \
+                   /dev/shm/*-recv-* /dev/shm/*-req-* /dev/shm/*-super-*'
+
+    # Reset capturing all output
+    exec 1>&3 2>&4
+}

--- a/t/ci/setup-lsf.sh
+++ b/t/ci/setup-lsf.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+[[ -z $LSB_DJOB_HOSTFILE ]] && \
+    { echo >&2 "$errmsg Found jsrun; no allocated nodes detected"; exit 1; }
+
+# Functions specific to LSF
+
+# Get the compute hosts being used in the current allocation.
+#
+# Returns the unique hosts being used on LSF, exluding the launch host.
+get_lsf_hosts()
+{
+    # NOTE: There's potential that some versions of LSF may change to where
+    # they put the user on the first compute node rather than a launch node.
+    local l_hosts=$(uniq $LSB_DJOB_HOSTFILE | tail -n +2)
+    echo $l_hosts
+}
+
+# Gets the compute hosts being used in the current allocation and returns them
+# as a list so they are usable by commands like pdsh.
+#
+# Returns the unique hosts being used on LSF as a list.
+# (e.g., host1,host2,...,hostn)
+get_hostlist()
+{
+    local l_hosts=$(get_lsf_hosts)
+    #replace spaces with commas
+    local l_hostlist=${l_hosts//[[:blank:]]/,}
+    echo $l_hostlist
+}
+
+# Variables specific to LSF
+nnodes=$(get_lsf_hosts | wc -w)
+
+# Define each resource set
+nprocs=${CI_NPROCS:-$nnodes}
+ncores=${CI_NCORES:-20}
+
+# Total resource sets and how many per host
+nres_sets=${CI_NRES_SETS:-$nnodes}
+nrs_per_node=${CI_NRS_PER_NODE:-1}
+
+if [[ $ncores -gt 20 ]]; then
+    echo >&2 "$errmsg Number of cores-per-resource-set (\$CI_NCORES=$ncores)" \
+        "needs to be <= 20."
+    exit 1
+fi
+
+if (($nres_sets % $nrs_per_node)); then
+    echo >&2 "$errmsg Total number of resource sets ($nres_sets) must be" \
+        "divisible by resource-sets-per-node ($nrs_per_node). Set" \
+        "\$CI_NRES_SETS and/or \$CI_NRS_PER_NODE accordingly."
+    exit 1
+fi
+
+if [ $(($nrs_per_node * $ncores)) -gt 40 ]; then
+    echo >&2 "$errmsg Number of cores-per-resource-set ($ncores) *"\
+        "resource-sets-per-node ($nrs_per_node) = $(($nrs_per_node*$ncores))" \
+        "needs to be <= 40. Set \$CI_NCORES and/or \$CI_NRS_PER_NODE" \
+        "accordingly."
+    exit 1
+fi
+
+if [ $(($nres_sets / $nrs_per_node)) -gt $nnodes ]; then
+    echo >&2 "$errmsg At least $(($nres_sets/$nrs_per_node)) allocated nodes" \
+        "required for $nres_sets total resource sets with $nrs_per_node" \
+        "resource-sets-per-node. Only $nnodes node(s) detected."
+    exit 1
+fi
+
+jsargs="-a${nprocs} -c${ncores} -r${nrs_per_node} -n${nres_sets}"
+
+app_out="-o"
+app_err="-k"
+JOB_RUN_COMMAND="jsrun $jsargs"
+JOB_RUN_ONCE_PER_NODE="jsrun -r1"
+JOB_ID=${JOB_ID:-$LSB_JOBID}
+
+echo "$infomsg ====================== LSF Job Info ======================"
+echo "$infomsg ----------------------- Job Status -----------------------"
+bjobs -l $JOB_ID
+echo "$infomsg ----------------------------------------------------------"

--- a/t/ci/setup-slurm.sh
+++ b/t/ci/setup-slurm.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+[[ -z $SLURM_NNODES ]] && \
+    { echo >&2 "$errmsg Found srun; no allocated nodes detected"; exit 1; }
+
+# Functions specific to SLURM
+
+# Get the compute hosts being used in the current allocation. Used with pdsh
+# during cleanup after tests are done.
+#
+# Returns the unique hosts being used on SLURM.
+get_hostlist()
+{
+    # In slurm, can do `pdsh -j $JOBID` to target all nodes in allocation,
+    # however using nodelist for consistency of cleanup_hosts function when
+    # using pdsh
+    echo $SLURM_NODELIST
+}
+
+# Variables specific to SLURM
+nnodes=$SLURM_NNODES
+nres_sets=$SLURM_NNODES
+nprocs=${CI_NPROCS:-$nnodes}
+
+app_out="-o"
+app_err="-e"
+JOB_RUN_COMMAND="srun -N${nnodes} --ntasks-per-node=${nprocs}"
+JOB_RUN_ONCE_PER_NODE="srun -n${nnodes}"
+JOB_ID=${JOB_ID:-$SLURM_JOBID}
+
+echo "$infomsg ====================== SLURM Job Info ======================"
+echo "$infomsg ------------------------ Job Status ------------------------"
+checkjob -v $JOB_ID
+echo "$infomsg ------------------------------------------------------------"


### PR DESCRIPTION
This adds scripts to create a testing suite to be used with continuous integration frameworks such as GitLab and Bamboo.

### Description
<!--- Describe your changes in detail -->
The primary files for running the continuous integration tests are:
* `RUN_CI_TESTS.sh`: simple script that runs all the tests. 

Tests can also be run individually:
* `001-setup-sh`: Sets up Sharness and variables needed for testing.
* `002-start-server.sh`: Starts `unifycrd` and tests to ensure it is running.
* `100-900` files: Scripts for testing the examples
* `990-stop-server.sh`: Stops `unifycrd` and cleans up.

Additional files:
* `ci-functions.sh`: Additional Sharness tests needed for this suite and helper functions used by the testing suite to make adding new tests easier. Sourced by `001-setup.sh`.
* `setup-lsf.sh`: Sets up functions and variables specific to systems using LSF. Sourced by `001-setup.sh` if on a system with LSF.
* `setup-slurm.sh`: Sets up functions and variables specific to systems using SLURM. Sourced by `001-setup.sh` if on a system with SLURM.

Documentation added to `docs/testing.rst` on running the CI tests and adding new tests. The docs won't render and links won't work until merged, but an example of how they'll look can be seen on [here](https://camstan-test-docs-unifycr.readthedocs.io/en/latest/testing.html#integration-tests).

These tests were set up using the newer examples that use `testutil.h` (`writeread.c`, `write.c`, `read.c`, `checkpoint-restart.c`, and `transfer.c`). This PR adds tests for writeread, write, and read (static, gotcha, and posix) and scaling up in files sizes. There are several tests here that are testing POSIX I/O wrappers. As more tests are added, the number of tests here can always be scaled back. The [Add write and read tests to the ci_testing](https://github.com/LLNL/UnifyCR/commit/5069eb5a8c44972121f026938e9f8e0bb0f338e7) commit is meant to serve as an example for how to add new tests.

If/when adding additional tests for the examples not using `testutil.h`, functions in the `ci-functions.sh` file may need to be adjusted or added to.

See the [Quickstart Guide](https://github.com/LLNL/UnifyCR/blob/a816e939287f151a144f7aaf52ba40b2d411cffb/t/ci/README.md) for links to the docs and more info on how to run the tests.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To have more complex, automated testing that can be run regularly on appropriate systems.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Tested on systems using LSF and SLURM.

Currently if using LSF with IBM's MPI, this testing suite will hang once enough files have been read to equal 64 clients per host due to a potential bug with our read path. See #342.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.