### PR TITLE
Additional bootstrap.sh fixes

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,6 +43,7 @@ cd ..
 
 echo "### building leveldb ###"
 cd leveldb
+git checkout 1.22
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
 	-DBUILD_SHARED_LIBS=yes ..
@@ -62,21 +63,28 @@ cd ..
 
 echo "### building argobots ###"
 cd argobots
-./autogen.sh && ./configure --prefix="$INSTALL_DIR"
+./autogen.sh && CC=gcc ./configure --prefix="$INSTALL_DIR"
 make -j $(nproc) && make install
 cd ..
 
 echo "### building mercury ###"
 cd mercury
 mkdir -p build && cd build
-cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" -DMERCURY_USE_BOOST_PP=ON \
-	-DBUILD_SHARED_LIBS=on ..
+cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+      -DMERCURY_USE_BOOST_PP=ON \
+      -DMERCURY_USE_CHECKSUMS=ON \
+      -DMERCURY_USE_EAGER_BULK=ON \
+      -DMERCURY_USE_SYSTEM_MCHECKSUM=OFF \
+      -DNA_USE_BMI=ON \
+      -DMERCURY_USE_XDR=OFF \
+      -DBUILD_SHARED_LIBS=on ..
 make -j $(nproc) && make install
 cd ..
 cd ..
 
 echo "### building margo ###"
 cd margo
+git checkout v0.4.3
 export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig"
 ./prepare.sh
 ./configure --prefix="$INSTALL_DIR"


### PR DESCRIPTION
### Description
Update `bootstrap.sh` to use the versions of dependencies that spack uses.  Also, update the mercury build lines to match those of spack, and make sure `-DNA_USE_BMI=on` is set. This got rid of a unifycrd startup error I was seeing:
```
   margo_server.c:47 in setup_remote_target: margo_init(bmi+tcp://)
   unifycr_init.c:327 in main: "Mercury/Argobots operation error."
```
Lastly, set `CC=gcc` for argobots, since it has build errors when built under the pgi compiler.

### Motivation and Context
Fix a unifycrd startup error.

### How Has This Been Tested?
Verified it got rid of the error.  Ran `start-client` test.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
